### PR TITLE
Use elc extension on hypb-org in ELC_COMPILE macro

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+2021-04-05  Mats Lidell  <matsl@gnu.org>
+
+* Makefile (ELC_COMPILE): Fix hypb-org extension
+
 2021-04-04  Mats Lidell  <matsl@gnu.org>
 
 * HY-NEWS: Section about hypb-ert

--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ EL_KOTL = kotl/kexport.el kotl/kfile.el kotl/kfill.el kotl/kimport.el kotl/klabe
 	  kotl/kview.el kotl/kvspec.el
 
 ELC_COMPILE =  hactypes.elc hibtypes.elc hib-debbugs.elc hib-doc-id.elc hib-kbd.elc \
-	     hib-org.el hib-social.elc hact.elc \
+	     hib-org.elc hib-social.elc hact.elc \
 	     hargs.elc hbdata.elc hbmap.elc hbut.elc hgnus.elc hhist.elc \
 	     hinit.elc hload-path.elc hmail.elc hmh.elc hmoccur.elc hmouse-info.elc \
 	     hmouse-drv.elc hmouse-key.elc hmouse-mod.elc hmouse-sh.elc hmouse-tag.elc \


### PR DESCRIPTION
## What

Use elc extension on hypb-org in `ELC_COMPILE` macro

## Why

Wrong extension makes `make clean` remove `hypb-org.el`