### PR TITLE
Allow buffer names to be lists

### DIFF
--- a/hui-jmenu.el
+++ b/hui-jmenu.el
@@ -145,7 +145,7 @@
     (if mname
 	;; Next line needed to ensure mode name is always formatted as
 	;; a string.
-	(format-mode-line mname)
+	(format-mode-line (or (car-safe mname) mname))
       (capitalize (symbol-name (buffer-local-value 'major-mode buffer))))))
 
 (defun hui-menu-frame-name (frame)


### PR DESCRIPTION
## What

Allow buffer names to be lists

## Why

Noticed that this change was still around in one of my work spaces. I think we talked about this more than a month ago but maybe it did not get into the repo? Anyway I submit it as a PR so we don't forget about it in case it was forgotten :smile:

Unfortunately I don't remember the detail well enough but it was something about that buffer names can be lists with some additional info as well as just a string. If it is a list the car of the list is the buffer name. I think the details are in a some of our private communication.