### PR TITLE
Add test for buttons in ls R listing

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2021-12-11  Mats Lidell  <matsl@gnu.org>
+
+* test/hpath-tests.el (hypb-run-shell-test-command): Test helper for
+    running shell commands.
+    (hpath:prepend-ls-directory-test): Test for "ls R" listing.
+
 2021-12-05  Bob Weiner  <rsw@gnu.org>
 
 * hyrolo.el (hyrolo-next-match): Handle case when no prior regexp search.

--- a/test/hpath-tests.el
+++ b/test/hpath-tests.el
@@ -18,6 +18,11 @@
 (require 'ert)
 (require 'hpath)
 
+(load (expand-file-name "hy-test-helpers"
+                        (file-name-directory (or load-file-name
+                                                 default-directory))))
+(declare-function hy-test-helpers:action-key-should-call-hpath:find "hy-test-helpers")
+
 (ert-deftest hpath:find-report-lisp-variable-path-name-when-not-exists ()
   "Test that hpath:find expands and returns filename when it is non-existent."
   (condition-case err
@@ -102,6 +107,26 @@
          (should (string= (hpath:substitute-value "$UNDEFINED_IS_NOT_SUBSTITUTED") "$UNDEFINED_IS_NOT_SUBSTITUTED"))
          (should (string= (hpath:substitute-value "${UNDEFINED_IS_NOT_SUBSTITUTED}") "${UNDEFINED_IS_NOT_SUBSTITUTED}"))
          ))
+
+(defun hypb-run-shell-test-command (command buffer)
+  "Run a shell COMMAND with output to BUFFER and select it."
+  (shell-command command buffer nil)
+  (switch-to-buffer buffer)
+  (shell-mode))
+
+(ert-deftest hpath:prepend-ls-directory-test ()
+  "Find file in ls -R listing."
+  (let ((shell-buffer "*hypb-test-shell-buffer*"))
+    (unwind-protect
+        (let ((explicit-shell-file-name "/usr/bin/sh")
+              (default-directory hyperb:dir))
+          (hypb-run-shell-test-command "ls -R" shell-buffer)
+          (dolist (file '("COPYING" "man/version.texi" "man/hkey-help.txt" "man/im/demo.png"))
+            (goto-char (point-min))
+            (search-forward (car (last (split-string file "/"))))
+            (backward-char 5)
+            (hy-test-helpers:action-key-should-call-hpath:find (expand-file-name file hyperb:dir))))
+      (kill-buffer shell-buffer))))
 
 (provide 'hpath-tests)
 ;;; hpath-tests.el ends here

--- a/test/hpath-tests.el
+++ b/test/hpath-tests.el
@@ -123,7 +123,7 @@
           (hypb-run-shell-test-command "ls -R" shell-buffer)
           (dolist (file '("COPYING" "man/version.texi" "man/hkey-help.txt" "man/im/demo.png"))
             (goto-char (point-min))
-            (search-forward (car (last (split-string file "/"))))
+            (should (search-forward (car (last (split-string file "/"))) nil t))
             (backward-char 5)
             (hy-test-helpers:action-key-should-call-hpath:find (expand-file-name file hyperb:dir))))
       (kill-buffer shell-buffer))))


### PR DESCRIPTION
## What 

Add test for buttons in ls R listing

## Why 

Tests are needed!

## Note

The `ls -R` listing seems to result in a one column only listing. We should have tests also where the listing produces multiple columns of files but this was so far I got with this today.