### PR TITLE
Remove use of with-suppressed-warnings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,9 @@
 2021-05-17  Mats Lidell  <matsl@gnu.org>
 
+* kotl/kotl-mode.el (kotl-mode):
+  hyperbole.el (fboundp): Do not use with-suppressed-warnings since not
+    available in Emacs 26
+
 * kotl/kmenu.el (id-menubar-set): Add external dependency.
 
 * hyrolo.el (google-contacts-history, google-contacts-expire-time)

--- a/hyperbole.el
+++ b/hyperbole.el
@@ -424,8 +424,7 @@ The function does NOT recursively descend into subdirectories of the
 directory or directories specified."
     ;; Don't use a 'let' on this next line or it will fail.
     (setq generated-autoload-file output-file)
-    (with-suppressed-warnings ((obsolete update-directory-autoloads))
-      (update-directory-autoloads dir))))
+    (update-directory-autoloads dir)))
 
 ;; Before the 6.0.1 release, Hyperbole used to patch the package-generate-autoloads
 ;; function to ensure that kotl/ subdirectories were autoloaded.  This

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -166,8 +166,7 @@ It provides the following keys:
   ;; We have been converting a buffer from a foreign format to a koutline.
   ;; Now that it is converted, ensure that `kotl-previous-mode' is set to
   ;; koutline.
-  (with-suppressed-warnings ((free-vars kotl-previous-mode))
-    (setq kotl-previous-mode 'kotl-mode))
+  (setq kotl-previous-mode 'kotl-mode)
   ;; Enable Org Table editing minor mode (user can disable via kotl-mode-hook
   ;; if desired).
   (orgtbl-mode 1)


### PR DESCRIPTION
## What

Remove use of with-suppressed-warnings

## Why

It was introduced in Emacs 27 and Elpa uses Emacs 26. Or maybe use #92 instead?