### PR TITLE
Broken test cases

### DIFF
--- a/test/hmouse-drv-tests.el
+++ b/test/hmouse-drv-tests.el
@@ -180,7 +180,7 @@
     (goto-char 3)
     (with-simulated-input "TMP RET"
       (hui:ibut-label-create)
-      (should (string= "<[TMP]> \"/tmp\"\n" (buffer-string))))))
+      (should (string= "\"/<[TMP]> tmp\"\n" (buffer-string))))))
 
 (ert-deftest hbut-ib-create-label-fails-if-label-exists ()
   "Creation of a label for an implicit button fails if a label exists."

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -32,7 +32,7 @@
     (goto-char 3)
     (with-simulated-input "TMP RET"
       (hui:ibut-label-create)
-      (should (string= "<[TMP]> \"/tmp\"\n" (buffer-string))))))
+      (should (string= "\"/<[TMP]> tmp\"\n" (buffer-string))))))
 
 (ert-deftest hui-ibut-label-create-fails-if-label-exists ()
   "Creation of a label for an implicit button fails if a label exists."

--- a/test/smart-org-tests.el
+++ b/test/smart-org-tests.el
@@ -60,7 +60,7 @@
       (org-mode)
       (insert "/tmp")
       (goto-char 1)
-      (hy-test-helpers:hypb-function-should-call-hpath:find 'smart-org "/tmp"))))
+      (hy-test-helpers:hypb-function-should-call-hpath:find 'smart-org "/tmp/"))))
 
 ;; Org Link
 (ert-deftest smart-org-mode-with-smart-keys-on-org-link-activates ()
@@ -94,7 +94,7 @@
       (org-mode)
       (insert "/tmp")
       (goto-char 1)
-      (hy-test-helpers:hypb-function-should-call-hpath:find 'action-key "/tmp"))))
+      (hy-test-helpers:hypb-function-should-call-hpath:find 'action-key "/tmp/"))))
 
 ;; Org Link
 (ert-deftest smart-org-mode-with-smart-keys-buttons-on-org-link-calls-org-meta-return ()


### PR DESCRIPTION
## What

Regression with latest changes on master. These test cases a broken after the latest changes on master. 

1.  ibut labels are not inserted at the right place. Seems point it not moved out of the ibut. Instead label are inserted where point is.
2. Action key on /tmp call hpath-find with /tmp/. This might be the expected behavior and test case should be updated?

## Note
Not filing as normal PR. Only for reporting this issue for discussion. 