### PR TITLE
Make test smart-menu-loads-kotl-example stable

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2021-11-05  Mats Lidell  <matsl@gnu.org>
 
+* test/kotl-mode-tests.el (smart-menu-loads-kotl-example): Add extra no op
+    input char to make test case stable.
+
 * hypb.el (hypb:mark-marker): Remove compatibility function, use plain
     mark-marker instead.
 

--- a/test/kotl-mode-tests.el
+++ b/test/kotl-mode-tests.el
@@ -38,7 +38,9 @@
   "Loading kotl-mode example file works."
   (skip-unless (not noninteractive))
   (setup-kotl-mode-example-test
-   (should (hact 'kbd-key "C-h h k e"))
+   ;; The additional no op key C-a below avoids ert results window to
+   ;; be set as current
+   (should (hact 'kbd-key "C-h h k e C-a"))
    (hy-test-helpers:consume-input-events)))
 
 (ert-deftest kotl-mode-example-loads-kotl-example ()


### PR DESCRIPTION
## What

Make test smart-menu-loads-kotl-example stable

## Why

Seems the `ert results buffer` gets selected sometimes (or even always not with emacs 29.0.50) for this test case. Use a trick with an additional input that makes it work on my machine. Not sure why the ert buffer comes in and breaks only this test case but it does. Should probably have another solution but don't know what that is and having test cases that break is a bad thing.