### PR TITLE
Add binding for shift tab in orgtbl map to allow demote of tree

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2021-11-08  Mats Lidell  <matsl@gnu.org>
+
+* test/kotl-orgtbl-tests.el (kotl-orgtbl-action-key-on-vertical-bar-toggles-orgtbl-mode)
+    (kotl-orgtbl-shift-tab-demotes-tree-outside-table): Add tests.
+
+* kotl/kotl-mode.el (kotl-mode): Change binding for orgtbl C-d to use new
+    uniq command name, add binding for orgtbl shift tab to provide demote
+    tree outside of table.
+
 2021-11-07  Bob Weiner  <rsw@gnu.org>
 
 * hypb.el (hypb:mark): Remove and use builtin mark function.

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -176,14 +176,17 @@ It provides the following keys:
   ;; same funcitonality when in a table, but may also be invoked from
   ;; a mouse button.
   (org-defkey orgtbl-mode-map "\M-\C-m"
-	      (orgtbl-make-binding 'orgtbl-meta-return 105
-				   "\M-\C-m" [(meta return)]))
+              (orgtbl-make-binding 'orgtbl-meta-return 105
+        			   "\M-\C-m" [(meta return)]))
   (org-defkey orgtbl-mode-map [(meta return)]
-	      (orgtbl-make-binding 'orgtbl-meta-return 106
-				   [(meta return)] "\M-\C-m"))
+              (orgtbl-make-binding 'orgtbl-meta-return 106
+        			   [(meta return)] "\M-\C-m"))
   (org-defkey orgtbl-mode-map "\C-d"
-	      (orgtbl-make-binding 'kotl-mode:delete-char 107
-				   "\C-d"))
+              (orgtbl-make-binding 'kotl-mode:delete-char 201
+        			   "\C-d"))
+  (org-defkey orgtbl-mode-map [(shift iso-lefttab)]
+              (orgtbl-make-binding 'org-shifttab 202
+        			   [(shift iso-lefttab)] [backtab] [(shift tab)]))
   (run-hooks 'kotl-mode-hook)
   (add-hook 'change-major-mode-hook #'kotl-mode:show-all nil t))
 


### PR DESCRIPTION
## What

Add binding for shift tab in orgtbl map to allow demote of tree

## Why

Shift tab should demote tree if outside of an org table

## Note

* I noticed that the binding for C-d could clash with other generated unique functions using 107 so switched to new series starting with 201.
* The C-d binding should really bind to org-delete-char but seems that if point is at the end of the table but not at the end of the cell it is still the ord binding that kicks in. That is dangerous since user can deleted passed the cell boundary. So for now I'm keeping the binding to force it to use `kotl-mode:delete-char` since that seems to be the lesser evil alternativ.
* Not sure the suggested shift-tab-binding covers all cases for all systems but seems to work for me both in GUI and terminal mode.