### PR TITLE
Relax type to function

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2021-09-17  Mats Lidell  <matsl@gnu.org>
+
+* hsettings.el (hyperbole-web-search-browser-function): Relax type to
+    function.
+
 2021-09-14  Mats Lidell  <matsl@gnu.org>
 
 * hbut.el (defib, defil, defal): Use declare notation for making macros

--- a/hsettings.el
+++ b/hsettings.el
@@ -219,7 +219,7 @@ Hyperbole, and then restart Emacs."
 
 (defcustom hyperbole-web-search-browser-function browse-url-browser-function
   "*Function of one url argument called by any Hyperbole Find/Web search."
-  :type browse-url--browser-defcustom-type
+  :type 'function
   :group 'hyperbole-commands)
 
 (defcustom hyperbole-web-search-alist


### PR DESCRIPTION
## What

Relax type to function

## Why

There are some problems with a more specific  `browse-url--browser-defcustom-type` which is also deprecated so we go by a more general `function` type since we also have a menu for selecting what browser to set as default. 