### PR TITLE
Fail packaging when proper version number is missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,7 +275,7 @@ clean:
 version: doc
 	@ echo ""
 	@ echo "Any fgrep output means the version number has not been updated in that file."
-	fgrep -L $(HYPB_VERSION) Makefile HY-ABOUT HY-NEWS README.md hversion.el hyperbole.el man/hyperbole.texi man/version.texi
+	fgrep -L $(HYPB_VERSION) Makefile HY-ABOUT HY-NEWS README.md hversion.el hyperbole.el man/hyperbole.texi man/version.texi; [ $$? -ne 0 ] || exit 1
 	@ echo ""
 
 # Build the Info, HTML and Postscript versions of the user manual and README.md.html.


### PR DESCRIPTION
@rswgnu The exit code was not handled properly in the Makefile. 

fgreps exit code is 1 when no files without matches are found which make considers as an error. 