### PR TITLE
Exclude the test folder from the tar ball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -351,7 +351,7 @@ $(pkg_dir)/hyperbole-$(HYPB_VERSION).tar.sig: $(pkg_dir)/hyperbole-$(HYPB_VERSIO
 $(pkg_dir)/hyperbole-$(HYPB_VERSION).tar: $(HYPERBOLE_FILES)
 	make version
 	cd $(pkg_dir) && $(RM) -fr $(pkg_hyperbole) $(pkg_hyperbole)-$(HYPB_VERSION)
-	cd .. && COPYFILE_DISABLE=1 $(TAR) -clf $(pkg_dir)/h.tar hyperbole
+	cd .. && COPYFILE_DISABLE=1 $(TAR) --exclude="test/*" -clf $(pkg_dir)/h.tar hyperbole
 	cd $(pkg_dir) && COPYFILE_DISABLE=1 $(TAR) xf h.tar && cd $(pkg_hyperbole) && $(MAKE) packageclean
 	cd $(pkg_hyperbole) && make autoloads && chmod 755 topwin.py && \
 	cd $(pkg_dir) && $(RM) h.tar; \


### PR DESCRIPTION
## What

This excludes the test folder from being inserted in the release tar ball as we talked about.

## Why?

Thinking about this now I'm not that sure it is a good idea. Why would we not want anyone who downloads the tar ball to have access to the test files? It is not that they take up a lot of space and they are not in the way for anyone who is not interested in them.