### PR TITLE
Use compatibility macro for with-suppressed-warnings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,10 @@
-2021-05-17  Mats Lidell  <matsl@gnu.org>
+2021-05-18  Mats Lidell  <matsl@gnu.org>
+
+* kotl/kotl-mode.el (hypb):
+  hyperbole.el (hypb): Use compatibility macro.
+
+* hypb.el (hypb-with-suppressed-warnings): Add compatibility macro for
+    suppressing warnings
 
 * Makefile (kotl/kotl-autoloads.el): Remove PRELOADS for generating
     autoloads. Patch from Stefan Monnier. Thank you Stefan.
@@ -6,6 +12,8 @@
 * kotl/kotl-mode.el (kotl-mode):
   hyperbole.el (fboundp): Do not use with-suppressed-warnings since not
     available in Emacs 26
+
+2021-05-17  Mats Lidell  <matsl@gnu.org>
 
 * kotl/kmenu.el (id-menubar-set): Add external dependency.
 

--- a/hypb.el
+++ b/hypb.el
@@ -18,6 +18,13 @@
 
 (eval-and-compile (mapc #'require '(compile hversion hact locate)))
 
+(defmacro hypb-with-suppressed-warnings (spec &rest body)
+  "Backwards compatibility macro."
+  (declare (debug (sexp &optional body)) (indent 1))
+  (if (fboundp 'with-suppressed-warnings)
+      `(with-suppressed-warnings ,spec ,@body)
+    `(with-no-warnings ,@body)))
+
 ;;; ************************************************************************
 ;;; Public variables
 ;;; ************************************************************************

--- a/hyperbole.el
+++ b/hyperbole.el
@@ -81,6 +81,13 @@
 ;; Ensure defgroup and defcustom are defined for use throughout Hyperbole.
 (require 'custom)
 
+(defmacro hypb-with-suppressed-warnings (spec &rest body)
+  "Backwards compatibility macro."
+  (declare (debug (sexp &optional body)) (indent 1))
+  (if (fboundp 'with-suppressed-warnings)
+      `(with-suppressed-warnings ,spec ,@body)
+    `(with-no-warnings ,@body)))
+
 (defgroup hyperbole nil
   "Hyperbole customizations category."
   :group 'applications)
@@ -424,7 +431,8 @@ The function does NOT recursively descend into subdirectories of the
 directory or directories specified."
     ;; Don't use a 'let' on this next line or it will fail.
     (setq generated-autoload-file output-file)
-    (update-directory-autoloads dir)))
+    (hypb-with-suppressed-warnings ((obsolete update-directory-autoloads))
+      (update-directory-autoloads dir))))
 
 ;; Before the 6.0.1 release, Hyperbole used to patch the package-generate-autoloads
 ;; function to ensure that kotl/ subdirectories were autoloaded.  This

--- a/hyperbole.el
+++ b/hyperbole.el
@@ -75,18 +75,13 @@
 ;;; Start Initializations
 ;;; ************************************************************************
 
+(require 'hypb)
+
 (defconst hyperbole-loading t
   "Temporary constant available for testing while Hyperbole is loading.")
 
 ;; Ensure defgroup and defcustom are defined for use throughout Hyperbole.
 (require 'custom)
-
-(defmacro hypb-with-suppressed-warnings (spec &rest body)
-  "Backwards compatibility macro."
-  (declare (debug (sexp &optional body)) (indent 1))
-  (if (fboundp 'with-suppressed-warnings)
-      `(with-suppressed-warnings ,spec ,@body)
-    `(with-no-warnings ,@body)))
 
 (defgroup hyperbole nil
   "Hyperbole customizations category."

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -18,12 +18,7 @@
 
 (eval-and-compile (mapc #'require '(cl-lib delsel hsettings hmail kfile kvspec kcell outline org-table kotl-orgtbl)))
 
-(defmacro hypb-with-suppressed-warnings (spec &rest body)
-  "Backwards compatibility macro."
-  (declare (debug (sexp &optional body)) (indent 1))
-  (if (fboundp 'with-suppressed-warnings)
-      `(with-suppressed-warnings ,spec ,@body)
-    `(with-no-warnings ,@body)))
+(require 'hypb)
 
 ;;; ************************************************************************
 ;;; Public variables

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -18,6 +18,13 @@
 
 (eval-and-compile (mapc #'require '(cl-lib delsel hsettings hmail kfile kvspec kcell outline org-table kotl-orgtbl)))
 
+(defmacro hypb-with-suppressed-warnings (spec &rest body)
+  "Backwards compatibility macro."
+  (declare (debug (sexp &optional body)) (indent 1))
+  (if (fboundp 'with-suppressed-warnings)
+      `(with-suppressed-warnings ,spec ,@body)
+    `(with-no-warnings ,@body)))
+
 ;;; ************************************************************************
 ;;; Public variables
 ;;; ************************************************************************
@@ -166,7 +173,8 @@ It provides the following keys:
   ;; We have been converting a buffer from a foreign format to a koutline.
   ;; Now that it is converted, ensure that `kotl-previous-mode' is set to
   ;; koutline.
-  (setq kotl-previous-mode 'kotl-mode)
+  (hypb-with-suppressed-warnings ((free-vars kotl-previous-mode))
+    (setq kotl-previous-mode 'kotl-mode))
   ;; Enable Org Table editing minor mode (user can disable via kotl-mode-hook
   ;; if desired).
   (orgtbl-mode 1)


### PR DESCRIPTION
## What

Use compatibility macro for with-suppressed-warnings

## Why

It was introduced in Emacs 27 and Elpa uses Emacs 26.  Alternative to #91 maybe?