### PR TITLE
Add button for running hyperbole ert tests

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,11 @@
+2021-04-04  Mats Lidell  <matsl@gnu.org>
+
+* HY-NEWS: Section about hypb-ert
+  Makefile (EL_COMPILE, ELC_COMPILE): Add hypb-ert
+  hypb-ert.el (hypb-run-ert-test-symbol, hypb-run-ert-test-selector)
+    (hypb-ert-sym, hypb-ert-sel): Add implicit buttons for running ert
+    tests.
+
 2021-04-03  Mats Lidell  <matsl@gnu.org>
 
 * man/hyperbole.texi (Smart Key - Todotxt Mode): Add node to document

--- a/HY-NEWS
+++ b/HY-NEWS
@@ -120,6 +120,9 @@
       pass.  If any fail, you can press the Action Key to see the source of
       the failure.
 
+    - Defal implicit buttons hypb-ert-sym and hypb-ert-sel: For running
+      hyperbole ert test from hyperbole source files.
+
 ===========================================================================
 *                                   V7.1.3
 ===========================================================================

--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ EL_COMPILE = hact.el hactypes.el hargs.el hbdata.el hbmap.el hbut.el \
 	     hpath.el hrmail.el hsettings.el hsmail.el hsys-org.el hsys-www.el htz.el \
 	     hycontrol.el hui-jmenu.el hui-menu.el hui-mini.el hui-mouse.el hui-select.el \
 	     hui-treemacs.el hui-window.el hui.el hvar.el hversion.el hvm.el hypb.el hyperbole.el \
-	     hyrolo-demo.el hyrolo-logic.el hyrolo-menu.el hyrolo.el hywconfig.el set.el
+	     hyrolo-demo.el hyrolo-logic.el hyrolo-menu.el hyrolo.el hywconfig.el set.el hypb-ert.el
 
 EL_KOTL = kotl/kexport.el kotl/kfile.el kotl/kfill.el kotl/kimport.el kotl/klabel.el \
 	  kotl/klink.el kotl/kmenu.el kotl/knode.el kotl/kotl-mode.el kotl/kotl-orgtbl.el \
@@ -175,7 +175,7 @@ ELC_COMPILE =  hactypes.elc hibtypes.elc hib-debbugs.elc hib-doc-id.elc hib-kbd.
 	     hycontrol.elc hui-jmenu.elc hui-menu.elc hui-mini.elc hui-mouse.elc hui-select.elc \
 	     hui-treemacs.elc hui-window.elc hui.elc hvar.elc hversion.elc hvm.elc hypb.elc hyperbole.elc \
 	     hyrolo-demo.elc hyrolo-logic.elc hyrolo-menu.elc hyrolo.elc hywconfig.elc \
-	     set.elc kprop-em.elc
+	     set.elc kprop-em.elc hypb-ert.elc
 
 ELC_KOTL = kotl/kexport.elc kotl/kfile.elc kotl/kfill.elc kotl/kimport.elc kotl/klabel.elc \
 	   kotl/klink.elc kotl/kmenu.elc kotl/knode.elc kotl/kotl-mode.elc kotl/kotl-orgtbl.elc \

--- a/hypb-ert.el
+++ b/hypb-ert.el
@@ -1,0 +1,45 @@
+;;; hypb-ert --- ert button support                   -*- lexical-binding: t; -*-
+
+;; Author: Mats Lidell <matsl@gnu.org>
+;;
+;; Orig-Date: 31-Mar-21 at 21:11:00
+;;
+;; Copyright (C) 2021  Free Software Foundation, Inc.
+;; See the "HY-COPY" file for license information.
+;;
+;; This file is part of GNU Hyperbole.
+
+;;; Commentary:
+
+;; Defines an implicit button for running an ert test
+;;
+;; Example:
+;;   Run the test hbut-defal-url
+;;   <hypb-ert-sym hbut-defal-url>
+;;
+;;   Run the tests specified by the test selector hbut-defal
+;;   <hypb-ert-sel hbut-defal>
+;;
+;;   Run all tests
+;;   <hypb-ert-sel t>
+
+;;; Code:
+
+(require 'hbut)
+(require 'hargs)
+
+(defun hypb-run-ert-test-symbol (test-symbol)
+  "Run the specified TEST-SYMBOL ert test."
+  (mapc 'load-file (directory-files "test" t "\\.el$"))
+  (ert (intern test-symbol)))
+
+(defun hypb-run-ert-test-selector (test-selector)
+  "Run the specified TEST-SELECTOR defined ert test."
+  (mapc 'load-file (directory-files "test" t "\\.el$"))
+  (ert test-selector))
+
+(defal hypb-ert-sym 'hypb-run-ert-test-symbol)
+(defal hypb-ert-sel 'hypb-run-ert-test-selector)
+
+(provide 'hypb-ert)
+;;; hypb-ert.el ends here


### PR DESCRIPTION
## What

Add button for running hyperbole ert tests

## Why

Make it possible to define a button for running one or more unit tests that can be placed with the code that is to be tested. This take a simple approach and load all tests available and then use ert's support for running a selection.