### PR TITLE
Handle if hui-window is loaded before hui-mouse

### DIFF
--- a/hmouse-drv.el
+++ b/hmouse-drv.el
@@ -4,7 +4,7 @@
 ;;
 ;; Orig-Date:    04-Feb-90
 ;;
-;; Copyright (C) 1989-2017  Free Software Foundation, Inc.
+;; Copyright (C) 1989-2018  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.
@@ -16,24 +16,12 @@
 ;;; Other required Elisp libraries
 ;;; ************************************************************************
 
-;; Keep this here at the top to prevent recursive reloads from
-;; Hyperbole autoload commands.
-(provide 'hmouse-drv)
-
-(if (and (boundp 'hmouse-alist) hmouse-alist)
-    (require 'hui-window)
-  ;; Force re-definition of hmouse-alist.
-  (makunbound 'hmouse-alist)
-  ;; Define hmouse-alist.
-  (load "hui-mouse")
-  ;; Add drag actions to hmouse-alist.
-  (load "hui-window"))
+(require 'hui-window)
 (require 'hypb)
 
 ;; Quiet byte compiler warnings for these free variables.
-(eval-when-compile
-  (defvar hkey-action nil)
-  (defvar pred-value nil))
+(defvar hkey-action)
+(defvar pred-value)
 
 ;;; ************************************************************************
 ;;; Public variables
@@ -1357,4 +1345,5 @@ not."
     (or rtn (progn (beep) (message "End of buffer")))
     rtn))
 
+(provide 'hmouse-drv)
 ;;; hmouse-drv.el ends here

--- a/hui-mouse.el
+++ b/hui-mouse.el
@@ -4,7 +4,7 @@
 ;;
 ;; Orig-Date:    04-Feb-89
 ;;
-;; Copyright (C) 1991-2017  Free Software Foundation, Inc.
+;; Copyright (C) 1991-2018  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.
@@ -403,7 +403,7 @@ smart keyboard keys.")
 (require 'hmouse-key)
 
 ;; This next library adds drag actions to `hmouse-alist'.
-(load "hui-window")
+(require 'hui-window)
 
 ;;; ************************************************************************
 ;;; support code

--- a/hui-window.el
+++ b/hui-window.el
@@ -4,7 +4,7 @@
 ;;
 ;; Orig-Date:    21-Sep-92
 ;;
-;; Copyright (C) 1992-2017  Free Software Foundation, Inc.
+;; Copyright (C) 1992-2018  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.
@@ -171,9 +171,9 @@ drag release window.")
 
 ;;;
 ;;; Add window handling to hmouse-alist dispatch table.
-;;;
-(if (not (boundp 'hmouse-alist))
-    (error "\"hui-window.el\": `hmouse-alist' must be defined before loading this.")
+
+(defvar hmouse-alist)
+(defun hui-window--register ()
   (unless (assoc #'(hmouse-inactive-minibuffer-p) hmouse-alist)
     (setq hmouse-alist
 	  (append
@@ -241,6 +241,7 @@ drag release window.")
 	     ;;
 	     )
 	   hmouse-alist))))
+(with-eval-after-load 'hui-mouse (hui-window--register))
 
 ;;; ************************************************************************
 ;;; Public functions


### PR DESCRIPTION
Hi Bob,

This is Stefans commit from elpa-hyperbole that is not touching on the XEmacs code. It is applied on top of current master so should apply cleanly.

* hmouse-drv.el: Just require `hui-window` without messing with
`hmouse-alist` any more.  Move compiler-silencing `defvar`s outside of
`eval-when-compile`.

* hui-mouse.el: Just use `require` instead of `load`.

* hui-window.el: Set hmouse-alist only after loading hui-mouse.
(hui-window--register): New function.
(hui-mouse): Use with-eval-after-load.