### PR TITLE
Use ibtypes tests for action key test

### DIFF
--- a/Changes
+++ b/Changes
@@ -20,10 +20,6 @@
 
 * test/hibtypes-tests.el (ibtypes::pathname-with-dash-loads-file-test):
     Bug fixed - Removed  expected failed.
-  test/hbut-tests.el (hbut-pathname-with-dash-loads-file-test): Remove
-    expected fail and added check for file loading
-    
-    Remove expected fail and added check for file loading
 * test/hbut-tests.el (hbut-pathname-with-dash-loads-file-test): Remove
     expected fail and added check for file loading
 

--- a/Changes
+++ b/Changes
@@ -20,9 +20,9 @@
 
 * test/hibtypes-tests.el (ibtypes::pathname-with-dash-loads-file-test):
     Bug fixed - Removed  expected failed.
-    (hbut-pathname-with-dash-loads-file-test): Bug fixed - Removed
-    expected failed.
-
+  test/hbut-tests.el (hbut-pathname-with-dash-loads-file-test): Remove
+    expected fail and added check for file loading
+    
 * test/hbut-tests.el (hbut-mail-address-test, hbut-pathname-test)
     (hbut-pathname-lisp-variable-test, hbut-pathname-env-variable-test)
     (hbut-pathname-emacs-lisp-file-test, hbut-pathname-anchor-test)

--- a/Changes
+++ b/Changes
@@ -1,25 +1,8 @@
 2021-04-18  Mats Lidell  <matsl@gnu.org>
 
-* test/hibtypes-tests.el (ibtypes::pathname-path-variable-test): Ert test
-    for path variables.
-
-* test/hpath-tests.el (hpath:path-at-point-in-path-variable-test)
-    (hpath:path-at-point-in-path-variable-shorter-than-three-colons-returns-nil-test):
-    Ert test for path variables.
-
-* test/hbut-tests.el (hub-mail-address-test, hub-pathname-test)
-    (hub-pathname-lisp-variable-test, hub-pathname-env-variable-test)
-    (hub-pathname-emacs-lisp-file-test, hub-pathname-anchor-test)
-    (hub-pathname-anchor-line-test, hub-pathname-line-column-test)
-    (hub-pathname-load-path-line-column-test)
-    (hub-pathname-with-dash-loads-file-test, hub-pathname-directory-test)
-    (hub-pathname-dot-slash-in-other-folder-should-fail-test)
-    (hub-annot-bib-test, hub-ctags-vgrind-test, ibtypes::etags-test)
-    (hub-text-toc-test, hub-dir-summary-test, hub-rfc-test)
-    (hub-man-apropos-test, hub-info-node-test): ibtypes test cases
-
 * test/hibtypes-tests.el (ibtypes::pathname-with-dash-loads-file-test):
     Bug fixed - Removed  expected failed.
+
 * test/hbut-tests.el (hbut-pathname-with-dash-loads-file-test): Remove
     expected fail and added check for file loading
 
@@ -34,6 +17,13 @@
     (hbut-text-toc-test, hbut-dir-summary-test, hbut-rfc-test)
     (hbut-man-apropos-test, hbut-info-node-test): ibtypes test cases
     converted to use action-key
+
+* test/hibtypes-tests.el (ibtypes::pathname-path-variable-test): Ert test
+    for path variables.
+
+* test/hpath-tests.el (hpath:path-at-point-in-path-variable-test)
+    (hpath:path-at-point-in-path-variable-shorter-than-three-colons-returns-nil-test):
+    Ert test for path variables.
 
 * test/hbut-tests.el (hbut-pathname-path-variable-test)
     (hbut-pathname-path-variable-with-two-colons-is-one-file-test)

--- a/Changes
+++ b/Changes
@@ -20,6 +20,8 @@
 
 * test/hibtypes-tests.el (ibtypes::pathname-with-dash-loads-file-test):
     Bug fixed - Removed  expected failed.
+    (hbut-pathname-with-dash-loads-file-test): Bug fixed - Removed
+    expected failed.
 
 * test/hbut-tests.el (hbut-mail-address-test, hbut-pathname-test)
     (hbut-pathname-lisp-variable-test, hbut-pathname-env-variable-test)
@@ -47,6 +49,8 @@
 * hpath.el (hpath:is-path-variable-p): Add to test if a string is a path-related variable.
            (hpath:choose-from-path-variable):
   hibtypes.el (pathname): Use this new function.
+
+* hibtypes.el (require 'hversion): Add this since added calls to  hyperb:* into this file.
 
 2021-04-17  Mats Lidell  <matsl@gnu.org>
 

--- a/Changes
+++ b/Changes
@@ -23,6 +23,10 @@
   test/hbut-tests.el (hbut-pathname-with-dash-loads-file-test): Remove
     expected fail and added check for file loading
     
+    Remove expected fail and added check for file loading
+* test/hbut-tests.el (hbut-pathname-with-dash-loads-file-test): Remove
+    expected fail and added check for file loading
+
 * test/hbut-tests.el (hbut-mail-address-test, hbut-pathname-test)
     (hbut-pathname-lisp-variable-test, hbut-pathname-env-variable-test)
     (hbut-pathname-emacs-lisp-file-test, hbut-pathname-anchor-test)

--- a/Changes
+++ b/Changes
@@ -29,6 +29,12 @@
 * test/hbut-tests.el (hbut-ib-url-with-label): Bug solved - removed
     expected failed.
 
+* test/hui-tests.el (hui-ibut-label-create)
+(hui-ibut-label-create-fails-if-label-exists): Test for hui.el
+
+* test/hbut-tests.el (hbut-ib-create-label)
+(hbut-ib-create-label-fails-if-label-exists): Moved to hui-tests.el
+
 2021-04-17  Bob Weiner  <rsw@gnu.org>
 
 * hpath.el (hpath:path-variable-regexp, hpath:choose-from-path-variable): Add.

--- a/Changes
+++ b/Changes
@@ -17,6 +17,20 @@
     (hub-annot-bib-test, hub-ctags-vgrind-test, ibtypes::etags-test)
     (hub-text-toc-test, hub-dir-summary-test, hub-rfc-test)
     (hub-man-apropos-test, hub-info-node-test): ibtypes test cases
+
+* test/hibtypes-tests.el (ibtypes::pathname-with-dash-loads-file-test):
+    Bug fixed - Removed  expected failed.
+
+* test/hbut-tests.el (hbut-mail-address-test, hbut-pathname-test)
+    (hbut-pathname-lisp-variable-test, hbut-pathname-env-variable-test)
+    (hbut-pathname-emacs-lisp-file-test, hbut-pathname-anchor-test)
+    (hbut-pathname-anchor-line-test, hbut-pathname-line-column-test)
+    (hbut-pathname-load-path-line-column-test)
+    (hbut-pathname-with-dash-loads-file-test, hbut-pathname-directory-test)
+    (hbut-pathname-dot-slash-in-other-folder-should-fail-test)
+    (hbut-annot-bib-test, hbut-ctags-vgrind-test, ibtypes::etags-test)
+    (hbut-text-toc-test, hbut-dir-summary-test, hbut-rfc-test)
+    (hbut-man-apropos-test, hbut-info-node-test): ibtypes test cases
     converted to use action-key
 
 * test/hbut-tests.el (hbut-pathname-path-variable-test)
@@ -33,8 +47,6 @@
 * hpath.el (hpath:is-path-variable-p): Add to test if a string is a path-related variable.
            (hpath:choose-from-path-variable):
   hibtypes.el (pathname): Use this new function.
-
-* hibtypes.el (require 'hversion): Add this since added calls to  hyperb:* into this file.
 
 2021-04-17  Mats Lidell  <matsl@gnu.org>
 

--- a/Changes
+++ b/Changes
@@ -1,17 +1,29 @@
 2021-04-18  Mats Lidell  <matsl@gnu.org>
 
-* test/hbut-tests.el (hbut-pathname-path-variable-test)
-    (hbut-pathname-path-variable-with-two-colons-is-one-file-test)
-    (hbut-pathname-path-variable-with-three-colons-is-a-path-test)
-    (hbut-pathname-path-variable-with-short-first-elemet-is-tramp-url-test):
-    Test for path variables.
-
 * test/hibtypes-tests.el (ibtypes::pathname-path-variable-test): Ert test
     for path variables.
 
 * test/hpath-tests.el (hpath:path-at-point-in-path-variable-test)
     (hpath:path-at-point-in-path-variable-shorter-than-three-colons-returns-nil-test):
     Ert test for path variables.
+
+* test/hbut-tests.el (hub-mail-address-test, hub-pathname-test)
+    (hub-pathname-lisp-variable-test, hub-pathname-env-variable-test)
+    (hub-pathname-emacs-lisp-file-test, hub-pathname-anchor-test)
+    (hub-pathname-anchor-line-test, hub-pathname-line-column-test)
+    (hub-pathname-load-path-line-column-test)
+    (hub-pathname-with-dash-loads-file-test, hub-pathname-directory-test)
+    (hub-pathname-dot-slash-in-other-folder-should-fail-test)
+    (hub-annot-bib-test, hub-ctags-vgrind-test, ibtypes::etags-test)
+    (hub-text-toc-test, hub-dir-summary-test, hub-rfc-test)
+    (hub-man-apropos-test, hub-info-node-test): ibtypes test cases
+    converted to use action-key
+
+* test/hbut-tests.el (hbut-pathname-path-variable-test)
+    (hbut-pathname-path-variable-with-two-colons-is-one-file-test)
+    (hbut-pathname-path-variable-with-three-colons-is-a-path-test)
+    (hbut-pathname-path-variable-with-short-first-elemet-is-tramp-url-test):
+    Test for path variables.
 
 * Makefile (ELC_KOTL): Add kotl/kprop-em.elc
     (ELC_COMPILE): Remove kprop-em.elc

--- a/test/demo-tests.el
+++ b/test/demo-tests.el
@@ -239,7 +239,8 @@
 
 ;; org
 (ert-deftest demo-org-hide-header-test ()
-  "Should work with action-key but does not. Works with org modes hide function."
+  "Hide org mode header.
+Bug: Should work with action-key but does not.  Works with org modes hide function."
   :expected-result :failed
   (with-temp-buffer
     (org-mode)

--- a/test/demo-tests.el
+++ b/test/demo-tests.el
@@ -240,7 +240,7 @@
 ;; org
 (ert-deftest demo-org-hide-header-test ()
   "Hide org mode header.
-Bug: Should work with action-key but does not.  Works with org modes hide function."
+Bug: Should work with action-key but does not.  Works with org mode's hide function."
   :expected-result :failed
   (with-temp-buffer
     (org-mode)

--- a/test/hbut-tests.el
+++ b/test/hbut-tests.el
@@ -323,13 +323,13 @@ Bug: With line spec looks in the wrong folder for the file?"
     (kill-buffer "hypb.el")))
 
 (ert-deftest hbut-pathname-with-dash-loads-file-test ()
-  "Pathname with dash loads file.
-Bug: Fails with 'Invalid function: hact'."
-  :expected-result :failed
+  "Pathname with dash loads file."
   (with-temp-buffer
     (insert "\"-${hyperb:dir}/test/hy-test-dependencies.el\"")
     (goto-char 2)
-    (action-key)))
+    (action-key)
+    (hy-test-helpers:should-last-message "Loading")
+    (hy-test-helpers:should-last-message "hy-test-dependencies.el")))
 
 (ert-deftest hbut-pathname-directory-test ()
   "Pathname with directory opens dired."

--- a/test/hbut-tests.el
+++ b/test/hbut-tests.el
@@ -11,12 +11,13 @@
 
 ;;; Commentary:
 
-;; Runs unit tests on some of the examples given in the DEMO file.
+;; Runs tests that are based on using the action-key.
 
 ;;; Code:
 
 (require 'ert)
 (require 'hbut)
+(require 'el-mock)
 
 (load (expand-file-name "hy-test-helpers"
                         (file-name-directory (or load-file-name
@@ -165,7 +166,7 @@ the button text"
                       (hy-test-helpers:action-key-should-call-hpath:find (expand-file-name "DEMO" hyperb:dir))))))
 
 (ert-deftest hbut-ib-url-with-label ()
-  "Find link using label"
+  "Find link using label."
   (with-temp-buffer
     (insert "<[PR34]>: \"https://github.com/rswgnu/hyperbole/pull/34\"")
     (goto-char 4)
@@ -221,6 +222,248 @@ the button text"
     (insert "\"/var:/bar:/tmp:/foo\"")
     (goto-char 14)
     (hy-test-helpers:action-key-should-call-hpath:find "/anonymous@var:/bar")))
+
+;; Mail address
+(ert-deftest hub-mail-address-test ()
+  "Open mail from mail address."
+  (unwind-protect
+      (with-temp-buffer
+        (insert "receiver@mail.org")
+        (goto-char 2)
+        (action-key)
+        (should (string= "*mail*" (buffer-name))))
+    (kill-buffer "*mail*")))
+
+;; Path name
+(ert-deftest hub-pathname-test ()
+  (unwind-protect
+      (with-temp-buffer
+        (insert (format "\"%s\"" (expand-file-name "DEMO" hyperb:dir)))
+        (goto-char 2)
+        (action-key)
+        (should (string= "DEMO" (buffer-name))))
+    (kill-buffer "DEMO")))
+
+(ert-deftest hub-pathname-lisp-variable-test ()
+  (unwind-protect
+      (with-temp-buffer
+        (insert "\"${hyperb:dir}/DEMO\"")
+        (goto-char 2)
+        (action-key)
+        (should (string= "DEMO" (buffer-name))))
+    (kill-buffer "DEMO")))
+
+(ert-deftest hub-pathname-env-variable-test ()
+  (unwind-protect
+      (with-temp-buffer
+        (insert "\"${HOME}\"")
+        (goto-char 2)
+        (action-key)
+        (should (equal major-mode 'dired-mode))
+        (should (= 0 (string-match (getenv "HOME") (file-truename default-directory)))))
+    nil))
+
+(ert-deftest hub-pathname-emacs-lisp-file-test ()
+  (unwind-protect
+      (with-temp-buffer
+        (insert "\"hyperbole.el\"")
+        (goto-char 2)
+        (action-key)
+        (should (equal major-mode 'emacs-lisp-mode))
+        (should (string= "hyperbole.el" (buffer-name)))))
+  (kill-buffer "hyperbole.el"))
+
+(ert-deftest hub-pathname-anchor-test ()
+  "Pathname with anchor."
+  (unwind-protect
+      (with-temp-buffer
+        (insert "\"${hyperb:dir}/DEMO#Smart Keys\"")
+        (goto-char 2)
+        (action-key)
+        (should (string= "DEMO" (buffer-name)))
+        (should (looking-at "\* Smart Keys")))
+    (kill-buffer "DEMO")))
+
+(ert-deftest hub-pathname-anchor-line-test ()
+  "Pathname with anchor and line specification.
+Bug: With line spec looks in the wrong folder for the file?"
+  :expected-result :failed
+  (unwind-protect
+      (with-temp-buffer
+        (insert "\"${hyperb:dir}/DEMO#Smart Keys:2\"")
+        (goto-char 2)
+        (action-key)
+        (should (string= "DEMO" (buffer-name)))
+        (forward-line -2)
+        (should (looking-at "\* Smart Keys")))
+    (kill-buffer "DEMO")))
+
+(ert-deftest hub-pathname-line-column-test ()
+  "Pathname with line and position specification."
+  (unwind-protect
+      (with-temp-buffer
+        (insert "\"${hyperb:dir}/DEMO:3:45\"")
+        (goto-char 2)
+        (action-key)
+        (should (string= "DEMO" (buffer-name)))
+        (should (= (line-number-at-pos) 3))
+        (should (= (current-column) 45)))
+    (kill-buffer "DEMO")))
+
+(ert-deftest hub-pathname-load-path-line-column-test ()
+  "Pathname with line and position specification."
+  (unwind-protect
+      (with-temp-buffer
+        (insert "\"${load-path}/hypb.el:10:5\"")
+        (goto-char 2)
+        (action-key)
+        (should (string= "hypb.el" (buffer-name)))
+        (should (= (line-number-at-pos) 10))
+        (should (= (current-column) 5)))
+    (kill-buffer "hypb.el")))
+
+(ert-deftest hub-pathname-with-dash-loads-file-test ()
+  "Pathname with dash loads file.
+Bug: Fails with 'Invalid function: hact'."
+  :expected-result :failed
+  (with-temp-buffer
+    (insert "\"-${hyperb:dir}/test/hy-test-dependencies.el\"")
+    (goto-char 2)
+    (action-key)))
+
+(ert-deftest hub-pathname-directory-test ()
+  "Pathname with directory opens dired."
+  (unwind-protect
+      (with-temp-buffer
+        (insert "\"/tmp\"")
+        (goto-char 2)
+        (action-key)
+        (should (string= "tmp" (buffer-name)))
+        (should (eq major-mode 'dired-mode)))
+    (kill-buffer "tmp")))
+
+(ert-deftest hub-pathname-dot-slash-in-other-folder-should-fail-test ()
+  "Pathname that starts with ./ only works if in same folder."
+  (with-temp-buffer
+    (insert "\"./hypb.el\"")
+    (goto-char 2)
+    (let ((help-buffer "*Help: Hyperbole Action Key*")
+          (default-directory (expand-file-name "test" hyperb:dir)))
+      (condition-case err
+          (action-key)
+        (error
+         (progn
+           (should (equal (car err) 'error))
+           (should (string-search
+                    "(Hyperbole Action Key): No action defined for this context; try another location"
+                    (cadr err)))))))))
+
+;; hub-annot-bib
+(ert-deftest hub-annot-bib-test ()
+  (unwind-protect
+      (progn
+        (hypb:display-file-with-logo (expand-file-name "DEMO" hyperb:dir))
+        (re-search-forward "\\[FSF 19\\]")
+        (backward-char 1)
+        (action-key)
+        (should (looking-at "\\[FSF 19\\] Free Software Foundation"))
+        (forward-line -2)
+        (should (looking-at "\\* References")))
+    (kill-buffer "DEMO")))
+
+;; ctags
+; Seems ctags -v does not give the proper answer
+(ert-deftest hub-ctags-vgrind-test ()
+  (unwind-protect
+      (with-temp-buffer
+        (insert "hy-test-helpers:consume-input-events hy-test-helpers.el 21\n")
+        (goto-char (point-min))
+        (forward-char 4)
+        (let ((default-directory (expand-file-name "test" hyperb:dir)))
+          (action-key)
+          (set-buffer "hy-test-helpers.el")
+          (should (looking-at "(defun hy-test-helpers:consume-input-events"))))
+    (kill-buffer "hy-test-helpers.el")))
+
+;; etags
+(ert-deftest ibtypes::etags-test ()
+  (unwind-protect
+      (with-temp-buffer
+        (insert "\n")
+        (insert "hy-test-helpers.el,103\n")
+        (insert "(defun hy-test-helpers:consume-input-events 21,359\n")
+        (rename-buffer (concat "TAGS" (buffer-name)))
+        (goto-char (point-min))
+        (forward-line 2)
+        (forward-char 10)
+        (let ((default-directory (expand-file-name "test" hyperb:dir)))
+          (action-key)
+          (set-buffer "hy-test-helpers.el")
+          (should (looking-at "(defun hy-test-helpers:consume-input-events"))))
+    (kill-buffer "hy-test-helpers.el")))
+
+;; text-toc
+(ert-deftest hub-text-toc-test ()
+  (unwind-protect
+      (progn
+        (hypb:display-file-with-logo (expand-file-name "DEMO" hyperb:dir))
+        (goto-char (point-min))
+        (re-search-forward " \* Koutl")
+        (action-key)
+        (should (bolp))
+        (should (looking-at "^* Koutliner")))
+    (kill-buffer "DEMO")))
+
+;; dir-summary
+(ert-deftest hub-dir-summary-test ()
+  (unwind-protect
+      (progn
+        (find-file (expand-file-name "MANIFEST" hyperb:dir))
+        (goto-char (point-min))
+        (re-search-forward "HY-ABOUT")
+        (forward-char -2)
+        (let ((hpath:display-where 'this-window))
+          (action-key)
+          (should (string= "HY-ABOUT" (buffer-name)))))
+    (progn
+      (kill-buffer "MANIFEST")
+      (kill-buffer "HY-ABOUT"))))
+
+;; rfc
+(ert-deftest hub-rfc-test ()
+  (dolist (rfc '("RFC822" "RFC-822" "rfc 822"))
+    (with-temp-buffer
+      (insert rfc)
+      (goto-char 2)
+      (with-mock
+        (mock (actypes::link-to-rfc "822") => t)
+        (should (action-key))))))
+
+;; man-apropos
+(ert-deftest hub-man-apropos-test ()
+  (with-temp-buffer
+    (insert "rm (1)   - remove")
+    (goto-char 4)
+    (with-mock
+     (mock (man "rm(1)") => t)
+     (action-key))))
+
+;; info-node
+(ert-deftest hub-info-node-test ()
+  "Got to info node."
+  (unwind-protect
+      (with-temp-buffer
+        (insert "\"(emacs)top\"")
+        (goto-char 6)
+        (action-key)
+        (should (string= "*info*" (buffer-name))))
+    (kill-buffer "*info*")))
+
+;; This file can't be byte-compiled without the `el-mock' package (because of
+;; the use of the `with-mock' macro), which is not a dependency of Hyperbole.
+;;  Local Variables:
+;;  no-byte-compile: t
+;;  End:
 
 (provide 'hbut-tests)
 ;;; hbut-tests.el ends here

--- a/test/hbut-tests.el
+++ b/test/hbut-tests.el
@@ -223,7 +223,7 @@
     (hy-test-helpers:action-key-should-call-hpath:find "/anonymous@var:/bar")))
 
 ;; Mail address
-(ert-deftest hub-mail-address-test ()
+(ert-deftest hbut-mail-address-test ()
   "Open mail from mail address."
   (unwind-protect
       (with-temp-buffer
@@ -234,7 +234,7 @@
     (kill-buffer "*mail*")))
 
 ;; Path name
-(ert-deftest hub-pathname-test ()
+(ert-deftest hbut-pathname-test ()
   (unwind-protect
       (with-temp-buffer
         (insert (format "\"%s\"" (expand-file-name "DEMO" hyperb:dir)))
@@ -243,7 +243,7 @@
         (should (string= "DEMO" (buffer-name))))
     (kill-buffer "DEMO")))
 
-(ert-deftest hub-pathname-lisp-variable-test ()
+(ert-deftest hbut-pathname-lisp-variable-test ()
   (unwind-protect
       (with-temp-buffer
         (insert "\"${hyperb:dir}/DEMO\"")
@@ -252,7 +252,7 @@
         (should (string= "DEMO" (buffer-name))))
     (kill-buffer "DEMO")))
 
-(ert-deftest hub-pathname-env-variable-test ()
+(ert-deftest hbut-pathname-env-variable-test ()
   (unwind-protect
       (with-temp-buffer
         (insert "\"${HOME}\"")
@@ -262,17 +262,18 @@
         (should (= 0 (string-match (getenv "HOME") (file-truename default-directory)))))
     nil))
 
-(ert-deftest hub-pathname-emacs-lisp-file-test ()
+(ert-deftest hbut-pathname-emacs-lisp-file-test ()
   (unwind-protect
       (with-temp-buffer
         (insert "\"hyperbole.el\"")
         (goto-char 2)
         (action-key)
         (should (equal major-mode 'emacs-lisp-mode))
+        (should (buffer-file-name))
         (should (string= "hyperbole.el" (buffer-name)))))
   (kill-buffer "hyperbole.el"))
 
-(ert-deftest hub-pathname-anchor-test ()
+(ert-deftest hbut-pathname-anchor-test ()
   "Pathname with anchor."
   (unwind-protect
       (with-temp-buffer
@@ -283,7 +284,7 @@
         (should (looking-at "\* Smart Keys")))
     (kill-buffer "DEMO")))
 
-(ert-deftest hub-pathname-anchor-line-test ()
+(ert-deftest hbut-pathname-anchor-line-test ()
   "Pathname with anchor and line specification.
 Bug: With line spec looks in the wrong folder for the file?"
   :expected-result :failed
@@ -297,7 +298,7 @@ Bug: With line spec looks in the wrong folder for the file?"
         (should (looking-at "\* Smart Keys")))
     (kill-buffer "DEMO")))
 
-(ert-deftest hub-pathname-line-column-test ()
+(ert-deftest hbut-pathname-line-column-test ()
   "Pathname with line and position specification."
   (unwind-protect
       (with-temp-buffer
@@ -309,8 +310,8 @@ Bug: With line spec looks in the wrong folder for the file?"
         (should (= (current-column) 45)))
     (kill-buffer "DEMO")))
 
-(ert-deftest hub-pathname-load-path-line-column-test ()
-  "Pathname with line and position specification."
+(ert-deftest hbut-pathname-load-path-line-column-test ()
+  "Pathname with `load-path', line and position specification."
   (unwind-protect
       (with-temp-buffer
         (insert "\"${load-path}/hypb.el:10:5\"")
@@ -321,16 +322,14 @@ Bug: With line spec looks in the wrong folder for the file?"
         (should (= (current-column) 5)))
     (kill-buffer "hypb.el")))
 
-(ert-deftest hub-pathname-with-dash-loads-file-test ()
-  "Pathname with dash loads file.
-Bug: Fails with 'Invalid function: hact'."
-  :expected-result :failed
+(ert-deftest hbut-pathname-with-dash-loads-file-test ()
+  "Pathname with dash loads file."
   (with-temp-buffer
     (insert "\"-${hyperb:dir}/test/hy-test-dependencies.el\"")
     (goto-char 2)
     (action-key)))
 
-(ert-deftest hub-pathname-directory-test ()
+(ert-deftest hbut-pathname-directory-test ()
   "Pathname with directory opens dired."
   (unwind-protect
       (with-temp-buffer
@@ -341,7 +340,7 @@ Bug: Fails with 'Invalid function: hact'."
         (should (eq major-mode 'dired-mode)))
     (kill-buffer "tmp")))
 
-(ert-deftest hub-pathname-dot-slash-in-other-folder-should-fail-test ()
+(ert-deftest hbut-pathname-dot-slash-in-other-folder-should-fail-test ()
   "Pathname that starts with ./ only works if in same folder."
   (with-temp-buffer
     (insert "\"./hypb.el\"")
@@ -357,8 +356,8 @@ Bug: Fails with 'Invalid function: hact'."
                     "(Hyperbole Action Key): No action defined for this context; try another location"
                     (cadr err)))))))))
 
-;; hub-annot-bib
-(ert-deftest hub-annot-bib-test ()
+;; hbut-annot-bib
+(ert-deftest hbut-annot-bib-test ()
   (unwind-protect
       (progn
         (hypb:display-file-with-logo (expand-file-name "DEMO" hyperb:dir))
@@ -372,7 +371,7 @@ Bug: Fails with 'Invalid function: hact'."
 
 ;; ctags
 ; Seems ctags -v does not give the proper answer
-(ert-deftest hub-ctags-vgrind-test ()
+(ert-deftest hbut-ctags-vgrind-test ()
   (unwind-protect
       (with-temp-buffer
         (insert "hy-test-helpers:consume-input-events hy-test-helpers.el 21\n")
@@ -402,7 +401,7 @@ Bug: Fails with 'Invalid function: hact'."
     (kill-buffer "hy-test-helpers.el")))
 
 ;; text-toc
-(ert-deftest hub-text-toc-test ()
+(ert-deftest hbut-text-toc-test ()
   (unwind-protect
       (progn
         (hypb:display-file-with-logo (expand-file-name "DEMO" hyperb:dir))
@@ -414,7 +413,7 @@ Bug: Fails with 'Invalid function: hact'."
     (kill-buffer "DEMO")))
 
 ;; dir-summary
-(ert-deftest hub-dir-summary-test ()
+(ert-deftest hbut-dir-summary-test ()
   (unwind-protect
       (progn
         (find-file (expand-file-name "MANIFEST" hyperb:dir))
@@ -429,7 +428,7 @@ Bug: Fails with 'Invalid function: hact'."
       (kill-buffer "HY-ABOUT"))))
 
 ;; rfc
-(ert-deftest hub-rfc-test ()
+(ert-deftest hbut-rfc-test ()
   (dolist (rfc '("RFC822" "RFC-822" "rfc 822"))
     (with-temp-buffer
       (insert rfc)
@@ -439,7 +438,7 @@ Bug: Fails with 'Invalid function: hact'."
         (should (action-key))))))
 
 ;; man-apropos
-(ert-deftest hub-man-apropos-test ()
+(ert-deftest hbut-man-apropos-test ()
   (with-temp-buffer
     (insert "rm (1)   - remove")
     (goto-char 4)
@@ -448,7 +447,7 @@ Bug: Fails with 'Invalid function: hact'."
      (action-key))))
 
 ;; info-node
-(ert-deftest hub-info-node-test ()
+(ert-deftest hbut-info-node-test ()
   "Got to info node."
   (unwind-protect
       (with-temp-buffer

--- a/test/hbut-tests.el
+++ b/test/hbut-tests.el
@@ -323,7 +323,9 @@ Bug: With line spec looks in the wrong folder for the file?"
     (kill-buffer "hypb.el")))
 
 (ert-deftest hbut-pathname-with-dash-loads-file-test ()
-  "Pathname with dash loads file."
+  "Pathname with dash loads file.
+Bug: Fails with 'Invalid function: hact'."
+  :expected-result :failed
   (with-temp-buffer
     (insert "\"-${hyperb:dir}/test/hy-test-dependencies.el\"")
     (goto-char 2)

--- a/test/hbut-tests.el
+++ b/test/hbut-tests.el
@@ -52,7 +52,7 @@
     (ibtype:delete 'ibtypes::defal-url)))
 
 (ert-deftest hbut-defal-url-%s ()
-  "defal supports %s in LINK-EXPR."
+  "Use defal with %s in LINK-EXPR."
   (defal defal-url "https://github.com/rswgnu/hyperbole/pull/%s")
   (unwind-protect
       (with-temp-buffer
@@ -80,8 +80,7 @@
   (should (string= x "test")))
 
 (ert-deftest hbut-defal-function ()
-  "defal call function should only supply the argument portion of
-the button text"
+  "Use only the argument portion of the button text."
   (defal defal-func 'hbut-verify-defal)
   (unwind-protect
       (with-temp-buffer

--- a/test/hibtypes-tests.el
+++ b/test/hibtypes-tests.el
@@ -137,13 +137,13 @@
     (kill-buffer "hypb.el")))
 
 (ert-deftest ibtypes::pathname-with-dash-loads-file-test ()
-  "Pathname with dash loads file.
-Bug: Fails with 'Invalid function: hact'."
-  :expected-result :failed
+  "Pathname with dash loads file."
   (with-temp-buffer
     (insert "\"-${hyperb:dir}/test/hy-test-dependencies.el\"")
     (goto-char 2)
-    (ibtypes::pathname)))
+    (ibtypes::pathname)
+    (hy-test-helpers:should-last-message "Loading")
+    (hy-test-helpers:should-last-message "hy-test-dependencies.el")))
 
 (ert-deftest ibtypes::pathname-directory-test ()
   "Pathname with directory opens dired."

--- a/test/hibtypes-tests.el
+++ b/test/hibtypes-tests.el
@@ -137,7 +137,9 @@
     (kill-buffer "hypb.el")))
 
 (ert-deftest ibtypes::pathname-with-dash-loads-file-test ()
-  "Pathname with dash loads file."
+  "Pathname with dash loads file.
+Bug: Fails with 'Invalid function: hact'."
+  :expected-result :failed
   (with-temp-buffer
     (insert "\"-${hyperb:dir}/test/hy-test-dependencies.el\"")
     (goto-char 2)

--- a/test/hibtypes-tests.el
+++ b/test/hibtypes-tests.el
@@ -324,7 +324,7 @@ Bug: Fails with 'Invalid function: hact'."
 
 ;; info-node
 (ert-deftest ibtypes::info-node-test ()
-  "Should work with ibtypes::pathname but does not. Works with action-key!?"
+  "Go to info node."
   (unwind-protect
       (with-temp-buffer
         (insert "\"(emacs)top\"")

--- a/test/hibtypes-tests.el
+++ b/test/hibtypes-tests.el
@@ -137,9 +137,7 @@
     (kill-buffer "hypb.el")))
 
 (ert-deftest ibtypes::pathname-with-dash-loads-file-test ()
-  "Pathname with dash loads file.
-Bug: Fails with 'Invalid function: hact'."
-  :expected-result :failed
+  "Pathname with dash loads file."
   (with-temp-buffer
     (insert "\"-${hyperb:dir}/test/hy-test-dependencies.el\"")
     (goto-char 2)

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -1,0 +1,44 @@
+;;; hui-tests.el --- Tests for hui.el                -*- lexical-binding: t; -*-
+;;
+;; Author: Mats Lidell <matsl@gnu.org>
+;;
+;; Orig-Date: 30-Jan-21 at 12:00:00
+;;
+;; Copyright (C) 2021  Free Software Foundation, Inc.
+;; See the "HY-COPY" file for license information.
+;;
+;; This file is part of GNU Hyperbole.
+
+;;; Commentary:
+;;
+;; Tests for "../hui.el"
+
+;;; Code:
+
+(require 'ert)
+(require 'with-simulated-input)
+
+(ert-deftest hui-ibut-label-create ()
+  "Create a label for an implicit button."
+  (with-temp-buffer
+    (insert "\"/tmp\"\n")
+    (goto-char 3)
+    (with-simulated-input "TMP RET"
+      (hui:ibut-label-create)
+      (should (string= "<[TMP]> \"/tmp\"\n" (buffer-string))))))
+
+(ert-deftest hui-ibut-label-create-fails-if-label-exists ()
+  "Creation of a label for an implicit button fails if a label exists."
+  (with-temp-buffer
+    (insert "<[LBL]>: \"/tmp\"\n")
+    (goto-char 14)
+    (with-simulated-input "TMP RET"
+      (condition-case err
+          (hui:ibut-label-create)
+        (error
+         (progn
+           (should (equal (car err) 'error))
+           (should (string-search "ibutton at point already has a label" (cadr err)))))))))
+
+(provide 'hui-tests)
+;;; hui-tests.el ends here


### PR DESCRIPTION
## What

- Used ibtypes test with action-key instead to check that proper ibtype is used.
- Moved hui tests to own file
- Some doc string updates