### PR TITLE
Add test for split-cell

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,8 @@
 
 2021-09-18  Mats Lidell  <matsl@gnu.org>
 
+* kotl/kotl-mode.el (kotl-mode:split-cell): Create new plist for split cell.
+
 * test/kotl-mode-tests.el (kotl-mode-split-cell): Add test for split-cell
 
 2021-09-14  Mats Lidell  <matsl@gnu.org>

--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,10 @@
 * Makefile (bin-warn): Control what warning messages to get when byte
     compiling.
 
+2021-09-18  Mats Lidell  <matsl@gnu.org>
+
+* test/kotl-mode-tests.el (kotl-mode-split-cell): Add test for split-cell
+
 2021-09-14  Mats Lidell  <matsl@gnu.org>
 
 * hbut.el (defib, defil, defal): Use declare notation for making macros

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -2545,7 +2545,7 @@ the current cell."
     ;; delete any preceding whitespace
     (skip-chars-backward " \t\n\r" start)
     (delete-region (max start (point)) (kcell-view:end-contents))
-    (kotl-mode:add-cell arg new-cell-contents (kcell-view:plist))))
+    (kotl-mode:add-cell arg new-cell-contents)))
 
 (defun kotl-mode:transpose-cells (arg)
   "Exchange current and previous visible cells, leaving point after both.

--- a/test/kotl-mode-tests.el
+++ b/test/kotl-mode-tests.el
@@ -307,6 +307,21 @@
           (should (looking-at-p "$")))
       (delete-file kotl-file))))
 
+(ert-deftest kotl-mode-split-cell ()
+  "Kotl-mode split cell."
+  (let ((kotl-file (make-temp-file "hypb" nil ".kotl")))
+    (unwind-protect
+        (progn
+          (find-file kotl-file)
+          (insert "firstsecond\n")
+          (backward-char 7)
+          (kotl-mode:split-cell)
+          (should (string= (kcell-view:label (point)) "2"))
+          (kotl-mode:demote-tree 0)
+          (should (string= (kcell-view:label (point)) "1a"))
+          (should (string= (kcell-view:idstamp) "02")))
+      (delete-file kotl-file))))
+
 (provide 'kotl-mode-tests)
 ;;; kotl-mode-tests.el ends here
 


### PR DESCRIPTION
## What

Add test for split-cell

## Why

This looks like a bug. When I run this I get

```
F kotl-mode-split-cell
    Kotl-mode split cell.
    (error "(kotl-mode:move-after): Can’t move tree <1> to within itself")
```
Can be recreated manually. Create a kotl-file with one cell with one word. Split the cell in the middle of the word. Try to demote the new cell that was created. Looking at the cell attributes it looks like the new cell is the same as the original cell where the split started.