### PR TITLE
Refactor hyperbole set functions - patch piece 3

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2023-01-07  Mats Lidell  <matsl@gnu.org>
+
+* Part three of patch from Stefan monnier. Thank you Stefan.
+  Contains:
+  - Replace use of functions from set.el with standard functions from
+    cl-lib.
+  - Use #' short hand
+
 2022-12-18  Mats Lidell  <matsl@gnu.org>
 
 * Makefile (ELC_COMPILE, ELC_KOTL): Use function to derive elc files.

--- a/hact.el
+++ b/hact.el
@@ -1,9 +1,9 @@
-;;; hact.el --- GNU Hyperbole button action handling  -*- lexical-binding: t; -let*-
+;;; hact.el --- GNU Hyperbole button action handling  -*- lexical-binding: t; -*-
 ;;
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:      7-Oct-22 at 23:01:56 by Mats Lidell
+;; Last-Mod:      7-Jan-23 at 23:58:55 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -158,12 +158,11 @@ If no SYMBOLS are given, set it to the empty set.  Return the symset.  Uses
 
 (defun    symset:add (elt symbol property)
   "Add ELT to SYMBOL's PROPERTY set.
-Return nil iff ELT is already in SET; otherwise, return PROPERTY's value.
+Return PROPERTY's value.
 Use `eq' for comparison."
   (let* ((set (get symbol property))
-	 (set:equal-op 'eq)
-	 (new-set (set:add elt set)))
-    (and new-set (put symbol property new-set))))
+	 (new-set (if (memq elt set) set (cons elt set))))
+    (put symbol property new-set)))
 
 (defun    symset:clear (symbol)
   "Set SYMBOL's symset to nil."
@@ -178,9 +177,8 @@ Use `eq' for comparison."
 (defun    symset:remove (elt symbol property)
   "Remove ELT from SYMBOL's PROPERTY set and return the new set.
 Assume PROPERTY is a valid set.  Use `eq' for comparison."
-  (let ((set (get symbol property))
-	(set:equal-op 'eq))
-    (put symbol property (set:remove elt set))))
+  (let ((set (get symbol property)))
+    (put symbol property (delq elt set))))
 
 ;;; ========================================================================
 ;;; htype class - Hyperbole Types, e.g. action and implicit button types

--- a/hsys-org.el
+++ b/hsys-org.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Jul-16 at 14:54:14
-;; Last-Mod:      3-Dec-22 at 02:33:37 by Bob Weiner
+;; Last-Mod:      7-Jan-23 at 23:59:42 by Mats Lidell
 ;;
 ;; Copyright (C) 2016-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -29,6 +29,7 @@
 ;;; ************************************************************************
 
 (eval-when-compile (require 'hmouse-drv))
+(require 'cl-lib)
 (require 'hbut)
 (require 'org)
 (require 'org-element)
@@ -39,10 +40,12 @@
 (defun hsys-org-meta-return-shared-p ()
   "Return non-nil if hyperbole-mode is active and shares the org-meta-return key."
   (let ((org-meta-return-keys (where-is-internal #'org-meta-return org-mode-map)))
-    (when (or (set:intersection org-meta-return-keys
-				(where-is-internal #'hkey-either hyperbole-mode-map))
-	      (set:intersection org-meta-return-keys
-				(where-is-internal #'action-key hyperbole-mode-map)))
+    (when (or (cl-intersection org-meta-return-keys
+			       (where-is-internal #'hkey-either hyperbole-mode-map)
+			       :test #'equal)
+	      (cl-intersection org-meta-return-keys
+			       (where-is-internal #'action-key hyperbole-mode-map)
+			       :test #'equal))
       t)))
 
 ;;;###autoload
@@ -82,7 +85,8 @@ with different settings of this option.  For example, a nil value makes
 
 ;;;###autoload
 (defvar hsys-org-mode-function #'hsys-org-mode-p
-"*Zero arg bool func that returns non-nil if point is in an Org-related buffer.")
+  "Function that determines whether point is in an Org mode-related buffer.
+Called with no argument and should return non-nil if and only if it is.")
 
 ;;; ************************************************************************
 ;;; Public Action Types

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Jun-89 at 22:08:29
-;; Last-Mod:     27-Nov-22 at 23:45:24 by Bob Weiner
+;; Last-Mod:      8-Jan-23 at 01:13:50 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -550,10 +550,10 @@ Return number of entries matched.  See also documentation for the variable
 		(or (not (integerp max-matches))
 		    (< total-matches (max max-matches (- max-matches)))))
       (setq hyrolo-buf (hyrolo-find-file-noselect file)
-	    hyrolo-entry-regexps (set:add (buffer-local-value 'hyrolo-entry-regexp hyrolo-buf)
-					  hyrolo-entry-regexps)
-	    outline-regexps (set:add (buffer-local-value 'outline-regexp hyrolo-buf)
-				     outline-regexps)
+	    hyrolo-entry-regexps (seq-uniq (append (list (buffer-local-value 'hyrolo-entry-regexp hyrolo-buf))
+					           hyrolo-entry-regexps))
+	    outline-regexps (seq-uniq (append (list (buffer-local-value 'outline-regexp hyrolo-buf))
+				              outline-regexps))
 	    hyrolo-file-list (cdr hyrolo-file-list)
 	    num-matched (cond ((and (featurep 'bbdb) (equal file bbdb-file))
 			       (hyrolo-bbdb-grep-file file regexp max-matches count-only))

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:     16-Oct-22 at 19:29:20 by Mats Lidell
+;; Last-Mod:      8-Jan-23 at 00:06:52 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -125,16 +125,17 @@ It provides the following keys:
     (setq hyrolo-entry-regexp (concat "^" kview:outline-regexp)
 	  kotl-previous-mode major-mode
 	  ;; Remove outline minor-mode mode-line indication.
+	  ;; FIXME: Why?
 	  minor-mode-alist (copy-sequence minor-mode-alist)
-	  minor-mode-alist (set:remove '(outline-minor-mode " Outl")
-				       minor-mode-alist)
- 	  minor-mode-alist (set:remove '(selective-display " Outline")
-				       minor-mode-alist)
-	  minor-mode-alist (set:remove '(selective-display " Otl")
-				       minor-mode-alist)
+	  minor-mode-alist (delete '(outline-minor-mode " Outl")
+				   minor-mode-alist)
+ 	  minor-mode-alist (delete '(selective-display " Outline")
+				   minor-mode-alist)
+	  minor-mode-alist (delete '(selective-display " Otl")
+				   minor-mode-alist)
 	  ;; Remove indication that buffer is narrowed.
-	  mode-line-format (copy-sequence mode-line-format)
-	  mode-line-format (set:remove "%n" mode-line-format)
+	  mode-line-format (remove "%n" mode-line-format)
+	  outline-regexp (concat " *[0-9][0-9a-z.]*" kview:default-label-separator)
 	  outline-level  #'kcell-view:level
 	  outline-regexp kview:outline-regexp))
   ;;
@@ -2563,9 +2564,10 @@ ATTRIBUTE and ignore any value of POS."
        (setq plist (cdr plist)))
      ;; Remove read-only attributes
      (setq existing-attributes (apply #'set:create existing-attributes)
-	   existing-attributes (set:difference
+	   existing-attributes (cl-set-difference
 				existing-attributes
-				kcell:read-only-attributes))
+				kcell:read-only-attributes
+				:test #'equal))
 
      (while (zerop (length (setq attribute
 				 (completing-read
@@ -2612,9 +2614,10 @@ confirmation."
        (setq plist (cdr plist)))
      ;; Remove read-only attributes
      (setq existing-attributes (apply #'set:create existing-attributes)
-	   existing-attributes (set:difference
+	   existing-attributes (cl-set-difference
 				existing-attributes
-				kcell:read-only-attributes))
+				kcell:read-only-attributes
+				:test #'equal))
 
      (while (zerop (length (setq attribute
 				 (completing-read
@@ -2622,7 +2625,7 @@ confirmation."
 					  (if top-cell-flag
 					      "0"
 					    (kcell-view:label)))
-				  (mapcar 'list
+				  (mapcar '#list
 					  (mapcar 'symbol-name
 						  existing-attributes))))))
        (beep))

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:      8-Jan-23 at 00:06:52 by Mats Lidell
+;; Last-Mod:      8-Jan-23 at 00:12:51 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -2625,7 +2625,7 @@ confirmation."
 					  (if top-cell-flag
 					      "0"
 					    (kcell-view:label)))
-				  (mapcar '#list
+				  (mapcar #'list
 					  (mapcar 'symbol-name
 						  existing-attributes))))))
        (beep))

--- a/set.el
+++ b/set.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    26-Sep-91 at 19:24:19
-;; Last-Mod:      6-Aug-22 at 23:23:08 by Mats Lidell
+;; Last-Mod:      8-Jan-23 at 00:08:44 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -17,15 +17,14 @@
 ;;   but this may be overidden by changing the function bound to
 ;;   the `set:equal-op' variable.  The empty set is equivalent to nil.
 
-;;   (set:create) creates an empty set and (set:add 'element nil) creates
-;;   a new set with the single member, 'element.
+;;   (set:create) creates an empty set.
 
 ;;; Code:
 ;; ************************************************************************
 ;; Public variables
 ;; ************************************************************************
 
-(defvar set:equal-op 'equal
+(defvar set:equal-op #'equal            ;FIXME: Should end in `-function'.
   "Comparison function used by set operators.
 It must be a function of two arguments which returns non-nil only when
 the arguments are equivalent.")
@@ -42,54 +41,9 @@ Uses `set:equal-op' for comparison."
     (setq set (cdr set)))
   set)
 
-(defmacro set:add (elt set)
-  "Add element ELT to SET and then return SET, even if SET is nil.
-Uses `set:equal-op' for comparison.
-Use (setq set (set:add elt set)) to assure set is always properly modified."
-  `(cond ((set:member ,elt ,set) ,set)
-	 (,set (setq ,set (cons ,elt ,set)))
-	 (t (list ,elt))))
-
-(defmacro set:remove (elt set)
-  "Remove element ELT from SET and return new set.
-Assume SET is a valid set.  Uses `set:equal-op' for comparison.
-Use (setq set (set:remove elt set)) to assure set is always properly modified."
-  `(let ((rest (set:member ,elt ,set))
-	 (rtn ,set))
-     (if rest
-	 (cond ((= (length rtn) 1) (setq rtn nil))
-	       ((= (length rest) 1)
-		(setcdr (nthcdr (- (length rtn) 2) rtn) nil))
-	       (t (setcar rest (car (cdr rest)))
-		  (setcdr rest (cdr (cdr rest))))))
-     rtn))
-
 ;; ************************************************************************
 ;; Public functions
 ;; ************************************************************************
-
-(defun set:combinations (set &optional arity)
-  "Return all possible combinations (subsets) of SET.
-This includes the empty set and the SET itself.  Assume SET is a
-valid set.  With optional ARITY, return only subsets with ARITY
-members."
-  (cond ((null arity) 
-	 (setq arity 0)
-	 (cons nil (apply 'nconc (mapcar (lambda (_elt) (setq arity (1+ arity)) (set:combinations set arity))
-					 set))))
-	((= arity 1) set)
-	((<= arity 0) '(nil))
-	(t (let ((rest) (ctr 1))
-	     (apply
-	      'nconc
-	      (mapcar (lambda (first)
-			(setq rest (nthcdr ctr set)
-			      ctr (1+ ctr))
-			(mapcar (lambda (elt)
-				  (if (listp elt) (cons first elt)
-				    (list first elt)))
-				(set:combinations rest (1- arity))))
-		      set))))))
 
 ;;;###autoload
 (defun set:create (&rest elements)
@@ -100,100 +54,6 @@ for comparison."
     (mapc (lambda (elt) (or (set:member elt set) (setq set (cons elt set))))
 	  elements)
     (nreverse set)))
-
-(defalias 'set:delete 'set:remove)
-(defun set:difference (&rest sets)
-  "Return difference of any number of SETS.
-Difference is the set of elements in the first set that are not in any of the
-other sets.  Uses `set:equal-op' for comparison."
-  (let ((rtn-set (set:members (car sets))))
-    (mapc (lambda (set)
-	    (mapc (lambda (elem) (setq rtn-set (set:remove elem rtn-set)))
-		  set))
-     (cdr sets))
-    (nreverse rtn-set)))
-
-(defalias 'set:size 'length)
-
-(defun set:empty (set)
-  "Return t if SET is empty."
-  (null set))
-
-(defun set:equal (set1 set2)
-  "Return t iff SET1 contains the same members as SET2.  Both must be sets.
-Uses `set:equal-op' for comparison."
-  (and (listp set1) (listp set2)
-       (= (set:size set1) (set:size set2))
-       (set:subset set1 set2)))
-
-(defun set:get (key set)
-  "Return the value associated with KEY in SET or nil.
-Assume elements of SET are of the form (key . value)."
-  (cdr (car (let ((set:equal-op (lambda (key elt) (equal key (car elt)))))
-	      (set:member key set)))))
-
-(defun set:intersection (&rest sets)
-  "Return intersection of all SETS given as arguments.
-Uses `set:equal-op' for comparison."
-  (let (rtn-set)
-    (mapc (lambda (elt) (or (memq nil (mapcar (lambda (set) (set:member elt set))
-					      (cdr sets)))
-			    (setq rtn-set (cons elt rtn-set))))
-	    (car sets))
-    (nreverse rtn-set)))
-
-(defun set:is (obj)
-  "Return t if OBJ is a set (a list with no repeated elements).
-Uses `set:equal-op' for comparison."
-  (and (listp obj)
-       (let ((lst obj))
-	 (while (and (not (set:member (car lst) (cdr lst)))
-		     (setq lst (cdr lst))))
-	 (null lst))))
-
-(defalias 'set:map 'mapcar)
-
-(defun set:members (list)
-  "Return set of unique elements of LIST.
-Uses `set:equal-op' for comparison.  See also `set:create'."
-  (let ((set))
-    (mapc (lambda (elt) (or (set:member elt set) (setq set (cons elt set))))
-	  list)
-    set))
-
-(defun set:replace (key value set)
-  "Replace or add element whose car matches KEY with element (KEY . VALUE) in SET.
-Return set if modified, else nil.
-Use (setq set (set:replace elt set)) to assure set is always properly modified.
-
-Use `set:equal-op' to match against KEY.  Assume each element in the set has a
-car and a cdr."
-  (let ((elt-set (set:member key set)))
-    (if elt-set
-	;; replace element
-	(progn (setcar elt-set (cons key value))
-	       set)
-      ;; add new element
-      (cons (cons key value) set))))
-
-(defun set:subset (sub set)
-  "Return t iff set SUB is a subset of SET.
-Uses `set:equal-op' for comparison."
-  ;; The empty set, nil, is a subset of every set, including
-  ;; itself. Each set includes it once as a subset.
-  (let ((is t))
-    (while (and sub (setq is (set:member (car sub) set)))
-      (setq sub (cdr sub)))
-    (and is t)))
-
-(defun set:union (&rest sets)
-  "Return union of all SETS given as arguments.
-Uses `set:equal-op' for comparison."
-  (let (rtn-set)
-    (mapc (lambda (set) (mapc (lambda (elt) (setq rtn-set (set:add elt rtn-set)))
-			      set))
-	  sets)
-    (nreverse rtn-set)))
 
 ;; ************************************************************************
 ;; Private variables


### PR DESCRIPTION
## What

The patch refactors use of the set functions in favor of using cl-lib functions that provides the same functionality. Some set functions remains though. So I'm not sure if this is a first step to remove set.el completely or if the remaining function is set.el still make sense to keep. Not sure about the role of set:equal-op in this scenario too since that one still remains.

A few other small unrelated but hopefully useful changes are kept in too to make the PR match Stefans patch better. 