### PR TITLE
Stefans patch piece 2

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,9 @@
 2021-07-20  Mats Lidell  <matsl@gnu.org>
 
+* hpath.el: Part two of patch from Stefan Monnier. Thank you Stefan. Use
+    lexical scope.
+    (hpath:substitute-value): Use match-beginning and match-end.
+
 * test/hpath-tests.el (hpath:subsitute-value-test): Add tests for
     hpath:substitute-value.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2021-07-20  Mats Lidell  <matsl@gnu.org>
+
+* test/hpath-tests.el (hpath:subsitute-value-test): Add tests for
+    hpath:substitute-value.
+
 2021-07-19  Mats Lidell  <matsl@gnu.org>
 
 * test/hmouse-drv-tests.el (hbut-etags-test): Rename test case due to name

--- a/hpath.el
+++ b/hpath.el
@@ -1,10 +1,10 @@
-;;; hpath.el --- GNU Hyperbole support routines for handling POSIX and MSWindows paths
+;;; hpath.el --- GNU Hyperbole support routines for handling POSIX and MSWindows paths  -*- lexical-binding: t; -*-
 ;;
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Nov-91 at 00:44:23
 ;;
-;; Copyright (C) 1991-2020  Free Software Foundation, Inc.
+;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.
@@ -1517,13 +1517,14 @@ in-buffer path will not match."
 
 (defun hpath:substitute-value (path)
   "Substitute matching value for Emacs Lisp variables and environment variables in PATH and return PATH."
-  ;; Uses free variables `match' and `start' from `hypb:replace-match-string'.
   (substitute-in-file-name
    (hpath:substitute-match-value
     "\\$@?\{\\([^\}]+\\)@?\}"
     path
-    (lambda (matched-str)
-      (let* ((var-group (substring path match start))
+    (lambda (_matched_str)
+      (let* ((match (match-beginning 0))
+             (start (match-end 0))
+             (var-group (substring path match start))
 	     (rest-of-path (substring path start))
 	     (var-ext (substring path (match-beginning 1) (match-end 1)))
 	     (var-name (if (= ?@ (aref var-ext (1- (length var-ext))))

--- a/test/hpath-tests.el
+++ b/test/hpath-tests.el
@@ -75,5 +75,33 @@
       (hpath:find "-tutorial.el")
       (should was-called))))
 
+(ert-deftest hpath:subsitute-value-test ()
+  "Environment and Lisp variables shall be substituted in a path."
+  (progn ()
+         (setq hypb:lc-var "lower")
+         (setq hypb:uc-var "UPPER")
+         (setenv "HYPB_TEST_ENV" "env")
+
+         (should (string= (hpath:substitute-value "/nothing/to/substitute") "/nothing/to/substitute"))
+
+         (should (string= (hpath:substitute-value "${hypb:lc-var}") hypb:lc-var))
+         (should (string= (hpath:substitute-value "${hypb:uc-var}") hypb:uc-var))
+         (should (string= (hpath:substitute-value "$HYPB_TEST_ENV") (getenv "HYPB_TEST_ENV")))
+         (should (string= (hpath:substitute-value "${HYPB_TEST_ENV}") (getenv "HYPB_TEST_ENV")))
+
+         (should (string= (hpath:substitute-value "prefix${hypb:lc-var}suffix") (concat "prefix" hypb:lc-var "suffix")))
+         (should (string= (hpath:substitute-value "prefix/$HYPB_TEST_ENV/suffix") (concat "prefix/" (getenv "HYPB_TEST_ENV") "/suffix")))
+         (should (string= (hpath:substitute-value "prefix${HYPB_TEST_ENV}suffix") (concat "prefix" (getenv "HYPB_TEST_ENV") "suffix")))
+
+         (should (string= (hpath:substitute-value "${hypb:lc-var}${hypb:uc-var}") (concat hypb:lc-var hypb:uc-var)))
+         (should (string= (hpath:substitute-value "$HYPB_TEST_ENV/$HYPB_TEST_ENV") (concat (getenv "HYPB_TEST_ENV") "/" (getenv "HYPB_TEST_ENV"))))
+         (should (string= (hpath:substitute-value "${HYPB_TEST_ENV}${HYPB_TEST_ENV}") (concat (getenv "HYPB_TEST_ENV") (getenv "HYPB_TEST_ENV"))))
+
+         (should (string= (hpath:substitute-value "prefix${hypb:lc-var}/$HYPB_TEST_ENV/suffix") (concat "prefix" hypb:lc-var "/" (getenv "HYPB_TEST_ENV") "/suffix")))
+
+         (should (string= (hpath:substitute-value "$UNDEFINED_IS_NOT_SUBSTITUTED") "$UNDEFINED_IS_NOT_SUBSTITUTED"))
+         (should (string= (hpath:substitute-value "${UNDEFINED_IS_NOT_SUBSTITUTED}") "${UNDEFINED_IS_NOT_SUBSTITUTED}"))
+         ))
+
 (provide 'hpath-tests)
 ;;; hpath-tests.el ends here


### PR DESCRIPTION
## What

Piece 2 from Stefan - hpath.el

This was a bit trickier so I kept it to this small change. Going lexical scope caused problems for `hpath:substitute-value` where dynamic `match` and `start` where used. I changed that to use `match-beginning` and `match-end`. I do not fully understand the code so added ert tests that worked before and after the change to check that it is OK. So please take a good look at that.

I find the lambda expression that is passed in as the NEW value as especially interesting and a source of learning. Could use a Sunday talk to dive into that one to learn further and to fully understand it.