### PR TITLE
Add target that controls what byte compile warnings are displayed

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2021-09-20  Mats Lidell  <matsl@gnu.org>
+
+* Makefile (bin-warn): Control what warning messages to get when byte
+    compiling.
+
 2021-09-17  Mats Lidell  <matsl@gnu.org>
 
 * hsettings.el (hyperbole-web-search-browser-function): Relax type to

--- a/Makefile
+++ b/Makefile
@@ -268,7 +268,7 @@ bin: src
 
 # Byte compile files but apply a filter for either including or
 # removing warnings. See variable {C-hv byte-compile-warnings RET} for
-# list if warnings that can be controlled. Default is set to suppress
+# list of warnings that can be controlled. Default is set to suppress
 # warnings for long docstrings.
 #
 # Example for getting warnings for obsolete functions and variables

--- a/Makefile
+++ b/Makefile
@@ -266,6 +266,25 @@ bin: src
 	$(RM) *.elc kotl/*.elc
 	$(EMACS) $(BATCHFLAGS) $(PRELOADS) -f batch-byte-compile $(EL_KOTL) $(EL_COMPILE)
 
+# Byte compile files but apply a filter for either including or
+# removing warnings. See variable {C-hv byte-compile-warnings RET} for
+# list if warnings that can be controlled. Default is set to suppress
+# warnings for long docstrings.
+#
+# Example for getting warnings for obsolete functions and variables
+#   HYPB_WARNINGS="free-vars" make bin-warn
+# Example for surpressing the free-vars warnings
+#   HYPB_WARNINGS="not free-vars" make bin-warn
+ifeq ($(origin HYPB_WARNINGS), undefined)
+HYPB_BIN_WARN = not docstrings
+else ifeq ($(origin HYPB_WARNINGS), environment)
+HYPB_BIN_WARN = ${HYPB_WARNINGS}
+endif
+bin-warn: src
+	$(RM) *.elc kotl/*.elc
+	$(EMACS) $(BATCHFLAGS) $(PRELOADS) --eval="(setq-default byte-compile-warnings '(${HYPB_BIN_WARN}))" \
+		-f batch-byte-compile $(EL_KOTL) $(EL_COMPILE)
+
 tags: TAGS
 TAGS: $(EL_TAGS)
 	$(ETAGS) $(EL_TAGS)


### PR DESCRIPTION
## What 

Add target that controls what byte compile warnings are displayed

## Why

Useful to limit the number of warnings for example when working on reducing a type of warning or to see if there are any warnings of a certain type. 

## Note

For some reason not all types of warnings can be controlled. Not sure why. Maybe because some warnings are closer to bugs than others. So there is no way to get zero output using this technique.