### PR TITLE
Update face code

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2021-05-02  Mats Lidell  <matsl@gnu.org>
+
+* hui-em-but.el (hbut-face): Add face for hbuts.
+    (hproperty:but-face): Use face for property.
+    (hbut-item-face): Add face for hbut items.
+    (hproperty:item-face): Use face for property.
+
 2021-05-02  Bob Weiner  <rsw@gnu.org>
 
 * kotl/kotl-mode.el (kotl-mode:kill-whole-line): Add override

--- a/hui-em-but.el
+++ b/hui-em-but.el
@@ -76,17 +76,10 @@
   :group 'hyperbole-buttons)
 
 (defface hbut-face
-  '((((class color) (min-colors 88) (background light))
-     :background "lightblue")
-    (((class color) (min-colors 88) (background dark))
-     :background "lightblue")
-    (((class color) (min-colors 16) (background light))
-     :background "lightblue")
-    (((class color) (in-colors 16) (background dark))
-     :background "lighblue")
-    (((class color) (min-colors 8))
-     :background "lightblue" :foreground "black")
-    (t :inverse-video t))
+  '((((min-colors 88) (background dark)) (:foreground "salmon1"))
+    (((background dark)) (:background "red" :foreground "black"))
+    (((min-colors 88)) (:foreground "salmon4"))
+    (t (:background "red")))
   "Face for hyperbole buttons."
   :group 'hyperbole-buttons)
 

--- a/hui-em-but.el
+++ b/hui-em-but.el
@@ -75,6 +75,48 @@
   :initialize #'custom-initialize-default
   :group 'hyperbole-buttons)
 
+(defface hbut-face
+  '((((class color) (min-colors 88) (background light))
+     :background "lightblue")
+    (((class color) (min-colors 88) (background dark))
+     :background "lightblue")
+    (((class color) (min-colors 16) (background light))
+     :background "lightblue")
+    (((class color) (in-colors 16) (background dark))
+     :background "lighblue")
+    (((class color) (min-colors 8))
+     :background "lightblue" :foreground "black")
+    (t :inverse-video t))
+  "Face for hyperbole buttons."
+  :group 'hyperbole-buttons)
+
+(defcustom hproperty:but-face 'hbut-face
+  "Hyperbole face for hyper-buttons."
+  :type 'face
+  :initialize #'custom-initialize-default
+  :group 'hyperbole-buttons)
+
+(defface hbut-item-face
+  '((((class color) (min-colors 88) (background light))
+     :background "yellow")
+    (((class color) (min-colors 88) (background dark))
+     :background "yellow")
+    (((class color) (min-colors 16) (background light))
+     :background "yellow")
+    (((class color) (in-colors 16) (background dark))
+     :background "yellow")
+    (((class color) (min-colors 8))
+     :background "yellow" :foreground "black")
+    (t :inverse-video t))
+  "Face for hyperbole buttons."
+  :group 'hyperbole-buttons)
+
+(defcustom hproperty:item-face 'hbut-item-face
+  "Hyperbole face for hyper-buttons."
+  :type 'face
+  :initialize #'custom-initialize-default
+  :group 'hyperbole-buttons)
+
 ;;; ************************************************************************
 ;;; Public functions
 ;;; ************************************************************************
@@ -249,17 +291,11 @@ highlighted."
 ;;; Private variables
 ;;; ************************************************************************
 
-(defvar hproperty:but-face
-  (progn (defface hbut nil "Hyperbole hyper-button face."
-	   :group 'hyperbole-buttons)
-	 'hbut)
-  "Hyperbole hyper-button face.")
 (setq hproperty:but hproperty:but-face)
 
 (defvar hproperty:item-button nil
   "Button used to highlight an item in a listing buffer.")
 (make-variable-buffer-local 'hproperty:item-button)
-(defvar hproperty:item-face nil "Item marking face.")
 
 (provide 'hui-em-but)
 

--- a/hui-em-but.el
+++ b/hui-em-but.el
@@ -55,7 +55,7 @@
      :background "red3")
     (((class color) (min-colors 16) (background light))
      :background "red3")
-    (((class color) (in-colors 16) (background dark))
+    (((class color) (min-colors 16) (background dark))
      :background "red3")
     (((class color) (min-colors 8))
      :background "red3" :foreground "black")


### PR DESCRIPTION
## What

Use customize defface for highlighting ebuts. Some small tweaks to make it work for light and dark background (But could spend a lot more time on that since there are many moving parts there.)

Not sure a about the hypb-items highlighting since it looks (from a quick look) that the regular `highlight` face is used for that. Default for that is also `nil` so you have to toggle it and reload the file with ebuts to see highlighting. Should we change the default to t or is it to colorish as default?

In short would need more time to go over this for it to feel good going out in the release but I think it will provide the basic functionality. 