### PR TITLE
Add orgtbl-mode-map binding for C-d

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2021-11-02  Mats Lidell  <matsl@gnu.org>
+
+* test/kotl-orgtbl-tests.el
+    (kotl-orgtbl-enabled-uses-kotl-mode-delete-char-ouside-of-table):
+    Add test for C-d binding in orgtbl.
+
+* kotl/kotl-mode.el (kotl-mode): Add orgtbl-mode-map binding for C-d.
+
 2021-10-31  Mats Lidell  <matsl@gnu.org>
 
 * test/kotl-mode-tests.el (kotl-mode-previous-cell-from-invalid-position)

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -181,6 +181,9 @@ It provides the following keys:
   (org-defkey orgtbl-mode-map [(meta return)]
 	      (orgtbl-make-binding 'orgtbl-meta-return 106
 				   [(meta return)] "\M-\C-m"))
+  (org-defkey orgtbl-mode-map "\C-d"
+	      (orgtbl-make-binding 'kotl-mode:delete-char 107
+				   "\C-d"))
   (run-hooks 'kotl-mode-hook)
   (add-hook 'change-major-mode-hook #'kotl-mode:show-all nil t))
 

--- a/test/kotl-orgtbl-tests.el
+++ b/test/kotl-orgtbl-tests.el
@@ -1,0 +1,54 @@
+;;; kotl-orgtbl-tests.el --- kotl orgtbl tests            -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2021  Mats Lidell
+
+;; Author: Mats Lidell <matsl@gnu.org>
+;;
+;; Orig-Date: 2-Nov-21 at 17:04:30
+;;
+;; Copyright (C) 2021  Free Software Foundation, Inc.
+;; See the "HY-COPY" file for license information.
+;;
+;; This file is part of GNU Hyperbole.
+
+;;; Commentary:
+
+;; Tests for kotl-orgtbl in "../kotl/kotl-orgtbl.el"
+
+;;; Code:
+
+(require 'ert)
+(require 'kotl-mode "kotl/kotl-mode")
+
+(load (expand-file-name "hy-test-helpers"
+                        (file-name-directory (or load-file-name
+                                                 default-directory))))
+(declare-function hy-test-helpers:consume-input-events "hy-test-helpers")
+
+(ert-deftest kotl-orgtbl-enabled-uses-kotl-mode-delete-char-ouside-of-table ()
+  "kotl-mode:detele-char is used ouside of org table."
+  (let ((kotl-file (make-temp-file "hypb" nil ".kotl")))
+    (unwind-protect
+        (progn
+          (find-file kotl-file)
+          (insert "1")
+
+          ;; Create an org table and leave point at end of cell
+          (should (hact 'kbd-key "RET |-| RET"))
+          (hy-test-helpers:consume-input-events)
+
+          ;; Verify that kotl-mode:delete-char is used outside of the
+          ;; table
+          (condition-case err
+              (progn
+                (should (hact 'kbd-key "C-d"))
+                (hy-test-helpers:consume-input-events))
+            (error
+             (progn
+               (should (equal (car err) 'error))
+               (should (string-match "(kotl-mode:delete-char): End of cell" (cadr err)))))
+            (:success (ert-fail "C-d shall fail when deleting at the end of a cell."))))
+      (delete-file kotl-file))))
+
+(provide 'kotl-orgtbl-tests)
+;;; kotl-orgtbl-tests.el ends here


### PR DESCRIPTION
## What

Add orgtbl-mode-map binding for C-d

## Why

When orgtbl is enabled we need to make sure that kotl-mode:delete-char is used outside of orgtbl to ensure that deletion is within cell boundaries.

## Note

Not sure about the proper use of `org-defkey` and  `orgtbl-make-binding` here but  it  seems to behave properly. 