### PR TITLE
Correct test cases failing on mac

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+2021-03-14  Mats Lidell  <matsl@gnu.org>
+
+* test/hibtypes-tests.el (ibtypes::pathname-env-variable-test): Use env
+    for HOME to not depend on machine or OS specifics
+
 2021-03-14  Bob Weiner  <rsw@gnu.org>
 
 * man/hyperbole.texi (Smart Key - Magit Mode):

--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 2021-03-14  Mats Lidell  <matsl@gnu.org>
 
+* test/demo-tests.el (demo-smart-scrolling-non-proportional-test): Make
+    test more robust
+
 * test/hibtypes-tests.el (ibtypes::pathname-env-variable-test): Use env
     for HOME to not depend on machine or OS specifics
 

--- a/test/demo-tests.el
+++ b/test/demo-tests.el
@@ -79,7 +79,6 @@
               (pos (point)))
           (end-of-line)
           (action-key)
-          (beginning-of-line)
           (should (= pos (window-start)))))
     (kill-buffer "DEMO")))
 
@@ -89,10 +88,12 @@
         (hypb:display-file-with-logo (expand-file-name "DEMO" hyperb:dir))
         (goto-char (point-min))
         (re-search-forward "Table of Contents")
+        (beginning-of-line)
         (let ((smart-scroll-proportional nil)
               (pos (point)))
+          (end-of-line)
           (action-key)
-          (should (< pos (point)))))
+          (should (< pos (window-start)))))
     (kill-buffer "DEMO")))
 
 ;; Hyperbole menus

--- a/test/hibtypes-tests.el
+++ b/test/hibtypes-tests.el
@@ -76,7 +76,7 @@
         (goto-char 2)
         (ibtypes::pathname)
         (should (equal major-mode 'dired-mode))
-        (should (= 0 (string-match "/home/.*" (file-truename default-directory)))))
+        (should (= 0 (string-match (getenv "HOME") (file-truename default-directory)))))
     nil))
 
 (ert-deftest ibtypes::pathname-emacs-lisp-file-test ()


### PR DESCRIPTION
This PR uses the environment for getting the HOME to not to depend on machine or OS specifics.

It also tried to make the non proportional scroll test more robust. Give it a try on Mac to see if it work better. 