### PR TITLE
Account for that current-time-zone returnes offset in seconds

### DIFF
--- a/htz.el
+++ b/htz.el
@@ -336,7 +336,7 @@ Optional argument TIMEZONE specifies a time zone."
 			      htz:world-timezones))
 		  (and (fboundp 'current-time-zone)
 		       (if (listp (current-time-zone))
-			   (car (current-time-zone))
+			   (/ (car (current-time-zone)) 36)
 			 (current-time-zone)))
 		  timezone))
 	(if (stringp timezone)


### PR DESCRIPTION
current-time-zone returns an offset in seconds. In my case (7200 "CEST"). That has to be compensated for in order to get it into the right number of hours.