### PR TITLE
Move backwards to previous cell when starting from invalid pos

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2021-10-31  Mats Lidell  <matsl@gnu.org>
+
+* test/kotl-mode-tests.el (kotl-mode-previous-cell-from-invalid-position)
+    (kotl-mode-backward-cell-from-invalid-position)
+    (kotl-mode-backward-cell-from-invalid-pos-leave-point-in-valid-pos):
+    Test cases for invalid start position before moving backwards.
+
+* kotl/kotl-mode.el (kotl-mode:previous-cell, kotl-mode:backward-cell):
+    Handle case when start pos is invalid.
+
 2021-10-26  Mats Lidell  <matsl@gnu.org>
 
 * hui.el (hui:link-directly): Use use-region-p for active region.

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -1365,6 +1365,12 @@ Return number of cells left to move."
       (kotl-mode:forward-cell (- arg))
     (let ((prior (= arg 0))
 	  (label-sep-len (kview:label-separator-length kview)))
+      (when (not (kview:valid-position-p))
+        (progn
+          (kotl-mode:to-valid-position t)
+          (kotl-mode:beginning-of-cell)
+          (setq arg (1- arg))
+          (setq prior t)))
       (while (and (> arg 0) (setq prior (kcell-view:backward t label-sep-len)))
 	(setq arg (1- arg)))
       (if (or prior (not (called-interactively-p 'interactive)))
@@ -1902,6 +1908,12 @@ Return non-nil iff there is a next tree within this koutline."
       (kotl-mode:next-cell (- arg))
     (let ((previous (= arg 0))
 	  (label-sep-len (kview:label-separator-length kview)))
+      (when (not (kview:valid-position-p))
+        (progn
+          (kotl-mode:to-valid-position t)
+          (kotl-mode:beginning-of-cell)
+          (setq arg (1- arg))
+          (setq previous t)))
       (while (and (> arg 0) (setq previous
 				  (kcell-view:previous t label-sep-len)))
 	(setq arg (1- arg)))


### PR DESCRIPTION
## What

Move backwards to previous cell when starting from invalid pos

## Why

It is more natural to move to the next cell if starting from between two cells, i.e. invalid position. Current behavior is to move to the previous valid cell and then jump to the previous cell. 

This PR counts moving to the previous cell as one step when starting from an invalid position. Test cases for this are added.

## Note

When moving backwards fails the position in the closest cell is kept leaving the point in a valid position. This is considered as a feature for now :smile: 