### PR TITLE
Typo in Makefile update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -337,10 +337,10 @@ ftp: package $(pkg_dir)/hyperbole-$(HYPB_VERSION).tar.gz
 autoloads: hyperbole-autoloads.el kotl/kotl-autoloads.el
 
 hyperbole-autoloads.el: $(EL_COMPILE)
-	$(EMACS) $(BATCHFLAGS) --debug n-eval "(progn (setq generated-autoload-file (expand-file-name \"hyperbole-autoloads.el\") backup-inhibited t) (make-directory-autoloads \".\"))"
+	$(EMACS) $(BATCHFLAGS) --debug --eval "(progn (setq generated-autoload-file (expand-file-name \"hyperbole-autoloads.el\") backup-inhibited t) (update-directory-autoloads \".\"))"
 
 kotl/kotl-autoloads.el: $(EL_KOTL)
-	$(EMACS) $(BATCHFLAGS) -eval "(progn (setq generated-autoload-file (expand-file-name \"kotl/kotl-autoloads.el\") backup-inhibited t) (update-directory-autoloads \"kotl/\"))"
+	$(EMACS) $(BATCHFLAGS) --eval "(progn (setq generated-autoload-file (expand-file-name \"kotl/kotl-autoloads.el\") backup-inhibited t) (update-directory-autoloads \"kotl/\"))"
 
 # Used for ftp.gnu.org tarball distributions.
 $(pkg_dir)/hyperbole-$(HYPB_VERSION).tar.gz:


### PR DESCRIPTION
Looks like there is an typo in latest commit to Makefile?  `make-directory-autoloads` looks like it takes two args so I had to revert back to use `update-directory-autoloads`.