### PR TITLE
Remove XEmacs bytecode objects compatibility

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2021-05-16  Mats Lidell  <matsl@gnu.org>
+
+* hypb.el (hypb:function-copy): Remove XEmacs compatibility code for
+    bytecode objects.
+
 2021-05-16  Bob Weiner  <rsw@gnu.org>
 
 * hyperbole.el (hyperb:maybe-load-autoloads): Add and call from hyperb:init.

--- a/hypb.el
+++ b/hypb.el
@@ -289,21 +289,8 @@ Return either the modified string or the original ARG when not modified."
 	      ((subrp func) (error "(hypb:function-copy): `%s' is a primitive; can't copy body"
 				   func-symbol))
 	      ((and (hypb:emacs-byte-code-p func) (fboundp 'make-byte-code))
-	       (if (not (fboundp 'compiled-function-arglist))
-		   (let ((new-code (append func nil))) ; turn it into a list
-		     (apply 'make-byte-code new-code))
-		 ;; Can't reference bytecode objects as vectors in modern
-		 ;; XEmacs.
-		 (let ((new-code (nconc
-				  (list (compiled-function-arglist func)
-					(compiled-function-instructions func)
-					(compiled-function-constants func)
-					(compiled-function-stack-depth func)
-					(compiled-function-doc-string func))))
-		       spec)
-		   (when (setq spec (compiled-function-interactive func))
-		     (setq new-code (nconc new-code (list (nth 1 spec)))))
-		   (apply 'make-byte-code new-code))))
+	       (let ((new-code (append func nil))) ; turn it into a list
+		 (apply 'make-byte-code new-code)))
 	      (t (error "(hypb:function-copy): Can't copy function body: %s" func))))
     (error "(hypb:function-copy): `%s' symbol is not bound to a function"
 	   func-symbol)))


### PR DESCRIPTION
## What

Remove XEmacs bytecode objects compatibility

## Why

The XEmacs functions cause compile warnings and we have dropped support for XEmacs so this can safely be removed.