### PR TITLE
Only url encode the user input to the search

### DIFF
--- a/hsettings.el
+++ b/hsettings.el
@@ -159,10 +159,9 @@ package to display search results."
     (if (assoc service-name hyperbole-web-search-alist)
 	(let ((browse-url-browser-function
 	       hyperbole-web-search-browser-function))
-	  (browse-url (browse-url-url-encode-chars
-		       (format (cdr (assoc service-name hyperbole-web-search-alist))
-			       search-term)
-		       "[*\"()',=;?% ]")))
+	  (browse-url 
+	   (format (cdr (assoc service-name hyperbole-web-search-alist))
+		   (browse-url-url-encode-chars search-term "[*\"()',=;?% ]"))))
       (user-error "(Hyperbole): Invalid web search service `%s'" service-name))))
 
 (defcustom inhibit-hyperbole-messaging t


### PR DESCRIPTION
## What

Only url encode the user input to the search

## Why

At least on Firefox using url encoding on the complete url does not work. It needs at least the '?' and '=' to not be url encoded. Just encoding the user entered search term feels safer.  