### PR TITLE
Add kprop-em.elc to ELC_KOTL and remove from ELC_COMPILE

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+2021-04-18  Mats Lidell  <matsl@gnu.org>
+
+* Makefile (ELC_KOTL): Add kotl/kprop-em.elc
+    (ELC_COMPILE): Remove kprop-em.elc
+
 2021-04-18  Bob Weiner  <rsw@gnu.org>
 
 * hpath.el (hpath:is-path-variable-p): Add to test if a string is a path-related variable.

--- a/Makefile
+++ b/Makefile
@@ -175,11 +175,11 @@ ELC_COMPILE =  hactypes.elc hibtypes.elc hib-debbugs.elc hib-doc-id.elc hib-kbd.
 	     hycontrol.elc hui-jmenu.elc hui-menu.elc hui-mini.elc hui-mouse.elc hui-select.elc \
 	     hui-treemacs.elc hui-window.elc hui.elc hvar.elc hversion.elc hvm.elc hypb.elc hyperbole.elc \
 	     hyrolo-demo.elc hyrolo-logic.elc hyrolo-menu.elc hyrolo.elc hywconfig.elc \
-	     set.elc kprop-em.elc hypb-ert.elc
+	     set.elc hypb-ert.elc
 
 ELC_KOTL = kotl/kexport.elc kotl/kfile.elc kotl/kfill.elc kotl/kimport.elc kotl/klabel.elc \
 	   kotl/klink.elc kotl/kmenu.elc kotl/knode.elc kotl/kotl-mode.elc kotl/kotl-orgtbl.elc \
-           kotl/kcell.elc kotl/kproperty.elc \
+           kotl/kcell.elc kotl/kproperty.elc kotl/kprop-em.elc \
            kotl/kview.elc kotl/kvspec.elc
 
 HY-TALK  = HY-TALK/.hypb HY-TALK/HYPB HY-TALK/HY-TALK.org


### PR DESCRIPTION
## What

Noticed that `kprop-em.elc` was in the wrong make macro so `make clean` did not remove the elc files.