### PR TITLE
More tests for ib with labels

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+2021-03-14  Mats Lidell  <matsl@gnu.org>
+
+* test/hy-test-dependencies.el (package-installed-p): Add
+    with-simulated-input
+
 2021-03-12  Mats Lidell  <matsl@gnu.org>
 
 * test/hbut-tests.el (hbut-verify-defal, hbut-defal-function): Test defal

--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 2021-03-14  Mats Lidell  <matsl@gnu.org>
 
+* test/hbut-tests.el (hbut-ib-link-to-file-with-label-variants): Test
+    variants of label separation chars and lengths
+
 * test/hy-test-dependencies.el (package-installed-p): Add
     with-simulated-input
 

--- a/Changes
+++ b/Changes
@@ -2,6 +2,9 @@
 
 * test/hbut-tests.el (hbut-ib-link-to-file-with-label-variants): Test
     variants of label separation chars and lengths
+    (hbut-ib-create-label): Test creation of label
+    (hbut-ib-create-label-fails-if-label-exists): Check creation fails
+    when label exists
 
 * test/hy-test-dependencies.el (package-installed-p): Add
     with-simulated-input

--- a/test/hbut-tests.el
+++ b/test/hbut-tests.el
@@ -162,5 +162,27 @@ the button text"
     (let ((browse-url-browser-function 'hbut-defal-url))
       (action-key))))
 
+(ert-deftest hbut-ib-create-label ()
+  "Create a label for an implicit button"
+  (with-temp-buffer
+    (insert "\"/tmp\"\n")
+    (goto-char 3)
+    (with-simulated-input "TMP RET"
+      (hui:ibut-label-create)
+      (should (string= "<[TMP]> \"/tmp\"\n" (buffer-string))))))
+
+(ert-deftest hbut-ib-create-label-fails-if-label-exists ()
+  "Creation of a label for an implicit button fails if a label exists."
+  (with-temp-buffer
+    (insert "<[LBL]>: \"/tmp\"\n")
+    (goto-char 14)
+    (with-simulated-input "TMP RET"
+      (condition-case err
+          (hui:ibut-label-create)
+        (error
+         (progn
+           (should (equal (car err) 'error))
+           (should (string-search "ibutton at point already has a label" (cadr err)))))))))
+
 (provide 'hbut-tests)
 ;;; hbut-tests.el ends here

--- a/test/hbut-tests.el
+++ b/test/hbut-tests.el
@@ -145,6 +145,14 @@ the button text"
     (goto-char 4)
     (hy-test-helpers:action-key-should-call-hpath:find (concat hyperb:dir "DEMO"))))
 
+(ert-deftest hbut-ib-link-to-file-with-label-variants ()
+  (cl-loop for ch in '(?: ?- ?=) do
+           (cl-loop for n from 0 to 3 do
+                    (with-temp-buffer
+                      (insert "<[demo]>" (make-string n ch) " \"${hyperb:dir}/DEMO\"")
+                      (goto-char 4)
+                      (hy-test-helpers:action-key-should-call-hpath:find (concat hyperb:dir "DEMO"))))))
+
 (ert-deftest hbut-ib-url-with-label ()
   "Should find link but fails with (user-error \"No link found\")"
   :expected-result :failed

--- a/test/hy-test-dependencies.el
+++ b/test/hy-test-dependencies.el
@@ -21,7 +21,8 @@
 (add-to-list 'package-archives '("melpa" . "https://melpa.org/packages/"))
 (unless (package-installed-p 'el-mock)
   (package-refresh-contents)
-  (package-install 'el-mock))
+  (package-install 'el-mock)
+  (package-install 'with-simulated-input))
 
 (provide 'hy-test-dependencies)
 ;;; hy-test-dependencies.el ends here


### PR DESCRIPTION
Adds more test for implicit buttons with labels.

Uses a new helper: `with-simulated-input` found on melpa. Seems promising. Check it out.