### PR TITLE
Add more defal and defil tests

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,12 +1,25 @@
+2021-03-06  Mats Lidell  <matsl@gnu.org>
+
+* test/hbut-tests.el (hbut-defal-url, hbut-defal-key-sequence)
+    (hbut-defil-it, hbut-defil, hbut-defil-url, hbut-defil-key-sequence):
+    Added more tests for defal and defil.
+
+* test/hibtypes-tests.el (ibtypes::ctags-vgrind-test):
+    (ibtypes::etags-test): Updated since tags info changed
+
+* test/hy-test-helpers.el
+    (hy-test-helpers:action-key-should-call-hpath:find): Add helper for
+    verifying hpath:find is called
+
 2021-02-28  Mats Lidell  <matsl@gnu.org>
 
 * test/hpath-tests.el
     (hpath:find-report-lisp-variable-path-name-when-not-exists): Verify
-    not found file name error message contains the expanded lisp variable. 
+    not found file name error message contains the expanded lisp variable.
 
 * hbut.el (defil): Use FIXEDCASE is non-nil to not alter the case of the
     replacement text.
- 
+
 * test/hbut-tests.el (hbut-defal, hbut-defal-fails-on-file-missing)
     (hbut-defil): Test for defal and defil implicit button macros.
 

--- a/test/hibtypes-tests.el
+++ b/test/hibtypes-tests.el
@@ -118,7 +118,7 @@
 (ert-deftest ibtypes::ctags-vgrind-test ()
   (unwind-protect
       (with-temp-buffer
-        (insert "hy-test-helpers:consume-input-events hy-test-helpers.el 20\n")
+        (insert "hy-test-helpers:consume-input-events hy-test-helpers.el 21\n")
         (goto-char (point-min))
         (forward-char 4)
         (let ((default-directory (concat default-directory "test")))
@@ -133,7 +133,7 @@
       (with-temp-buffer
         (insert "\n")
         (insert "hy-test-helpers.el,103\n")
-        (insert "(defun hy-test-helpers:consume-input-events 20,359\n")
+        (insert "(defun hy-test-helpers:consume-input-events 21,359\n")
         (rename-buffer (concat "TAGS" (buffer-name)))
         (goto-char (point-min))
         (forward-line 2)

--- a/test/hy-test-helpers.el
+++ b/test/hy-test-helpers.el
@@ -16,6 +16,7 @@
 ;;; Code:
 
 (require 'ert)
+(require 'cl-macs)
 
 (defun hy-test-helpers:consume-input-events ()
   "Use recusive-edit to consume the events kbd-key generate."
@@ -28,6 +29,15 @@
     (should (save-excursion
               (goto-char (point-max))
               (search-backward msg (- (point-max) 350))))))
+
+(defun hy-test-helpers:action-key-should-call-hpath:find (str)
+  "Call action-key and check that hpath:find was called with STR."
+  (let ((was-called nil))
+    (cl-letf (((symbol-function 'hpath:find)
+               (lambda (filename)
+                 (setq was-called (should (string= str filename))))))
+      (action-key)
+      (should was-called))))
 
 (provide 'hy-test-helpers)
 ;;; hy-test-helpers.el ends here


### PR DESCRIPTION
## What

This PR adds some more tests for defil and defal. 

Also added test helper for more unit test like tests verifying that hpath:find is called with the right arguments so that we don't go the fill way to check that the proper file was loaded. We might consider going more in this direction though the integration tests that goes the full way is still not a bad idea I think. Look for `hbut-defil-it` and `hbut-defil` to see the difference.

Not sure but there seems to be some problems with cleaning up the defal and defil after a test case. I'm using  `ibtype:delete` now but not sure if that is the proper way to do that.