### PR TITLE
Add dependency on hvar to resolve use of var:remove-all

### DIFF
--- a/hsettings.el
+++ b/hsettings.el
@@ -24,6 +24,7 @@
 ;;; ************************************************************************
 
 (require 'hversion)
+(require 'hvar)
 
 ;;; Read the comments and modify as desired.
 


### PR DESCRIPTION
## What

Add dependency on hvar to resolve use of var:remove-all

## Why

hsettings has recently started to use var:remove-all. Without the require hyperbole-toggle-messaging leads to this:

```
Debugger entered--Lisp error: (void-function var:remove-all)
  var:remove-all()
  hyperbole-toggle-messaging(0)
  #f(compiled-function (symbol value) #<bytecode 0xce25c2264384696>)(inhibit-hyperbole-messaging t)
  custom-initialize-set(inhibit-hyperbole-messaging t)
  custom-declare-variable(inhibit-hyperbole-messaging t "*Determine whether Hyperbole supports explicit but..." :type boolean :initialize custom-initialize-set :set #f(compiled-function (symbol value) #<bytecode 0xce25c2264384696>) :group hyperbole-buttons)
  byte-code("\300\301\302\303\304\305\306\307\310\311\312\313&\13\210\300\314\315\316\304\305\312\317&\7\210\300\320\321\322\306\323\310\324\304\325\312\317&\13\207" [custom-declare-variable inhibit-hyperbole-messaging t "*Determine whether Hyperbole supports explicit but..." :type boolean :initialize custom-initialize-set :set #f(compiled-function (symbol value)
[...]
```