### PR TITLE
Test installations using different sources

### DIFF
--- a/install-test/elpa/.emacs
+++ b/install-test/elpa/.emacs
@@ -1,0 +1,11 @@
+;; .emacs
+
+(require 'package)
+(when (< emacs-major-version 27)
+  (package-initialize))
+(unless (package-installed-p 'hyperbole)
+  (package-refresh-contents)
+  (package-install 'hyperbole))
+(hyperbole-mode 1)
+
+(message "%s" "Hyperbole successfully installed")

--- a/install-test/local-install-test.sh
+++ b/install-test/local-install-test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+echo *** Install test ***
+
+install_method="$1"
+
+app=/tmp/hypb-$$
+
+mkdir -p $app
+cp -a * $app
+export HOME=$app/$install_method
+
+[ -e $app/$install_method/install-local.sh ] && cd $app/$install_method && ./install-local.sh
+
+cd $app/$install_method
+emacs --batch -l $app/$install_method/.emacs \
+      --eval '(load (expand-file-name "test/hy-test-dependencies.el" hyperb:dir))' \
+      -l hypb-ert \
+      --eval "(mapc #'load-file (hypb-run-ert-test-libraries))" \
+      -f ert-run-tests-batch-and-exit

--- a/install-test/straight/.emacs
+++ b/install-test/straight/.emacs
@@ -1,0 +1,26 @@
+;; Use this in your Emacs init file to install Straight
+(progn
+  (defvar bootstrap-version)
+  (setq package-enable-at-startup nil)
+  (let ((bootstrap-file
+         (expand-file-name "straight/repos/straight.el/bootstrap.el" user-emacs-directory))
+        (bootstrap-version 5))
+    (unless (file-exists-p bootstrap-file)
+      (with-current-buffer
+          (url-retrieve-synchronously
+           "https://raw.githubusercontent.com/raxod502/straight.el/develop/install.el"
+           'silent 'inhibit-cookies)
+        (goto-char (point-max))
+        (eval-print-last-sexp)))
+    (load bootstrap-file nil 'nomessage)))
+
+;; Then use this to install Hyperbole
+(straight-use-package
+ '(hyperbole
+   :host nil
+   :repo "https://git.savannah.gnu.org/git/hyperbole.git"
+   :config (hyperbole-mode 1)))
+
+(hyperbole-mode 1)
+
+(message "%s" "Hyperbole successfully installed")

--- a/install-test/tarball/.emacs
+++ b/install-test/tarball/.emacs
@@ -1,0 +1,8 @@
+;;; tarball -- hyperbole installed from a tar ball
+
+(unless (and (featurep 'hyperbole) hyperbole-mode)
+  (push (expand-file-name "hyperbole" (getenv "HOME")) load-path)
+  (require 'hyperbole)
+  (hyperbole-mode 1))
+
+(message "%s" "Hyperbole successfully installed")

--- a/install-test/tarball/install-local.sh
+++ b/install-test/tarball/install-local.sh
@@ -1,0 +1,7 @@
+TARBALL=hyperbole-8.0.0pre0.20210605.220551
+
+curl -O https://elpa.gnu.org/devel/$TARBALL.tar
+tar -xf $TARBALL.tar
+ln -s $TARBALL hyperbole
+cd hyperbole
+make bin


### PR DESCRIPTION
## What

Test installations using different sources

## Description

This is work in progress for an install test. Current setup is to run the script `local-install-test.sh` with args `tarball`, `elpa` or `straight` to choose what install source to use. If the install is successful the unit test are executed in non interactive mode to verify the install further.

Don't know if it makes sense to have these as individual or a combined target in the main Makefile. Since the test is **post** install it might suite better just to run it at times manually or in an automated fashion when a new version of Hyperbole is uploaded in a pipeline.

Please take a look and tell me what you think. 
