### PR TITLE
WIP - Update kexport to html

### DIFF
--- a/kotl/kexport.el
+++ b/kotl/kexport.el
@@ -100,10 +100,11 @@ pattern may be:
 ;;; ************************************************************************
 
 ;;;###autoload
-(defun kexport:html (export-from output-to &optional soft-newlines-flag)
+(defun kexport:html (export-from output-to &optional soft-newlines-flag no-header)
   "Export a koutline buffer or file in EXPORT-FROM to html format in OUTPUT-TO.
 By default, this retains newlines within cells as they are.  With optional prefix arg, SOFT-NEWLINES-FLAG,
 hard newlines are not used.  Also converts Urls and Klinks into Html hyperlinks.
+Fourth arg NO-HEADER, if non-nil, export only the html body.
 STILL TODO:
   Make delimited pathnames into file links (but not if within klinks).
   Copy attributes stored in cell 0 and attributes from each cell."
@@ -156,20 +157,21 @@ STILL TODO:
 	(setq title (read-string (format "Title for %s: " output-to-buf-name)
 				 title)))
 
-    (princ "<!doctype html>\n\n")
-    (princ "<html lang=\"en\">\n")
+    (when (not no-header)
+      (princ "<!doctype html>\n\n")
+      (princ "<html lang=\"en\">\n")
 
-    (princ "<head>\n")
-    (princ "<meta charset=\"utf-8\">\n")
-    (princ (format "<title>%s</title>\n" title))
-    (if kexport:html-description
-	(princ (format "<meta name=\"generator\" content=\"%s\">\n"
-		       kexport:html-description)))
-    (if kexport:html-keywords
-	(princ (format "<meta id=\"keywords\" CONTENT=\"%s\">\n"
-		       kexport:html-keywords)))
-    (princ "<link rel=\"stylesheet\" href=\"https://www.gnu.org/software/hyperbole/man/hyperbole.css\">")
-    (princ "</head>\n\n")
+      (princ "<head>\n")
+      (princ "<meta charset=\"utf-8\">\n")
+      (princ (format "<title>%s</title>\n" title))
+      (if kexport:html-description
+	  (princ (format "<meta name=\"generator\" content=\"%s\">\n"
+		         kexport:html-description)))
+      (if kexport:html-keywords
+	  (princ (format "<meta id=\"keywords\" CONTENT=\"%s\">\n"
+		         kexport:html-keywords)))
+      (princ "<link rel=\"stylesheet\" href=\"https://www.gnu.org/software/hyperbole/man/hyperbole.css\">")
+      (princ "</head>\n\n"))
     
     (princ "<body>\n\n")
     (princ (format "<h1>%s</h1>\n\n" title))
@@ -178,22 +180,15 @@ STILL TODO:
 	     ">" (hypb:replace-match-string
 		  "<" (kview:label-separator kview) "&lt;")
 	     "&gt;"))
-	   i level label contents)
+	   label contents)
       (princ "<ul>")
       (kview:map-tree
        (lambda (kview)
-	 (setq level (kcell-view:level)
-	       i level)
-	 (while (> i 1)
-	   ;;(princ "<li>")
-	   (setq i (1- i)))
-         (princ "<li>")
-	 (princ "<table><tr>\n")
-	 (princ "<td>")
+         (princ "<li><table><tr>\n<td>\n")
 	 (setq label (kcell-view:label))
 	 (princ (format "<span id=\"k%s\"></span>" (kcell-view:idstamp)))
-	 (princ (format "<span id=\"k%s\">%s%s</span></td>\n" label label separator))
-	 (princ "<td>")
+	 (princ (format "<span id=\"k%s\">%s%s</span>\n" label label separator))
+	 (princ "</td><td>\n")
 	 (setq contents (kcell-view:contents))
 	 (if (string-match "\\`\\([-_$%#@~^&*=+|/A-Za-z0-9 ]+\\):.*\\S-"
 			   contents)
@@ -203,16 +198,11 @@ STILL TODO:
 	 (if soft-newlines-flag
 	     (princ contents)
 	   (princ "<pre>") (princ contents) (princ "</pre>"))
-	 (princ "</td>\n")
-	 (princ "</tr></table>")
-	 (setq i level)
-	 (while (> i 1)
-	   ;; (princ "</li>")
-	   (setq i (1- i)))
-         (princ "</li>")
+	 (princ "\n</td>\n")
+	 (princ "</tr></table></li>")
 	 (terpri) (terpri))
        kview t t))
-    (princ "</ul>")
+    (princ "</ul>\n")
     (princ "</body>\n</html>\n")
     (set-buffer standard-output)
     (save-buffer)))

--- a/kotl/kexport.el
+++ b/kotl/kexport.el
@@ -161,7 +161,6 @@ STILL TODO:
 
     (princ "<head>\n")
     (princ "<meta charset=\"utf-8\">\n")
-    (princ "<span ID=\"top\"></span><span id=\"k0\"></span>\n")
     (princ (format "<title>%s</title>\n" title))
     (if kexport:html-description
 	(princ (format "<meta name=\"generator\" content=\"%s\">\n"
@@ -180,26 +179,26 @@ STILL TODO:
 		  "<" (kview:label-separator kview) "&lt;")
 	     "&gt;"))
 	   i level label contents)
+      (princ "<ul>")
       (kview:map-tree
        (lambda (kview)
 	 (setq level (kcell-view:level)
 	       i level)
 	 (while (> i 1)
-	   (princ "<ul>")
+	   ;;(princ "<li>")
 	   (setq i (1- i)))
+         (princ "<li>")
 	 (princ "<table><tr>\n")
+	 (princ "<td>")
 	 (setq label (kcell-view:label))
-	 (princ (format "<span id=\"k%s\"></span>" label))
 	 (princ (format "<span id=\"k%s\"></span>" (kcell-view:idstamp)))
-	 (princ (format
-		 "<font>%s%s</font></pre></td>\n"
-		 label separator))
+	 (princ (format "<span id=\"k%s\">%s%s</span></td>\n" label label separator))
 	 (princ "<td>")
 	 (setq contents (kcell-view:contents))
 	 (if (string-match "\\`\\([-_$%#@~^&*=+|/A-Za-z0-9 ]+\\):.*\\S-"
 			   contents)
 	     (princ (format "<a id=\"%s\"></a>"
-			    (substring contents 0 (match-end 1)))))
+			    (replace-regexp-in-string " " "-" (substring contents 0 (match-end 1))))))
 	 (setq contents (kexport:html-markup contents))
 	 (if soft-newlines-flag
 	     (princ contents)
@@ -208,10 +207,12 @@ STILL TODO:
 	 (princ "</tr></table>")
 	 (setq i level)
 	 (while (> i 1)
-	   (princ "</ul>")
+	   ;; (princ "</li>")
 	   (setq i (1- i)))
+         (princ "</li>")
 	 (terpri) (terpri))
        kview t t))
+    (princ "</ul>")
     (princ "</body>\n</html>\n")
     (set-buffer standard-output)
     (save-buffer)))

--- a/kotl/kexport.el
+++ b/kotl/kexport.el
@@ -4,7 +4,7 @@
 ;;
 ;; Orig-Date:    26-Feb-98
 ;;
-;; Copyright (C) 1998-2017  Free Software Foundation, Inc.
+;; Copyright (C) 1998-2020  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.
@@ -31,15 +31,6 @@
 (defvar kexport:output-filename nil
   "This is automatically set to the full pathname of the file presently being exported.")
 
-;; CSS notes
-;; <body>  "BGCOLOR=\"#FFFFFF\"" ;; white background TODO - remove should be in css
-
-(defcustom kexport:html-body-attributes
-  "BGCOLOR=\"#FFFFFF\"" ;; white background TODO - remove should be in css
-  "*String of HTML attributes attached to the <BODY> tag of an HTML exported koutline file."
-  :type 'string
-  :group 'hyperbole-koutliner)
-
 (defcustom kexport:html-description
   "Created by Hyperbole's outliner. See (hyperbole)Koutliner for more information." ; TODO - proper hypb link type in html?
   "*String to insert as the HTML-exported document's description, or nil for none."
@@ -52,13 +43,6 @@
   :type '(choice (const nil)
 		 (string))
   :group 'hyperbole-koutliner)
-
-(defcustom kexport:label-html-font-attributes
-  "COLOR=\"#C100C1\" SIZE=\"-1\""
-  "*String of HTML font attributes attached to kcell labels when exported."
-  :type 'string
-  :group 'hyperbole-koutliner)
-
 
 (defvar kexport:kcell-reference-regexp
   "[0-9a-zA-Z][.0-9a-zA-Z]*=\\([.0-9a-zA-Z]+\\)")
@@ -73,7 +57,7 @@
    '(">" . "&gt;")
    ;;
    ;; italicize keybindings
-   '("{[^}]+}" . "<i>\0</i>")
+   '("{[^}]+}" . "<i>\\&</i>")
    ;;
    ;; make URLs into hyperlinks
    (cons hpath:url-regexp  'kexport:html-url)
@@ -91,10 +75,10 @@
    ;; make klinks into hyperlinks
    (cons (concat "&lt;\\s-*@\\s-*" kexport:kcell-reference-regexp
 		 "[^&>]*&gt;")
-	 "<a href=\"#k\\1\">\0</a>")
+	 "<a href=\"#k\\1\">\\&</a>")
    (cons (format "&lt;\\s-*@\\s-*\\(%s\\)[^=&>]*&gt;"
 		 kexport:kcell-partial-reference-regexp)
-	 "<a href=\"#k\\1\">\0</a>")
+	 "<a href=\"#k\\1\">\\&</a>")
    (cons (format "&lt;\\s-*\\([^ \t\n\r,<>]+\\)\\s-*,\\s-*%s[^=&>]*&gt;"
 		 kexport:kcell-reference-regexp)
 	 'kexport:html-file-klink)
@@ -174,9 +158,10 @@ STILL TODO:
 
     (princ "<!doctype html>\n\n")
     (princ "<html lang=\"en\">\n")
+
     (princ "<head>\n")
     (princ "<meta charset=\"utf-8\">\n")
-    ;; (princ "<A ID=\"top\"></A><A ID=\"k0\"></A>\n")
+    (princ "<span ID=\"top\"></span><span id=\"k0\"></span>\n")
     (princ (format "<title>%s</title>\n" title))
     (if kexport:html-description
 	(princ (format "<meta name=\"generator\" content=\"%s\">\n"
@@ -184,9 +169,11 @@ STILL TODO:
     (if kexport:html-keywords
 	(princ (format "<meta id=\"keywords\" CONTENT=\"%s\">\n"
 		       kexport:html-keywords)))
+    (princ "<link rel=\"stylesheet\" href=\"https://www.gnu.org/software/hyperbole/man/hyperbole.css\">")
     (princ "</head>\n\n")
-    (princ "<body>\n\n") ;; TODO - use css instead of body attributes
-    (princ (format "<h1>%s</h1>\n\n" title))  ;; TODO - don't use center, use css instead
+    
+    (princ "<body>\n\n")
+    (princ (format "<h1>%s</h1>\n\n" title))
     (let* ((separator
 	    (hypb:replace-match-string
 	     ">" (hypb:replace-match-string
@@ -202,11 +189,10 @@ STILL TODO:
 	   (setq i (1- i)))
 	 (princ "<table><tr>\n")
 	 (setq label (kcell-view:label))
-	 ; (princ (format "<a id=\"k%s\"></a>" label))
-	 ; (princ (format "<a id=\"k%s\"></a>\n" (kcell-view:idstamp)))
-	 (princ (format "<td id=\"k%s\" id=\"k%s\" width=2%% valign=top><pre>\n" label (kcell-view:idstamp)))
+	 (princ (format "<span id=\"k%s\"></span>" label))
+	 (princ (format "<span id=\"k%s\"></span>" (kcell-view:idstamp)))
 	 (princ (format
-		 "<font>%s%s</font></pre></td>\n" ; TODO - use css instead of font attributes
+		 "<font>%s%s</font></pre></td>\n"
 		 label separator))
 	 (princ "<td>")
 	 (setq contents (kcell-view:contents))
@@ -241,8 +227,8 @@ Works exclusively within a call to `hypb:replace-match-string'."
 			     (match-end 1))))
     (if (equal filename (file-name-nondirectory
 			 kexport:input-filename))
-	"<a href=\"#k\\2\">\0</a>"
-      (format "<a href=\"file://%s#k\\2\">\0</a>"
+	"<a href=\"#k\\2\">\\&</a>"
+      (format "<a href=\"file://%s#k\\2\">\\&</a>"
 	      (expand-file-name filename
 				(if kexport:input-filename
 				    (file-name-directory

--- a/kotl/kexport.el
+++ b/kotl/kexport.el
@@ -31,14 +31,17 @@
 (defvar kexport:output-filename nil
   "This is automatically set to the full pathname of the file presently being exported.")
 
+;; CSS notes
+;; <body>  "BGCOLOR=\"#FFFFFF\"" ;; white background TODO - remove should be in css
+
 (defcustom kexport:html-body-attributes
-  "BGCOLOR=\"#FFFFFF\"" ;; white background
+  "BGCOLOR=\"#FFFFFF\"" ;; white background TODO - remove should be in css
   "*String of HTML attributes attached to the <BODY> tag of an HTML exported koutline file."
   :type 'string
   :group 'hyperbole-koutliner)
 
 (defcustom kexport:html-description
-  "Created by Hyperbole's outliner.\nSee \"(hyperbole)Koutliner\" for more information."
+  "Created by Hyperbole's outliner. See (hyperbole)Koutliner for more information." ; TODO - proper hypb link type in html?
   "*String to insert as the HTML-exported document's description, or nil for none."
   :type '(choice (const nil)
 		 (string))
@@ -169,18 +172,21 @@ STILL TODO:
 	(setq title (read-string (format "Title for %s: " output-to-buf-name)
 				 title)))
 
-    (princ "<html><head>\n\n")
-    (princ "<a id=\"top\"></a><a id=\"k0\"></a>\n")
+    (princ "<!doctype html>\n\n")
+    (princ "<html lang=\"en\">\n")
+    (princ "<head>\n")
+    (princ "<meta charset=\"utf-8\">\n")
+    ;; (princ "<A ID=\"top\"></A><A ID=\"k0\"></A>\n")
     (princ (format "<title>%s</title>\n" title))
     (if kexport:html-description
-	(princ (format "<meta id=\"description\" content=\"%s\">\n"
+	(princ (format "<meta name=\"generator\" content=\"%s\">\n"
 		       kexport:html-description)))
     (if kexport:html-keywords
-	(princ (format "<meta id=\"keywords\" content=\"%s\">\n"
+	(princ (format "<meta id=\"keywords\" CONTENT=\"%s\">\n"
 		       kexport:html-keywords)))
     (princ "</head>\n\n")
-    (princ (format "<body %s>\n\n" kexport:html-body-attributes))
-    (princ (format "<center><h1>%s</h1></center>\n\n" title))
+    (princ "<body>\n\n") ;; TODO - use css instead of body attributes
+    (princ (format "<h1>%s</h1>\n\n" title))  ;; TODO - don't use center, use css instead
     (let* ((separator
 	    (hypb:replace-match-string
 	     ">" (hypb:replace-match-string
@@ -196,12 +202,11 @@ STILL TODO:
 	   (setq i (1- i)))
 	 (princ "<table><tr>\n")
 	 (setq label (kcell-view:label))
-	 (princ (format "<a id=\"k%s\"></a>" label))
-	 (princ (format "<a id=\"k%s\"></a>\n" (kcell-view:idstamp)))
-	 (princ "<td width=2% valign=top><pre>\n")
+	 ; (princ (format "<a id=\"k%s\"></a>" label))
+	 ; (princ (format "<a id=\"k%s\"></a>\n" (kcell-view:idstamp)))
+	 (princ (format "<td id=\"k%s\" id=\"k%s\" width=2%% valign=top><pre>\n" label (kcell-view:idstamp)))
 	 (princ (format
-		 "<font %s>%s%s</font></pre></td>\n"
-		 kexport:label-html-font-attributes
+		 "<font>%s%s</font></pre></td>\n" ; TODO - use css instead of font attributes
 		 label separator))
 	 (princ "<td>")
 	 (setq contents (kcell-view:contents))
@@ -221,7 +226,7 @@ STILL TODO:
 	   (setq i (1- i)))
 	 (terpri) (terpri))
        kview t t))
-    (princ "</body></html>\n")
+    (princ "</body>\n</html>\n")
     (set-buffer standard-output)
     (save-buffer)))
 

--- a/kotl/kexport.el
+++ b/kotl/kexport.el
@@ -32,7 +32,7 @@
   "This is automatically set to the full pathname of the file presently being exported.")
 
 (defcustom kexport:html-description
-  "Created by Hyperbole's outliner. See (hyperbole)Koutliner for more information." ; TODO - proper hypb link type in html?
+  "Created by Koutliner. See https://www.gnu.org/software/hyperbole/ for more information."
   "*String to insert as the HTML-exported document's description, or nil for none."
   :type '(choice (const nil)
 		 (string))
@@ -165,10 +165,10 @@ STILL TODO:
       (princ "<meta charset=\"utf-8\">\n")
       (princ (format "<title>%s</title>\n" title))
       (if kexport:html-description
-	  (princ (format "<meta name=\"generator\" content=\"%s\">\n"
-		         kexport:html-description)))
+	  (princ (format "<meta name=\"generator\" content=\"Hyperbole %s - %s\">\n"
+		         hyperb:version kexport:html-description)))
       (if kexport:html-keywords
-	  (princ (format "<meta id=\"keywords\" CONTENT=\"%s\">\n"
+	  (princ (format "<meta id=\"keywords\" content=\"%s\">\n"
 		         kexport:html-keywords)))
       (princ "<link rel=\"stylesheet\" href=\"https://www.gnu.org/software/hyperbole/man/hyperbole.css\">")
       (princ "</head>\n\n"))


### PR DESCRIPTION
## What

Update kexport to html

## Why

The kexport to html is not compliant with html5 and there are some bugs regarding export of links and key sequences. 

This is work in progress. The export works but the result looks bad since the cells are rendered as the table cells they are and the hyperbole.css used puts a frame around them etc. So more to do there if we want it to look pretty.

This does not yet address the request to control how the header looks and if it shall be exported at all. 