### PR TITLE
Use cl functions

### DIFF
--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -3097,8 +3097,8 @@ Leave point at end of line now residing at START."
 	 ;; Make local-cmd have the same property list as cmd,
 	 ;; e.g. so pending-delete property is the same, but delete
 	 ;; interactive-only property to suppress byte-compiler warnings.
-	 (setplist local-cmd (copy-list (symbol-plist cmd)))
-	 (remprop local-cmd 'interactive-only)
+	 (setplist local-cmd (cl-copy-list (symbol-plist cmd)))
+	 (cl-remprop local-cmd 'interactive-only)
 	 (substitute-key-definition
 	  cmd local-cmd kotl-mode-map global-map)))
      '(


### PR DESCRIPTION
## What

Use the cl functions for copy-list and remprop

## Why

I can't see that copy-list and remprop is defined en emacs 27 nor emacs 28. I had to do this change in order to byte compile.