### PR TITLE
Set hook to be local to kotl-mode

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2021-05-13  Mats Lidell  <matsl@gnu.org>
+
+* kotl/kotl-mode.el (kotl-mode): Set hook to be local to buffer.
+
 2021-05-12  Mats Lidell  <matsl@gnu.org>
 
 * kotl/kotl-mode.el (kotl-mode): Use write-file-functions

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -87,7 +87,7 @@ It provides the following keys:
   ;;
   ;; Ensure that outline structure data is saved when save-buffer is called
   ;; from save-some-buffers, {C-x s}.
-  (add-hook 'write-file-functions #'kotl-mode:update-buffer)
+  (add-hook 'write-file-functions #'kotl-mode:update-buffer nil 'local)
   (mapc #'make-local-variable
 	'(kotl-previous-mode indent-line-function indent-region-function
 			     outline-isearch-open-invisible-function


### PR DESCRIPTION
## What

Set hook to be local to kotl-mode.

## Why

This hook should only be used for kotl.mode. Stefan pointed out that my recent change would make it global which is not consistent with the old behavior.