### PR TITLE
Verify error message from hpath:find is correct

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 2021-02-28  Mats Lidell  <matsl@gnu.org>
 
+* test/hpath-tests.el
+    (hpath:find-report-lisp-variable-path-name-when-not-exists): Verify
+    not found file name error message contains the expanded lisp variable. 
+
 * hbut.el (defil): Use FIXEDCASE is non-nil to not alter the case of the
     replacement text.
  

--- a/test/hpath-tests.el
+++ b/test/hpath-tests.el
@@ -1,0 +1,29 @@
+;;; hpath-tests.el --- unit tests for hpath         -*- lexical-binding: t; -*-
+
+;; Author: Mats Lidell <matsl@gnu.org>
+;;
+;; Orig-Date: 28-Feb-21 at 23:26:00
+;;
+;; Copyright (C) 2021  Free Software Foundation, Inc.
+;; See the "HY-COPY" file for license information.
+;;
+;; This file is part of GNU Hyperbole.
+
+;;; Commentary:
+
+;; Unit tests for "../hpath.el"
+
+;;; Code:
+
+(require 'ert)
+(require 'hpath)
+
+(ert-deftest hpath:find-report-lisp-variable-path-name-when-not-exists ()
+  "hpath:find prints out the wrong filename on lisp variable expanded filenames"
+  :expected-result :failed
+  (condition-case err
+      (hpath:find "${hyperb:dir}/UNKNOWNFILE")
+    (error (should (string-search (concat hyperb:dir "UNKNOWNFILE") (cadr err))))))
+
+(provide 'hpath-tests)
+;;; hpath-tests.el ends here


### PR DESCRIPTION
## What

Verify error message from hpath:find is correct

## Why

When a lisp variable is used in the path name the expanded path name in the error message is not correct. In the example the error message is UNKNOWNFILE/UNKNOWNFILE but should be "`the expanded hyperbole-dir-path`/UNKNOWNFILE".