### PR TITLE
Hide docstring warnings when using bin target

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2021-09-26  Mats Lidell  <matsl@gnu.org>
+
+* Makefile (bin): Hide docstring warnings.
+
 2021-09-26  Robert Weiner  <bk@bka-iMac.lan>
 
 * hbut.el (ebut:operate): Rewrote to handle label modification properly and thereby

--- a/Makefile
+++ b/Makefile
@@ -264,7 +264,8 @@ src: autoloads tags
 # which do not yet exist, plus build TAGS file.
 bin: src
 	$(RM) *.elc kotl/*.elc
-	$(EMACS) $(BATCHFLAGS) $(PRELOADS) -f batch-byte-compile $(EL_KOTL) $(EL_COMPILE)
+	$(EMACS) $(BATCHFLAGS) $(PRELOADS) --eval="(setq-default byte-compile-warnings '(not docstrings))" \
+		-f batch-byte-compile $(EL_KOTL) $(EL_COMPILE)
 
 # Byte compile files but apply a filter for either including or
 # removing warnings. See variable {C-hv byte-compile-warnings RET} for


### PR DESCRIPTION
Hide docstring warnings when using bin target