### PR TITLE
Use use-region-p for active region

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,7 @@
-<<<<<<< HEAD
+2021-10-26  Mats Lidell  <matsl@gnu.org>
+
+* hui.el (hui:link-directly): Use use-region-p for active region.
+
 2021-10-17  Bob Weiner  <rsw@gnu.org>
 
 * hpath.el (hpath:symlink-referent): Fix handling of relative symlinks, adding

--- a/hui.el
+++ b/hui.el
@@ -750,7 +750,7 @@ See also documentation for `hui:link-possible-types'."
 		     (hui:hbut-label
 		      (cond ((hmouse-prior-active-region)
 			     hkey-region)
-			    ((marker-position (hypb:mark-marker t))
+			    ((use-region-p)
 			     (hui:hbut-label-default
 			      (region-beginning) (region-end))))
 		      "link-directly"


### PR DESCRIPTION
## What

Use use-region-p for active region

## Why

This solved the problem with strange button names when using `{M-o w}` 

If mark is set is not a good indication if region is active. So we could pick up whatever is between mark and point and use that as a suggested name of the button. With `use-region-p` the region needs to be active which is what we want. (At least I hope this is the best solution. Seems to solve it.)

## Note

There are some code cleanups that I spotted related to this. `hypb:mark-marker` is an XEmacs compatibility function that can be removed. And there are other mark related compatibility code as well. All of these could go now since we only support Emacs. If you agree I will do that in a separate PR.