### PR TITLE
Fix even more warnings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 2021-06-19  Mats Lidell  <matsl@gnu.org>
 
+* hui-menu.el (hyperbole-menubar-menu): Use easy-menu-add-item.
+
 * hmouse-drv.el (window-jump, wj-vec-left, wj-vec-right, wj-vec-down)
     (wj-vec-up): Declare function and variables.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2021-06-19  Mats Lidell  <matsl@gnu.org>
 
+* kotl/kotl-mode.el (kotl-mode:end-of-buffer): looking-back requires two
+    args.
+
 * test/hyrolo-tests.el (hyrolo-demo-search-work)
     (hyrolo-demo-tab-jump-to-first-match, hyrolo-demo-toggle-visibility):
     Add tests for hyrolo.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,24 @@
 2021-06-19  Mats Lidell  <matsl@gnu.org>
 
+* hmouse-drv.el (window-jump, wj-vec-left, wj-vec-right, wj-vec-down)
+    (wj-vec-up): Declare function and variables.
+
+* hsys-org.el (org-link): Use org-link-open-from-string.
+
+* hui-mouse.el (helm-action-buffer, helm-alive-p, helm-buffer): Declare
+    helm variables.
+    (company-show-doc-buffer, company-show-location)
+    (company-select-mouse): Declare helm functions.
+    (smart-calendar): Use calendar-scroll-left-three-months and
+    calendar-scroll-right-three-months
+    (smart-calendar-assist): Use calendar-scroll-left-three-months and
+    calendar-scroll-right-three-months and diary-view-entries.
+
+* hui-treemacs.el (treemacs-version, aw-ignored-buffers): Declare
+    variables.
+
+* hycontrol.el (ibuffer-mode-map): Declare used variable.
+
 * kotl/kotl-mode.el (kotl-mode:end-of-buffer): looking-back requires two
     args.
 

--- a/hmouse-drv.el
+++ b/hmouse-drv.el
@@ -126,6 +126,13 @@ This permits the Smart Keys to behave as paste keys.")
 (defvar aw-frame-size)
 (defvar aw-keys)
 
+;; window-jump
+(declare-function window-jump "ext:window-jump")
+(defvar	wj-vec-left)
+(defvar	wj-vec-right)
+(defvar	wj-vec-down)
+(defvar	wj-vec-up)
+
 ;;; ************************************************************************
 ;;; Private variables
 ;;; ************************************************************************

--- a/hsys-org.el
+++ b/hsys-org.el
@@ -83,10 +83,7 @@ with different settings of this option.  For example, a nil value makes
   "Follows an optional Org mode LINK to its target.
 If LINK is nil, follows any link at point.  Otherwise, triggers an error."
   (if (stringp link)
-      (cond ((fboundp #'org-link-open-from-string)
-	     (org-link-open-from-string link))
-            ((fboundp #'org-open-link-from-string)
-	     (org-open-link-from-string link))) ;; autoloaded
+      (org-link-open-from-string link)
     (org-open-at-point))) ;; autoloaded
 
 (defact org-internal-link-target (&optional link-target)

--- a/hui-menu.el
+++ b/hui-menu.el
@@ -292,7 +292,7 @@ Return t if cutoff, else nil."
 				    "Koutline")
 				   ((global-key-binding [menu-bar OO-Browser])
 				    "OO-Browser"))))
-	     (add-submenu nil (infodock-hyperbole-menu t) add-before))))
+             (easy-menu-add-item (current-global-map) '("menu-bar") (infodock-hyperbole-menu t) add-before))))
   ;; Force a menu-bar update.
   (force-mode-line-update))
 

--- a/hui-mouse.el
+++ b/hui-mouse.el
@@ -138,6 +138,9 @@ Its default value is #'smart-scroll-down.  To disable it, set it to
 (declare-function helm-resume "ext:helm")
 (declare-function helm-window "ext:helm-lib")
 (declare-function with-helm-buffer "ext:helm-lib")
+(defvar helm-action-buffer)
+(defvar helm-alive-p)
+(defvar helm-buffer)
 
 (declare-function ibuffer-mark-for-delete "ibuffer")
 (declare-function ibuffer-unmark-forward "ibuffer")
@@ -151,6 +154,12 @@ Its default value is #'smart-scroll-down.  To disable it, set it to
 (declare-function br-buffer-menu-select "ext:br")
 
 (declare-function gnus-topic-read-group "gnus-topic")
+
+(declare-function company-show-doc-buffer "ext:company")
+;; (declare-function company-quick-help-manual-begin "ext:company?")
+(declare-function company-show-location "ext:company")
+(declare-function company-select-mouse "ext:company")
+
 
 ;;; ************************************************************************
 ;;; Hyperbole context-sensitive keys dispatch table
@@ -740,9 +749,9 @@ If key is pressed:
 
   (interactive)
   (cond ((eobp) (calendar-cursor-to-nearest-date)
-	 (scroll-calendar-left-three-months 1))
+	 (calendar-scroll-left-three-months 1))
 	((< (current-column) 5) (calendar-cursor-to-nearest-date)
-	 (scroll-calendar-right-three-months 1))
+	 (calendar-scroll-right-three-months 1))
 	(t (calendar-cursor-to-nearest-date)
 	   (diary-view-entries 1))))
 
@@ -762,10 +771,10 @@ If assist-key is pressed:
 
   (interactive)
   (cond ((eobp) (calendar-cursor-to-nearest-date)
-	 (scroll-calendar-right-three-months 1))
+	 (calendar-scroll-right-three-months 1))
 	((< (current-column) 5) (calendar-cursor-to-nearest-date)
-	 (scroll-calendar-left-three-months 1))
-	(t (mark-diary-entries))))
+	 (calendar-scroll-left-three-months 1))
+	(t (diary-view-entries))))
 
 ;;; ************************************************************************
 ;;; smart-company mode functions
@@ -884,9 +893,7 @@ If assist-key is pressed:
 	 ;; Prevent any region selection from causing multiple files
 	 ;; to be marked for deletion; we want to mark only one.
 	 (deactivate-mark t)
-	 (if (fboundp 'dired-flag-file-deletion)
-	     (dired-flag-file-deletion 1)
-	   (dired-flag-file-deleted 1)))))
+	 (dired-flag-file-deletion 1))))
 
 ;;; ************************************************************************
 ;;; smart-gnus functions

--- a/hui-mouse.el
+++ b/hui-mouse.el
@@ -774,7 +774,7 @@ If assist-key is pressed:
 	 (calendar-scroll-right-three-months 1))
 	((< (current-column) 5) (calendar-cursor-to-nearest-date)
 	 (calendar-scroll-left-three-months 1))
-	(t (diary-view-entries))))
+	(t (diary-mark-entries))))
 
 ;;; ************************************************************************
 ;;; smart-company mode functions

--- a/hui-treemacs.el
+++ b/hui-treemacs.el
@@ -18,6 +18,8 @@
 
 (eval-and-compile (require 'treemacs nil t))
 
+(defvar treemacs-version)
+
 (unless (and (featurep 'treemacs) (string-greaterp treemacs-version "v2"))
   (error "(hui-treemacs): Hyperbole requires Treemacs package version 2.0 or greater"))
 
@@ -32,6 +34,7 @@
 (declare-function treemacs-node-buffer-and-position "etx:treemacs-mouse-interface")
 (declare-function treemacs-quit "ext:treemacs-core-utils")
 (declare-function treemacs-toggle-node "ext:treemacs-interface")
+(defvar aw-ignored-buffers)
 
 ;;; ************************************************************************
 ;;; smart-treemacs functions

--- a/hycontrol.el
+++ b/hycontrol.el
@@ -228,6 +228,11 @@ The final predicate should always be t, for default values, typically of zero.")
   "HyControl copy of `prefix-arg' that it changes within key bindings.
 `pre-command-hook' synchronizes this value to `prefix-arg'.")
 
+;;; ************************************************************************
+;;; Public declarations
+;;; ************************************************************************
+(defvar ibuffer-mode-map)
+
 ;;; Frame Keys
 
 (defvar hycontrol-frames-mode-map

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -1540,7 +1540,7 @@ Leave point at the start of the cell."
   (interactive)
   (kotl-mode:maintain-region-highlight)
   (goto-char (point-max))
-  (when (looking-back "\\]\\s-*")
+  (when (looking-back "\\]\\s-*" nil)
     ;; Internal Koutline structures are exposed, re-narrow the Koutline
     (kotl-mode))
   ;; To move to cell end.


### PR DESCRIPTION
## What

Fix even more warnings. 

Tried to remove some more warnings but did also find some other problems. So contains also some replacements of functions that are deprecated but should be available from Emacs 27 (Only verified by by inspection.) and fixing a call with too few arguments.

## Why

We need to silence the output when compiling.