### PR TITLE
Break recursive dependency between hpath and hact

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+2021-04-19  Mats Lidell  <matsl@gnu.org>
+
+* hpath.el (hact): Add dependency on hact
+* hact.el (mapc): Remove dependency on hpath
+
 2021-04-18  Mats Lidell  <matsl@gnu.org>
 
 * test/hibtypes-tests.el (ibtypes::pathname-with-dash-loads-file-test):

--- a/hact.el
+++ b/hact.el
@@ -16,7 +16,7 @@
 ;;; Other required Elisp libraries
 ;;; ************************************************************************
 
-(eval-and-compile (mapc #'require '(hhist hpath set)))
+(eval-and-compile (mapc #'require '(hhist set)))
 
 ;;; ************************************************************************
 ;;; Public variables

--- a/hpath.el
+++ b/hpath.el
@@ -16,6 +16,7 @@
 ;;; Other required Elisp libraries
 ;;; ************************************************************************
 
+(require 'hact)
 (require 'subr-x) ;; For string-trim
 (require 'hversion) ;; for (hyperb:window-system) definition
 (require 'hui-select) ;; for `hui-select-markup-modes'


### PR DESCRIPTION
## What

Break recursive dependency between `hpath` and `hact`

## Why

This seems to fix the native compilation issue. 

`hact.el` still has a dependency on `hpath.el`. There is one function from hpath that is used in hact. So don't know if this the final say or just a hint want seems to work and what is broken.

From a dependency point of view it looks strange to have this type of circular dependency. But don't know if there is some Emacs lisp voodoo that can be applied or if the modules should be arranged differently. Happy to learn how to  deal with this.