### PR TITLE
Hyperbole install from source tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -395,3 +395,12 @@ all-tests: test-all
 test-all:
 	@echo "# Tests: $(TEST_ERT_FILES)"
 	$(INTERACTIVE) --eval "(load-file \"test/hy-test-dependencies.el\")" --eval "(progn $(LOAD_TEST_ERT_FILES) (ert-run-tests-interactively t))"
+
+# Hyperbole install tests - Verify that hyperbole can be installed
+# using different sources. See folder "install-test"
+.PHONY: install-elpa install-tarball install-straight install-all
+install-all: install-elpa install-tarball install-straight
+
+install-elpa install-tarball install-straight:
+	@echo "Install Hyperbole using $@"
+	(cd ./install-test/ && ./local-install-test.sh $(subst install-,,$@))

--- a/install-test/tarball/install-local.sh
+++ b/install-test/tarball/install-local.sh
@@ -1,7 +1,6 @@
-TARBALL=hyperbole-8.0.0pre0.20210605.220551
-
-curl -O https://elpa.gnu.org/devel/$TARBALL.tar
-tar -xf $TARBALL.tar
-ln -s $TARBALL hyperbole
+curl -O https://elpa.gnu.org/devel/hyperbole.tar
+tar -xf hyperbole.tar
+rm hyperbole.tar
+ln -s hyperbole* hyperbole
 cd hyperbole
 make bin


### PR DESCRIPTION
## What

Hyperbole install from source tests

## Why

We want to be able to run the install tests from make. Adds targets for `install-(elpa, tarball, straight)`.

### Note

This runs an install an verifies it by running the ert tests. Since we have two known bugs that remembers us to be fixed by breaking the test this makes the install test also fail. When those tests are fixed (and any other failing tests) these install tests should work.

And Elpa will not work now either since the install requires Hyperbole 8 to to work. So `make install-elpa` will have to wait for Hyperbole 8 to be released before it will work.  