### PR TITLE
Add defal defil tests plus some extras

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
-2021-02-28  Mats Lidell  <mats.lidell@lidells.se>
+2021-02-28  Mats Lidell  <matsl@gnu.org>
 
+* hbut.el (defil): Use FIXEDCASE is non-nil to not alter the case of the
+    replacement text.
+ 
 * test/hbut-tests.el (hbut-defal, hbut-defal-fails-on-file-missing)
     (hbut-defil): Test for defal and defil implicit button macros.
 

--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+2021-02-28  Mats Lidell  <mats.lidell@lidells.se>
+
+* (demo-man-appropos-test, ibtypes::man-apropos-test): Mock call to man.
+
 2021-02-21  Bob Weiner  <rsw@gnu.org>
 
 * hyperbole.el (hkey-define-key): Removed, had bug that did not use prefix

--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 2021-02-28  Mats Lidell  <mats.lidell@lidells.se>
 
+* test/hbut-tests.el (hbut-defal, hbut-defal-fails-on-file-missing)
+    (hbut-defil): Test for defal and defil implicit button macros.
+
 * (demo-man-appropos-test, ibtypes::man-apropos-test): Mock call to man.
 
 2021-02-21  Bob Weiner  <rsw@gnu.org>

--- a/hbut.el
+++ b/hbut.el
@@ -1802,7 +1802,7 @@ commit changes."
 		   (hact ,link-expr button-text)
 		 (let ((referent (when (and button-text (stringp ,link-expr)
 					    (string-match ,text-regexp button-text))
-				   (replace-match ,link-expr nil nil button-text))))
+				   (replace-match ,link-expr t nil button-text))))
 		   (ibtype:activate-link referent))))))
        (put (intern (format "ibtypes::%s" ',type))
 	    'function-documentation

--- a/test/demo-tests.el
+++ b/test/demo-tests.el
@@ -24,6 +24,7 @@
 (require 'hib-social)
 (require 'eww)
 (require 'compile)
+(require 'el-mock)
 
 (load (expand-file-name "hy-test-helpers"
                         (file-name-directory (or load-file-name
@@ -347,15 +348,12 @@
 
 ;; Man appropos
 (ert-deftest demo-man-appropos-test ()
-  (unwind-protect
-      (with-temp-buffer
-        (insert "rm (1)   - remove")
-        (goto-char 4)
-        (action-key)
-        (sit-for 0.2)
-        (set-buffer "*Man 1 rm*")
-        (should (looking-at "RM\(1\)")))
-    (kill-buffer "*Man 1 rm*")))
+  (with-temp-buffer
+    (insert "rm (1)   - remove")
+    (goto-char 4)
+    (with-mock
+      (mock (man "rm(1)") => t)
+      (action-key))))
 
 ;; Explicit buttons
 (ert-deftest demo-factorial-test ()

--- a/test/hbut-tests.el
+++ b/test/hbut-tests.el
@@ -1,0 +1,60 @@
+;;; hbut-tests.el --- hbut unit tests         -*- lexical-binding: t; -*-
+
+;; Author: Mats Lidell <matsl@gnu.org>
+;;
+;; Orig-Date: 28-Feb-21 at 22:52:00
+;;
+;; Copyright (C) 2021  Free Software Foundation, Inc.
+;; See the "HY-COPY" file for license information.
+;;
+;; This file is part of GNU Hyperbole.
+
+;;; Commentary:
+
+;; Runs unit tests on some of the examples given in the DEMO file.
+
+;;; Code:
+
+(require 'ert)
+(require 'hbut)
+
+(ert-deftest hbut-defal ()
+  (defal hfile "${hyperb:dir}/\\1")
+  (unwind-protect
+      (with-temp-buffer
+        (insert "<hfile DEMO>")
+        (goto-char 4)
+        (action-key)
+        (should (string= (concat hyperb:dir "DEMO") buffer-file-name))))
+    (progn
+      (kill-buffer "DEMO")
+      (fmakunbound 'ibtypes::hfile)))
+
+(ert-deftest hbut-defal-fails-on-file-missing ()
+  (defal hfile "${hyperb:dir}/\\1")
+  (unwind-protect
+      (with-temp-buffer
+        (insert "<hfile UNKNOWN-FILE>")
+        (goto-char 4)
+        (condition-case err
+            (action-key)
+          (error
+           (progn
+             (should (equal (car err) 'error))
+             (should (string-search "hpath:find" (cadr err)))))))
+    (fmakunbound 'ibtypes::hfile)))
+
+(ert-deftest hbut-defil ()
+  (defil hfile "<<<" ">>>" ".*" "${hyperb:dir}/\\&")
+  (unwind-protect
+      (with-temp-buffer
+        (insert "<<<DEMO>>>")
+        (goto-char 4)
+        (action-key)
+        (should (string= (concat hyperb:dir "DEMO") buffer-file-name)))
+    (progn
+      (kill-buffer "DEMO")
+      (fmakunbound 'ibtypes::hfile))))
+
+(provide 'hbut-tests)
+;;; hbut-tests.el ends here

--- a/test/hibtypes-tests.el
+++ b/test/hibtypes-tests.el
@@ -189,16 +189,12 @@
 
 ;; man-apropos
 (ert-deftest ibtypes::man-apropos-test ()
-  (unwind-protect
-      (with-temp-buffer
-        (insert "rm (1)   - remove")
-        (goto-char 4)
-        (ibtypes::man-apropos)
-        (sit-for 0.2)
-        (set-buffer "*Man 1 rm*")
-        (should (looking-at "RM\(1\)")))
-    (kill-buffer "*Man 1 rm*")))
-
+  (with-temp-buffer
+    (insert "rm (1)   - remove")
+    (goto-char 4)
+    (with-mock
+     (mock (man "rm(1)") => t)
+     (ibtypes::man-apropos))))
 
 ;; klink
 


### PR DESCRIPTION
## What

* Adds tests for defal and defil (Added one test to verify that if file does not exists that causes and error and not silently opens a buffer.) 
* Fix problem with replacements text being converted to uppercase
* Use mock for man page test to avoid asynchronous generation of the man page