### PR TITLE
Use mark-marker

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+2021-11-05  Mats Lidell  <matsl@gnu.org>
+
+* hypb.el (hypb:mark-marker): Remove compatibility function, use plain
+    mark-marker instead.
+
+* kotl/kotl-mode.el (kotl-mode:transpose-lines, kotl-mode:yank-pop)
+    (kotl-mode:exchange-point-and-mark, kotl-mode:transpose-lines-internal):
+  hui.el (hui:ebut-create, hui:ebut-edit):
+  hsmail.el (mail-yank-original):
+  hbut.el (ebut:operate):
+  hargs.el (hargs:iforms): Use mark-marker.
+
 2021-11-02  Mats Lidell  <matsl@gnu.org>
 
 * test/kotl-orgtbl-tests.el

--- a/hargs.el
+++ b/hargs.el
@@ -727,7 +727,7 @@ help when appropriate."
 				     prompt)
 				   nil t))))
 	  ;; Get value of mark.  Does not do I/O.
-	  (?m . (integer . (marker-position (hypb:mark-marker t))))
+	  (?m . (integer . (marker-position (mark-marker))))
 	  ;; Get numeric prefix argument or a number from the minibuffer.
 	  (?N . (integer .
 		 (if prefix-arg
@@ -751,7 +751,7 @@ help when appropriate."
 	  (?P . (prefix-arg . prefix-arg))
 	  ;; Get region, point and mark as 2 args.  No I/O
 	  (?r . (region .
-		 (if (marker-position (hypb:mark-marker t))
+		 (if (marker-position (mark-marker))
 		     (list 'args (min (point) (hypb:mark t))
 			   (max (point) (hypb:mark t)))
 		   (list 'args nil nil))))

--- a/hbut.el
+++ b/hbut.el
@@ -357,13 +357,13 @@ button is found in the current buffer."
 						hui:ebut-modify hui:gbut-create
                        				hui:gbut-modify hui:link-create ebut:program))
 			     ;; Ignore action-key-depress-prev-point
-			     (progn (setq mark (marker-position (hypb:mark-marker t))
+			     (progn (setq mark (marker-position (mark-marker))
 					  start (region-beginning)
 					  end (region-end)
 					  buf-lbl (buffer-substring-no-properties start end))
 				    (equal buf-lbl curr-label))
 			   ;; Utilize any action-key-depress-prev-point
-			   (progn (setq mark (marker-position (hypb:mark-marker t)))
+			   (progn (setq mark (marker-position (mark-marker)))
 				  (setq prev-point (and action-key-depress-prev-point
 							(marker-position action-key-depress-prev-point)))
 				  (setq start (if (and prev-point mark (<= prev-point mark))

--- a/hsmail.el
+++ b/hsmail.el
@@ -184,7 +184,7 @@ Use (setq sc-nuke-mail-headers 'all) to have them removed."
 		  ;; the removal.
 		  (or (hypb:supercite-p)
 		      (mail-yank-clear-headers
-		       start (marker-position (hypb:mark-marker t))))
+		       start (marker-position (mark-marker))))
 		  (goto-char start)
 		  (let ((mail-indentation-spaces (if arg (prefix-numeric-value arg)
 						   mail-indentation-spaces))
@@ -220,7 +220,7 @@ Use (setq sc-nuke-mail-headers 'all) to have them removed."
 		  ;; It is cleaner to avoid activation, even though the command
 		  ;; loop would deactivate the mark because we inserted text.
 		  (goto-char (prog1 (hypb:mark t)
-			       (set-marker (hypb:mark-marker t)
+			       (set-marker (mark-marker)
 					   (point) (current-buffer))))
 		  (if (not (eolp)) (insert ?\n))))
 	  (with-current-buffer mail-reply-buffer

--- a/hui.el
+++ b/hui.el
@@ -120,9 +120,9 @@ Default is the current button."
 Indicate button creation by delimiting and adding any necessary instance number to the button label.
 
 For programmatic creation, use `ebut:program' instead."
-  (interactive (list (and (marker-position (hypb:mark-marker t))
+  (interactive (list (and (marker-position (mark-marker))
 			  (region-beginning))
-		     (and (marker-position (hypb:mark-marker t))
+		     (and (marker-position (mark-marker))
 			  (region-end))))
   (let ((default-lbl) lbl but-buf actype)
     (save-excursion
@@ -179,7 +179,7 @@ be entirely within or entirely outside of an existing explicit button.  When
 region is within the button, the button is interactively modified.  Otherwise,
 a new button is created interactively with the region as the default label."
   (interactive)
-  (let ((m (marker-position (hypb:mark-marker t)))
+  (let ((m (marker-position (mark-marker)))
 	(op action-key-depress-prev-point) (p (point)) (lbl-key))
     (if (and m (eq (marker-buffer m) (marker-buffer op))
 	     (< op m) (<= (- m op) (hbut:max-len))

--- a/hypb.el
+++ b/hypb.el
@@ -514,12 +514,6 @@ then `locate-post-command-hook'."
 
 (defalias 'hypb:mark #'mark)
 
-(defun hypb:mark-marker (inactive-p)
-  "Return this buffer's mark as a marker object, or nil if no mark.
-INACTIVE-P is unused, it is for compatibility with XEmacs' version of
-`mark-marker'."
-  (mark-marker))
-
 ;;;###autoload
 (defun hypb:map-plist (func plist)
   "Return result of applying FUNC of two args, key and value, to key-value pairs in PLIST, a property list."

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -895,7 +895,7 @@ that contains mark."
    ;; Transpose point and mark lines, leaving point on the line of text that
    ;; originally contained point.
    ((= arg 0)
-    (kotl-mode:transpose-lines-internal (point-marker) (hypb:mark-marker t))
+    (kotl-mode:transpose-lines-internal (point-marker) (mark-marker))
     (kotl-mode:exchange-point-and-mark))
    ;;
    ;; Move previous line past ARG next lines and leave point after previous
@@ -1331,7 +1331,7 @@ doc string for `insert-for-yank-1', which see."
     (if before
 	(funcall (or yank-undo-function 'delete-region) (point) (mark t))
       (funcall (or yank-undo-function 'delete-region) (mark t) (point)))
-    (set-marker (hypb:mark-marker t) (point) (current-buffer))
+    (set-marker (mark-marker) (point) (current-buffer))
     (let* ((yank-text (current-kill arg))
 	   (indent (kcell-view:indent))
 	   (indent-str (make-string indent ?\ )))
@@ -2862,7 +2862,7 @@ Does not delete newline at end of line."
   "Put the mark where point is now, and point where the mark is now.
 This is like `exchange-point-and-mark', but doesn't activate the mark."
   (goto-char (prog1 (hypb:mark t)
-	       (set-marker (hypb:mark-marker t) (point) (current-buffer)))))
+	       (set-marker (mark-marker) (point) (current-buffer)))))
 
 (defun kotl-mode:indent-line (&optional arg)
   "Indent line relative to the previous one.
@@ -3113,10 +3113,10 @@ Leave point at end of line now residing at START."
     ;; Set non-point and non-mark markers to point nowhere before signalling
     ;; an error.
     (or (eq start (point-marker))
-	(eq start (hypb:mark-marker t))
+	(eq start (mark-marker))
 	(set-marker start nil))
     (or (eq end (point-marker))
-	(eq end (hypb:mark-marker t))
+	(eq end (mark-marker))
 	(set-marker start nil))
     (error "(kotl-mode:transpose-lines): Point or mark is at an invalid position")))
 


### PR DESCRIPTION
## What 

Use mark-marker

## Why

Removes the hypb:mark-marker function that is a compatibility with XEmacs function and is thus not needed..