### PR TITLE
Compatibility changes for tests with Emacs 27.1

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,14 @@
+2021-04-27  Mats Lidell  <matsl@gnu.org>
+
+* test/hypb-tests.el (hypb:replace-match-string-after-27.1-test): Use
+    separate test for replace matches that were fixed after Emacs 27.1.
+
+* test/hui-tests.el (hui-ibut-label-create-fails-if-label-exists): Use
+    string-match.
+
+* test/hbut-tests.el (hbut-ib-create-label-fails-if-label-exists)
+(hbut-pathname-dot-slash-in-other-folder-should-fail-test): Use string-match.
+
 2021-04-26  Bob Weiner  <rsw@gnu.org>
 
 * hui.el (hui:global-bind-key): Renamed from hui:bind-key and made that

--- a/test/hbut-tests.el
+++ b/test/hbut-tests.el
@@ -192,7 +192,7 @@
         (error
          (progn
            (should (equal (car err) 'error))
-           (should (string-search "ibutton at point already has a label" (cadr err)))))))))
+           (should (string-match "ibutton at point already has a label" (cadr err)))))))))
 
 (ert-deftest hbut-pathname-path-variable-test ()
   "Find file in path variable value."
@@ -352,7 +352,7 @@
         (error
          (progn
            (should (equal (car err) 'error))
-           (should (string-search
+           (should (string-match
                     "(Hyperbole Action Key): No action defined for this context; try another location"
                     (cadr err)))))))))
 

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -38,7 +38,7 @@
         (error
          (progn
            (should (equal (car err) 'error))
-           (should (string-search "ibutton at point already has a label" (cadr err)))))))))
+           (should (string-match "ibutton at point already has a label" (cadr err)))))))))
 
 (provide 'hui-tests)
 ;;; hui-tests.el ends here

--- a/test/hypb-tests.el
+++ b/test/hypb-tests.el
@@ -79,8 +79,11 @@
                             s
                             (match-beginning 0) (match-end 0)
                             (match-beginning 1) (match-end 1))))
-                 "b<abbc,0,4,1,3>a<ac,0,2,1,1><abc,0,3,1,2>"))
+                 "b<abbc,0,4,1,3>a<ac,0,2,1,1><abc,0,3,1,2>")))
+
+(ert-deftest hypb:replace-match-string-after-27.1-test ()
   ;; anchors (bug#15107, bug#44861)
+  (skip-unless (version< "27.1" emacs-version))
   (should (equal (hypb:replace-match-string "a\\B" "a aaaa" "b")
                  "a bbba"))
   (should (equal (hypb:replace-match-string "\\`\\|x" "--xx--" "z")


### PR DESCRIPTION
## What

Some compatibility fixes for Emacs 27.1.

Unfortunately not complete. There are still tests failing under 27.1.