### PR TITLE
Use write-file-functions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2021-05-12  Mats Lidell  <matsl@gnu.org>
+
+* kotl/kotl-mode.el (kotl-mode): Use write-file-functions
+
 2021-05-11  Mats Lidell  <matsl@gnu.org>
 
 * hmouse-tag.el (br-edit, br-edit-feature): Add external dependencies.

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -87,7 +87,7 @@ It provides the following keys:
   ;;
   ;; Ensure that outline structure data is saved when save-buffer is called
   ;; from save-some-buffers, {C-x s}.
-  (add-hook 'local-write-file-hooks #'kotl-mode:update-buffer)
+  (add-hook 'write-file-functions #'kotl-mode:update-buffer)
   (mapc #'make-local-variable
 	'(kotl-previous-mode indent-line-function indent-region-function
 			     outline-isearch-open-invisible-function


### PR DESCRIPTION
## What

Use `write-file-functions`

## Why

`local-write-file-hooks` is obsolete

## WIP

_This is work in progress. I noticed that there are more use of obsolete functions and that they might require some more work to get right so will pause this PR for now to get back to it later._