### PR TITLE
Remove wrapped closing parens

### DIFF
--- a/hargs.el
+++ b/hargs.el
@@ -346,8 +346,7 @@ Handles all of the interactive argument types that `hargs:iform-read' does."
 	       ;; Possibly non-existent file name
 	       ((when no-default (hpath:at-p 'file 'non-exist)))
 	       (no-default nil)
-	       ((buffer-file-name))
-	       ))
+	       ((buffer-file-name))))
 	((eq hargs:reading-p 'directory)
 	 (cond ((derived-mode-p 'dired-mode)
 		(let ((dir (dired-get-filename nil t)))
@@ -360,12 +359,10 @@ Handles all of the interactive argument types that `hargs:iform-read' does."
 	       ;; Possibly non-existent directory name
 	       ((when no-default (hpath:at-p 'directory 'non-exist)))
 	       (no-default nil)
-	       (default-directory)
-	       ))
+	       (default-directory)))
 	((eq hargs:reading-p 'string)
 	 (or (hargs:delimited "\"" "\"") (hargs:delimited "'" "'")
-	     (hargs:delimited "`" "'")
-	     ))
+	     (hargs:delimited "`" "'")))
 	((or (eq hargs:reading-p 'actype)
 	     (eq hargs:reading-p 'actypes))
 	 (let ((name (hargs:find-tag-default)))
@@ -763,8 +760,7 @@ help when appropriate."
 	  ;; Get Lisp expression but don't evaluate.
 	  (?x . (sexpression . (read-minibuffer prompt default)))
 	  ;; Get Lisp expression and evaluate.
-	  (?X . (sexpression . (eval-minibuffer prompt default)))
-	  ))
+	  (?X . (sexpression . (eval-minibuffer prompt default)))))
 
 (defvar hargs:iform-vector nil
   "Vector of forms for each interactive command character code.")

--- a/hbut.el
+++ b/hbut.el
@@ -812,8 +812,7 @@ Suitable for use as part of `write-file-functions'."
 		 ;; never holding a buffer which is out of sync with file,
 		 ;; due to some other user's edits.
 		 ;; Maybe this should be user or site configurable.
-		 (or (buffer-modified-p buf) (kill-buffer buf))
-		 )))))
+		 (or (buffer-modified-p buf) (kill-buffer buf)))))))
   ;; Must return nil, so can be used as part of write-file-functions.
   nil)
 
@@ -934,8 +933,7 @@ Ignore email-related buffers."
 	    (goto-char (+ (point) (- end start)))
 	    (if (not (eq (following-char) ?\ ))
 		(insert ?\ ))
-	    (insert comment-end)
-	    )))))
+	    (insert comment-end))))))
 
 ;;; Regexps derived in part from "filladapt.el" by Kyle E. Jones under
 ;;; the GPL.
@@ -961,8 +959,7 @@ Ignore email-related buffers."
     ;; Fortran comments
     "\n[Cc][ \t]+"
     ;; Postscript comments
-    "\n[ \t]*\\(%+[ \t]*\\)+"
-    )
+    "\n[ \t]*\\(%+[ \t]*\\)+")
   "List of regexps of fill prefixes to remove from the middle of buttons.")
 
 (defun    hbut:fill-prefix-remove (label)

--- a/hgnus.el
+++ b/hgnus.el
@@ -93,8 +93,7 @@ as ARG means don't indent and don't delete any header fields."
       (interactive "P")
       (mail-yank-original arg)
       (exchange-point-and-mark)
-      (run-hooks 'news-reply-header-hook))
-  )
+      (run-hooks 'news-reply-header-hook)))
 
 ;;; ************************************************************************
 ;;; Private variables

--- a/hib-doc-id.el
+++ b/hib-doc-id.el
@@ -196,8 +196,7 @@ Also display standard Hyperbole help for implicit button BUT."
 	(set-buffer-modified-p nil)
 	(setq buffer-read-only nil)
 	(goto-char (point-min)))
-      (kill-buffer report-buf)
-      )))
+      (kill-buffer report-buf))))
 
 (provide 'hib-doc-id)
 

--- a/hib-social.el
+++ b/hib-social.el
@@ -237,8 +237,7 @@
     ("\\`\\(gl\\|gitlab\\)\\'"    . "https://www.gitlab.com/%s/%s/%s%s")
     ("\\`\\(gt\\|git\\)\\'"       . "(cd %s && git %s %s)")
     ("\\`\\(in\\|instagram\\)\\'" . "https://www.instagram.com/explore/tags/%s/")
-    ("\\`\\(tw\\|twitter\\)\\'"   . "https://twitter.com/search?q=%%23%s&src=hashtag")
-)
+    ("\\`\\(tw\\|twitter\\)\\'"   . "https://twitter.com/search?q=%%23%s&src=hashtag"))
   "Alist of (social-media-service-regexp  . expression-to-display-hashtag-reference) elements.")
 
 (defconst hibtypes-social-username-alist
@@ -246,8 +245,7 @@
     ("\\`\\(gh\\|github\\)\\'"    . "https://github.com/%s/")
     ("\\`\\(gl\\|gitlab\\)\\'"    . "https://www.gitlab.com/%s/")
     ("\\`\\(in\\|instagram\\)\\'" . "https://www.instagram.com/%s/")
-    ("\\`\\(tw\\|twitter\\)\\'"   . "https://twitter.com/search?q=@%s")
-    )
+    ("\\`\\(tw\\|twitter\\)\\'"   . "https://twitter.com/search?q=@%s"))
   "Alist of (social-media-service-regexp  . url-with-%s-for-username) elements.")
 
 ;; Assume at least a 2-character project name

--- a/hinit.el
+++ b/hinit.el
@@ -91,8 +91,7 @@
 	    (or (file-writable-p hbmap:dir-user)
 		(or (progn (hypb:chmod '+ 700 hbmap:dir-user)
 			   (file-writable-p hbmap:dir-user))
-		    (error "(hyperb:init): Can't write to 'hbmap:dir-user'")
-		    )))
+		    (error "(hyperb:init): Can't write to 'hbmap:dir-user'"))))
 	   (t (error "(hyperb:init): `hbmap:dir-user' create failed"))))))
   t)
 

--- a/hmail.el
+++ b/hmail.el
@@ -245,8 +245,7 @@ Signals error when current mail reader is not supported."
 		;; Found matching msg
 		(buffer-substring (match-beginning 2) (match-end 2))))
 	;; (rmail:msg-hdrs-full toggled)
-	()
-	))))
+	()))))
 
 ;;; ------------------------------------------------------------------------
 ;;; Each mail reader-specific Hyperbole support module must also define

--- a/hmh.el
+++ b/hmh.el
@@ -61,8 +61,7 @@
   (defalias 'rmail:summ-msg-to   'mh-goto-msg)
   (defalias 'rmail:summ-new      'mh-rescan-folder)
   (if (called-interactively-p 'interactive)
-      (message "Hyperbole MH mail reader support initialized."))
-  )
+      (message "Hyperbole MH mail reader support initialized.")))
 
 (defun Mh-hbut-highlight ()
   "Highlight any Hyperbole buttons in buffer for which display support exists."
@@ -70,8 +69,7 @@
 
 (defun Mh-msg-hdrs-full (toggled)
   "If TOGGLED is non-nil, toggle full/hidden headers, else show full headers.
-For now, a no-op."
-  )
+For now, a no-op.")
 
 (defun Mh-msg-narrow ()
   "Narrow mail reader buffer to current message.

--- a/hmouse-drv.el
+++ b/hmouse-drv.el
@@ -980,8 +980,7 @@ Return non-nil iff associated help documentation is found."
 				     (actype:doc 'hbut:current t)))
 		      (hattr:report
 		       (nthcdr 2 (hattr:list 'hbut:current))))
-		    (terpri)
-		    ))
+		    (terpri)))
 		"")
 	    (message "No %s Key command for current context."
 		     (if assisting "Assist" "Action"))))

--- a/hmouse-sh.el
+++ b/hmouse-sh.el
@@ -85,8 +85,7 @@ Use nil as cmd values to unbind a key.  Works under GNU Emacs only."
 	   [left-fringe down-mouse-5]
 	   [right-fringe down-mouse-5]
 	   [vertical-line down-mouse-5]
-	   [mode-line down-mouse-5])
-	  )))
+	   [mode-line down-mouse-5]))))
 	   
   (hmouse-set-key-list
    release-cmd
@@ -155,8 +154,7 @@ Use nil as cmd values to unbind a key.  Works under GNU Emacs only."
 	   [vertical-line drag-mouse-5]
 	   [vertical-line mouse-5]
 	   [mode-line drag-mouse-5]
-	   [mode-line mouse-5])
-	  ))))
+	   [mode-line mouse-5])))))
 
 (defun hmouse-bind-shifted-key-emacs (shifted-mouse-key-number depress-cmd release-cmd)
   "Ensure SHIFTED-MOUSE-KEY-NUMBER (1-5), e.g. 1 for [Smouse-1], is bound to DEPRESS-CMD and RELEASE-CMD (includes depresses and drags).
@@ -193,8 +191,7 @@ Use nil as CMD value to unbind the key.  Works under GNU Emacs only."
 	   [left-fringe S-down-mouse-5]
 	   [right-fringe S-down-mouse-5]
 	   [vertical-line S-down-mouse-5]
-	   [mode-line S-down-mouse-5])
-	  )))
+	   [mode-line S-down-mouse-5]))))
 	  
   (hmouse-set-key-list
    release-cmd
@@ -263,8 +260,7 @@ Use nil as CMD value to unbind the key.  Works under GNU Emacs only."
 	   [vertical-line S-drag-mouse-5]
 	   [vertical-line S-mouse-5]
 	   [mode-line S-drag-mouse-5]
-	   [mode-line S-mouse-5])
-	  ))))
+	   [mode-line S-mouse-5])))))
 	   
 (defun hmouse-get-bindings (hmouse-middle-flag)
   "Return the list of active bindings of mouse keys used by Hyperbole.
@@ -304,8 +300,7 @@ These may be the bindings prior to initializing Hyperbole or the Hyperbole bindi
 		   [mode-line S-down-mouse-1] [mode-line S-drag-mouse-1]
 		   [mode-line S-mouse-1]
 		   [mode-line S-down-mouse-2] [mode-line S-drag-mouse-2]
-		   [mode-line S-mouse-2]
-		   )
+		   [mode-line S-mouse-2])
 	       ;; X, macOS or MS Windows
 	       '([S-down-mouse-2] [S-drag-mouse-2] [S-mouse-2]
 		 [S-down-mouse-3] [S-drag-mouse-3] [S-mouse-3]
@@ -330,8 +325,7 @@ These may be the bindings prior to initializing Hyperbole or the Hyperbole bindi
 		 [mode-line S-down-mouse-2] [mode-line S-drag-mouse-2]
 		 [mode-line S-mouse-2]
 		 [mode-line S-down-mouse-3] [mode-line S-drag-mouse-3]
-		 [mode-line S-mouse-3]
-		 )))
+		 [mode-line S-mouse-3])))
      (nconc
       (mapcar (lambda (key)
 		(cons key (key-binding key)))
@@ -369,20 +363,17 @@ These may be the bindings prior to initializing Hyperbole or the Hyperbole bindi
 	    [mode-line down-mouse-2] [mode-line drag-mouse-2]
 	    [mode-line mouse-2]
 	    [mode-line down-mouse-3] [mode-line drag-mouse-3]
-	    [mode-line mouse-3]
-	    )))
+	    [mode-line mouse-3])))
   (nconc
    (mapcar (lambda (key)
 	     (cons key (key-binding key)))
 	   '([button2] [button2up]
-	     [button3] [button3up]
-	     ))
+	     [button3] [button3up]))
    (when (boundp 'mode-line-map)
      (mapcar (function
 	      (lambda (key)
 		(cons key (lookup-key mode-line-map key))))
-	     '([button3] [button3up])))
-   ))
+	     '([button3] [button3up])))))
 
 ;; Based on a function from Emacs mouse.el.
 (defun hmouse-posn-set-point (position)

--- a/hpath.el
+++ b/hpath.el
@@ -395,8 +395,7 @@ See the function `hpath:get-external-display-alist' for detailed format document
 			(Info-find-node file "*" nil t))
 		    (error "Invalid file"))))))
 
-      '("\\.rdb\\'" . rdb:initialize)
-      )))
+      '("\\.rdb\\'" . rdb:initialize))))
   "*Alist of (FILENAME-REGEXP . EDIT-FUNCTION) elements for calling special
 functions to display particular file types within Emacs.  See also
 the function (hpath:get-external-display-alist) for external display program settings."
@@ -766,8 +765,7 @@ Always returns nil if (hpath:remote-available-p) returns nil."
 	       ;; host and path
 	       ((and (looking-at "/\\([^/:@ \t\n\r\"`'|]+:[^]@:, \t\n\r\"`'|\)\}]+\\)")
 		     (setq path (match-string-no-properties 1)))
-		(concat "/" user "@" path))
-	       )))
+		(concat "/" user "@" path)))))
       (hpath:delete-trailer path))))
 
 (defun hpath:remote-p (path)
@@ -835,8 +833,7 @@ Always returns nil if (hpath:remote-available-p) returns nil."
 		       "/\\([^/:@ \t\n\r\"`'|]+:[^]@:, \t\n\r\"`'|\)\}]*\\)"
 		       path)
 		      (setq result (match-string-no-properties 1 path)))
-		 (concat "/" user "@" result))
-		))
+		 (concat "/" user "@" result))))
 	 (hpath:delete-trailer result))))
 
 (defun hpath:at-p (&optional type non-exist)
@@ -1767,8 +1764,7 @@ If `/~' appears, all of FILENAME through that `/' is discarded."
        "\\(/\\|[^a-zA-Z0-9]\\)?\\(https?\\|ftp\\|telnet\\|news\\|nntp\\):[/~]"
        filename)
       (substring filename (match-beginning 2))
-    (hyperb:substitute-in-file-name filename)))
-))))
+    (hyperb:substitute-in-file-name filename)))))))
 
 (defun hpath:enable-find-file-urls ()
   "Enable the use of ftp and www Urls as arguments to `find-file' commands."

--- a/hrmail.el
+++ b/hrmail.el
@@ -65,8 +65,7 @@
   (defalias 'rmail:summ-msg-to   'rmail-summary-goto-msg)
   (defalias 'rmail:summ-new      'rmail-new-summary)
   (if (called-interactively-p 'interactive)
-      (message "Hyperbole RMAIL mail reader support initialized."))
-  )
+      (message "Hyperbole RMAIL mail reader support initialized.")))
 
 (defun Rmail-msg-hdrs-full (toggled)
   "If TOGGLED is non-nil, toggle full/hidden headers, else show full headers."

--- a/htz.el
+++ b/htz.el
@@ -270,8 +270,7 @@ Optional argument TIMEZONE specifies a time zone."
 	  (capitalize (car (rassq month htz:months-assoc)))
 	  (- year (* (/ year 100) 100))	;1990 -> 90
 	  time
-	  (if timezone (concat " " timezone) "")
-	  ))
+	  (if timezone (concat " " timezone) "")))
 
 (defun htz:date-make-unix (year month day time &optional timezone)
   "Approximate Unix date format from YEAR, MONTH, DAY, and TIME.

--- a/hui-jmenu.el
+++ b/hui-jmenu.el
@@ -133,8 +133,7 @@
     "----"
     ["Pop-from-Ring"      hywconfig-delete-pop      (not (hywconfig-ring-empty-p))]
     ["Save-to-Ring"       hywconfig-ring-save       t]
-    ["Yank-from-Ring"     hywconfig-yank-pop        (not (hywconfig-ring-empty-p))]
-    ))
+    ["Yank-from-Ring"     hywconfig-yank-pop        (not (hywconfig-ring-empty-p))]))
 
 ;;; ************************************************************************
 ;;; Private functions

--- a/hui-menu.el
+++ b/hui-menu.el
@@ -63,8 +63,7 @@
 	  ["Toggle-URLs-in-New-Window"
 	   (setq browse-url-new-window-flag (not browse-url-new-window-flag))
 	   :style toggle
-	   :selected browse-url-new-window-flag]
-	  )))
+	   :selected browse-url-new-window-flag])))
 
 ;; List explicit buttons in the current buffer for menu activation.
 (defun hui-menu-explicit-buttons (rest-of-menu)
@@ -232,8 +231,7 @@ Return t if cutoff, else nil."
 	     ["Ignore"
 	      (customize-save-variable 'hsys-org-enable-smart-keys nil)
 	      :style radio :selected (when (boundp 'hsys-org-enable-smart-keys)
-					(eq hsys-org-enable-smart-keys nil))]
-	     ))
+					(eq hsys-org-enable-smart-keys nil))]))
 	  '("----")
 	  '(("Smart-Key-Press-at-Eol"
 	     "----"
@@ -248,8 +246,7 @@ Return t if cutoff, else nil."
 	     ["Scrolls-Proportionally"
 	      (setq smart-scroll-proportional t)
 	      :style radio :selected (when (boundp 'smart-scroll-proportional)
-				       smart-scroll-proportional)]
-	     ))
+				       smart-scroll-proportional)]))
 	  '("----"
 	    ["Toggle-Isearch-Invisible-Text" hypb:toggle-isearch-invisible
 	     :visible (boundp 'isearch-invisible)
@@ -262,8 +259,7 @@ Return t if cutoff, else nil."
 					  (listp hyrolo-add-hook)
 					  (memq 'hyrolo-set-date hyrolo-add-hook))]
 	    ["Toggle-Smart-Key-Debug (HyDebug)" hkey-toggle-debug
-	     :style toggle :selected hkey-debug]
-	    ))
+	     :style toggle :selected hkey-debug]))
   "Untitled menu of Hyperbole options.")
 
 (defvar infodock-hyperbole-menu nil)
@@ -345,8 +341,7 @@ REBUILD-FLAG is non-nil, in which case the menu is rebuilt."
 		   ["Edit-Per-Directory-File" (find-file hbmap:filename) t]
 		   ["Edit-Personal-File" (find-file
 					  (expand-file-name
-					   hbmap:filename hbmap:dir-user)) t]
-		   )
+					   hbmap:filename hbmap:dir-user)) t])
 		 (cons "Customize" hui-menu-options)
 		 '("Documentation"
 		   ["Manual"      (id-info "(hyperbole)Top") t]
@@ -366,8 +361,7 @@ REBUILD-FLAG is non-nil, in which case the menu is rebuilt."
 		    ["Show-Action-Types"
 		     (hui:htype-help-current-window 'actypes) t]
 		    ["Show-Implicit-Button-Types"
-		     (hui:htype-help-current-window 'ibtypes 'no-sort) t]
-		    ))
+		     (hui:htype-help-current-window 'ibtypes 'no-sort) t]))
 		 '("Explicit-Button"
 		   :filter hui-menu-explicit-buttons
 		   ["Activate" hui:ebut-act t]
@@ -379,14 +373,12 @@ REBUILD-FLAG is non-nil, in which case the menu is rebuilt."
 		    "----"
 		    ["Buffer-Buttons"   (hui:hbut-report -1) t]
 		    ["Current-Button"   (hui:hbut-report)    t]
-		    ["Ordered-Buttons"  (hui:hbut-report 1)  t]
-		    )
+		    ["Ordered-Buttons"  (hui:hbut-report 1)  t])
 		   ["Modify" hui:ebut-modify t]
 		   ["Rename" hui:ebut-rename t]
 		   ["Search" hui:ebut-search t]
 		   ["Types"
-		    (hui:htype-help-current-window 'actypes) t]
-		   )
+		    (hui:htype-help-current-window 'actypes) t])
 		 (append
 		  '("Find"
 		    ["Manual"   (id-info-item "menu, Find") t]
@@ -405,8 +397,7 @@ REBUILD-FLAG is non-nil, in which case the menu is rebuilt."
 		    ["Save-Lines-Here"      hypb:save-lines t]
 		    "----"
 		    "Web-Search:")
-		  (hui-menu-web-search)
-		  )
+		  (hui-menu-web-search))
 		 '("Global-Button"
 		   :filter hui-menu-global-buttons
 		   ["Create" hui:gbut-create t]
@@ -414,8 +405,7 @@ REBUILD-FLAG is non-nil, in which case the menu is rebuilt."
 		   ["Edit"   hui:gbut-modify t]
 		   ["Help"   gbut:help t]
 		   ["Modify" hui:gbut-modify t]
-                   ["Rename" hui:gbut-rename t]
-		   )
+                   ["Rename" hui:gbut-rename t])
 		 '("Implicit-Button"
 		   ["Manual"   (id-info "(hyperbole)Implicit Buttons") t]
 		   "----"
@@ -424,8 +414,7 @@ REBUILD-FLAG is non-nil, in which case the menu is rebuilt."
 		   ["Help"   hui:hbut-help t]
 		   ["Label"  hui:ibut-label-create t]
 		   ["Rename" hui:ibut-rename t]
-		   ["Types"  (hui:htype-help 'ibtypes 'no-sort) t]
-		   )
+		   ["Types"  (hui:htype-help 'ibtypes 'no-sort) t])
 		 '("Koutliner"
 		   ["Manual" (id-info "(hyperbole)Koutliner") t]
 		   ["Example"   kotl-mode:example t]
@@ -446,8 +435,7 @@ REBUILD-FLAG is non-nil, in which case the menu is rebuilt."
 					  (kcell-view:label)))
 		    (eq major-mode 'kotl-mode)]
 		   ["Show-Top-Level-Only" kotl-mode:hide-body
-		    (eq major-mode 'kotl-mode)]
-		   )
+		    (eq major-mode 'kotl-mode)])
 		 '("Mail-Lists"
 		   ["Manual" (id-info "(hyperbole)Suggestion or Bug Reporting")
 		    t]
@@ -469,8 +457,7 @@ REBUILD-FLAG is non-nil, in which case the menu is rebuilt."
 				   "Just send the message; subject and body are ignored.") t]
 		   ["Leave-Hyperbole-Bug-Report-List"
 		    (hmail:compose "bug-hyperbole-leave@gnu.org" nil
-				   "Just send the message; subject and body are ignored.") t]
-		   )
+				   "Just send the message; subject and body are ignored.") t])
 		 infodock-hyrolo-menu
 		 '("Screen (HyControl)" :filter hui-menu-screen)
 		 hui-menu-hywconfig)))))

--- a/hui-mini.el
+++ b/hui-mini.el
@@ -527,8 +527,7 @@ constructs.  If not given, the top level Hyperbole menu is used."
 		'("Screen/"     (menu . screen)
 		  "Screen display management commands.")
 		'("Win/"        (menu . win)
-		  "Window configuration management commands.")
-		))))
+		  "Window configuration management commands.")))))
        '(butfile .
 	 (("Butfile>")
 	  ("DirFile"      (find-file hbmap:filename)
@@ -538,8 +537,7 @@ constructs.  If not given, the top level Hyperbole menu is used."
 	   "Displays manual section on button files.")
 	  ("PersonalFile" (find-file
 			    (expand-file-name hbmap:filename hbmap:dir-user))
-	   "Edits user-specific button file.")
-	  ))
+	   "Edits user-specific button file.")))
        '(cust .
          (("Cust>")
 	  ("All-Options" (customize-browse 'hyperbole)
@@ -605,8 +603,7 @@ constructs.  If not given, the top level Hyperbole menu is used."
 	  ("EWW" (setq browse-url-browser-function #'eww-browse-url))
 	  ("Firefox" (setq browse-url-browser-function #'browse-url-firefox))
 	  ("KDE" (setq browse-url-browser-function #'browse-url-kde))
-	  ("XTerm" (setq browse-url-browser-function #'browse-url-text-xterm))
-	  ))
+	  ("XTerm" (setq browse-url-browser-function #'browse-url-text-xterm))))
        '(cust-web .
          (("Web Search>")
 	  ("Chrome" (setq hyperbole-web-search-browser-function #'browse-url-chrome))
@@ -617,8 +614,7 @@ constructs.  If not given, the top level Hyperbole menu is used."
 	  ("EWW" (setq hyperbole-web-search-browser-function #'eww-browse-url))
 	  ("Firefox" (setq hyperbole-web-search-browser-function #'browse-url-firefox))
 	  ("KDE" (setq hyperbole-web-search-browser-function #'browse-url-kde))
-	  ("XTerm" (setq hyperbole-web-search-browser-function #'browse-url-text-xterm))
-	  ))
+	  ("XTerm" (setq hyperbole-web-search-browser-function #'browse-url-text-xterm))))
        '(doc .
 	 (("Doc>")
 	  ("About"        (hypb:display-file-with-logo
@@ -643,8 +639,7 @@ constructs.  If not given, the top level Hyperbole menu is used."
 	  ("Types/"       (menu . types)
 	   "Provides documentation on Hyperbole types.")
 	  ("WhyUse"       (find-file (expand-file-name "HY-WHY.kotl" hyperb:dir))
-	   "Lists use cases for Hyperbole Hyperbole.")
-	 ))
+	   "Lists use cases for Hyperbole Hyperbole.")))
        '(ebut .
 	 (("EButton>")
 	  ("Act"    hui:ebut-act
@@ -661,8 +656,7 @@ constructs.  If not given, the top level Hyperbole menu is used."
 	  ("Search" hui:ebut-search
 	   "Locates and displays personally created buttons in context.")
 	  ("Types"  (hui:htype-help-current-window 'actypes)
-	   "Displays documentation for one or all action types used by explicit buttons.")
-	  ))
+	   "Displays documentation for one or all action types used by explicit buttons.")))
        '(ebut-help .
 	 (("Help on>")
 	  ("BufferButs"   (hui:hbut-report -1)
@@ -670,8 +664,7 @@ constructs.  If not given, the top level Hyperbole menu is used."
 	  ("CurrentBut"   (hui:hbut-report)
 	   "Summarizes only current button in buffer.")
 	  ("OrderedButs"  (hui:hbut-report 1)
-	   "Summarizes explicit buttons in lexicographically order.")
-	  ))
+	   "Summarizes explicit buttons in lexicographically order.")))
        '(find .
          (("Find>")
 	  ("GrepFiles"           hypb:rgrep  "Show numbered line matches in all specified files.")
@@ -680,8 +673,7 @@ constructs.  If not given, the top level Hyperbole menu is used."
 	  ("OccurHere"           occur       "Show numbered line matches for regexp from this buffer.")
 	  ("RemoveLines"         hypb:remove-lines "Following point, remove all lines that match regexp.")
 	  ("SaveLines"           hypb:save-lines  "Following point, keep only lines that match regexp.")
-	  ("Web/" (menu . web) "Searches major web sites.")
-	  ))
+	  ("Web/" (menu . web) "Searches major web sites.")))
        '(gbut .
 	 (("GButton>")
 	  ("Act"    gbut:act        "Activates global button by name.")
@@ -692,8 +684,7 @@ constructs.  If not given, the top level Hyperbole menu is used."
 	  ("Info"   (id-info "(hyperbole)Global Buttons")
 	   "Displays manual section on global buttons.")
 	  ("Modify" hui:gbut-modify "Modifies global button attributes.")
-	  ("Rename" hui:gbut-rename "Renames a global button.")
-	  ))
+	  ("Rename" hui:gbut-rename "Renames a global button.")))
        '(ibut .
 	 (("IButton>")
 	  ("Act"    hui:ibut-act
@@ -708,8 +699,7 @@ constructs.  If not given, the top level Hyperbole menu is used."
 	  ("Rename" hui:ibut-rename
 	   "Modifies a label preceding an implicit button in the current buffer.")
 	  ("Types"  (hui:htype-help 'ibtypes 'no-sort)
-	   "Displays documentation for one or all implicit button types.")
-	  ))
+	   "Displays documentation for one or all implicit button types.")))
        '(msg .
 	 (("Msg>")
 	  ("Compose-Hypb-Mail"
@@ -733,8 +723,7 @@ constructs.  If not given, the top level Hyperbole menu is used."
 	  ("Unsub-Hypb-Bug"
 	   (hmail:compose "bug-hyperbole-leave@gnu.org" nil
 			  "Just send the message; subject and body are ignored.")
-	   "Unsubscribe from the Hyperbole bug reporting list.")
-	  ))
+	   "Unsubscribe from the Hyperbole bug reporting list.")))
        '(otl
 	 . (("Kotl>")
 	    ("All"       kotl-mode:show-all "Expand all collapsed cells.")
@@ -763,8 +752,7 @@ constructs.  If not given, the top level Hyperbole menu is used."
 	    ("Top"       kotl-mode:top-cells
 	     "Hide all but top-level cells.")
 	    ("Vspec"     kvspec:activate
-	     "Prompt for and activate a view specifiction.")
-	    ))
+	     "Prompt for and activate a view specifiction.")))
        '(hyrolo .
 	 (("Rolo>")
 	  ("Add"              hyrolo-add	  "Add a new rolo entry.")
@@ -781,8 +769,7 @@ constructs.  If not given, the top level Hyperbole menu is used."
 	  ("StringFind"       hyrolo-fgrep  "Find entries containing a string.")
 	  ("WordFind"         hyrolo-word   "Find entries containing words.")
 	  ("Yank"             hyrolo-yank
-	   "Find an entry containing a string and insert it at point.")
-	  ))
+	   "Find an entry containing a string and insert it at point.")))
        '(screen .
 	 (("Screen>")
 	  ("FramesControl"    hycontrol-enable-frames-mode
@@ -794,8 +781,7 @@ constructs.  If not given, the top level Hyperbole menu is used."
 	  ("ActionTypes"      (hui:htype-help-current-window 'actypes)
 	   "Displays documentation for one or all action types.")
 	  ("IButTypes"        (hui:htype-help-current-window 'ibtypes 'no-sort)
-	   "Displays documentation for one or all implicit button types.")
-	  ))
+	   "Displays documentation for one or all implicit button types.")))
        '(win .
 	 (("WinConfig>")
 	  ("AddName"        hywconfig-add-by-name
@@ -811,10 +797,8 @@ constructs.  If not given, the top level Hyperbole menu is used."
 	   "Saves current window configuration to ring.")
 	  ("YankRing"       (progn (call-interactively 'hywconfig-yank-pop)
 				   (hyperbole 'win))
-	   "Restores next window configuration from ring.")
-	  ))
-       (hui:menu-web-search)
-       ))))
+	   "Restores next window configuration from ring.")))
+       (hui:menu-web-search)))))
 
 ;; Always rebuild the Hyperbole minibuffer menu when this file is loaded.
 (hyperbole-minibuffer-menu)

--- a/hui-mouse.el
+++ b/hui-mouse.el
@@ -469,8 +469,7 @@ Its default value is #'smart-scroll-down.  To disable it, set it to
     ;;
     ;; Todotxt
     ((eq major-mode 'todotxt-mode) .
-     ((smart-todotxt) . (smart-todotxt-assist)))
-    )
+     ((smart-todotxt) . (smart-todotxt-assist))))
   "Alist of predicates and form-conses for the Action and Assist Keyboard Keys.
 Each element is: (PREDICATE-FORM . (ACTION-KEY-FORM . ASSIST-KEY-FORM)).
 When the Action or Assist Key is pressed, the first or second form,
@@ -1012,8 +1011,7 @@ If key is pressed within:
 	     (progn (set-buffer gnus-summary-buffer)
 		    (setq this-command 'gnus-summary-next-unread-article)
 		    (gnus-summary-next-unread-article)
-		    (gnus-summary-goto-subject gnus-current-article)
-		    )
+		    (gnus-summary-goto-subject gnus-current-article))
 	   (let ((artic (get-buffer-window gnus-article-buffer)))
 	     (if artic (select-window artic)))))
 	((and (not (eolp)) (Info-handle-in-note)))
@@ -1036,8 +1034,7 @@ If assist-key is pressed within:
 	     (progn (set-buffer gnus-summary-buffer)
 		    (setq this-command 'gnus-summary-prev-article)
 		    (gnus-summary-prev-article nil)
-		    (gnus-summary-goto-subject gnus-current-article)
-		    )
+		    (gnus-summary-goto-subject gnus-current-article))
 	   (let ((artic (get-buffer-window gnus-summary-buffer)))
 	     (if artic (select-window artic)))))
 	((and (not (eolp)) (Info-handle-in-note)))
@@ -1568,8 +1565,7 @@ local variable containing its pathname."
 			(if ref
 			    (if (string-match "(\\(.\\)\\(.+\\))" ref)
 				(setq ref (concat (substring ref 0 (match-end 1))
-						  "\)"))))
-			)))))))
+						  "\)")))))))))))
     (cond ((equal ref "") nil)
 	  ((stringp ref) (list 'manual-entry ref))
 	  (t ref))))
@@ -1590,8 +1586,7 @@ locate the definition."
 		  (if (or (looking-at "\\([_~<>:a-zA-Z0-9]+\\)[ \t\n\r]*(")
 			  (looking-at "\\([_~<:A-Z][_<>:A-Z0-9]+\\)"))
 		      (setq ref (buffer-substring
-				 (match-beginning 1) (match-end 1))
-			    )))))
+				 (match-beginning 1) (match-end 1)))))))
     (if ref
 	(list 'smart-tags-display ref nil
 	      (smart-tags-file-list (and (boundp 'man-path) man-path))))))
@@ -1609,8 +1604,7 @@ If not on a file name, returns nil."
 		    (skip-chars-backward "^ \t")
 		    (if (looking-at "/[^ \t\n\r]+")
 			(setq ref (buffer-substring
-				   (match-beginning 0) (match-end 0))
-			      )))))
+				   (match-beginning 0) (match-end 0)))))))
     (if ref
 	(list (if (br-in-browser)
 		  'find-file 'find-file-other-window)

--- a/hui-select.el
+++ b/hui-select.el
@@ -163,8 +163,7 @@
     (indented-text-mode "[^ \t\n*]")
     (Info-mode "[^ \t\n]")
     (outline-mode "[^*]")
-    (text-mode  "[^ \t\n*]")
-    )
+    (text-mode  "[^ \t\n*]"))
   "List of (major-mode . non-terminator-line-regexp) elements used to avoid early dropoff when marking indented code.")
 
 (defvar hui-select-indent-end-regexp-alist
@@ -179,8 +178,7 @@
     (fundamental-mode "[ \t]*$")
     (indented-text-mode "[ \t]*$")
     (Info-mode "[ \t]*$")
-    (text-mode  "[ \t]*$")
-    )
+    (text-mode  "[ \t]*$"))
   "List of (major-mode . terminator-line-regexp) elements used to include a final line when marking indented code.")
 
 (defcustom hui-select-char-p nil
@@ -233,8 +231,7 @@
     (indent-def hui-select-indent-def)
     (paragraph hui-select-paragraph)
     (page hui-select-page)
-    (buffer hui-select-buffer)
-    )
+    (buffer hui-select-buffer))
   "Unordered list of (<region-type-symbol> <region-selection-function>) pairs.
 Used to go from one thing to a bigger thing.  See `hui-select-bigger-thing'.
 Nil value for <region-selection-function> means that region type is skipped

--- a/hui.el
+++ b/hui.el
@@ -800,8 +800,7 @@ See also documentation for `hui:link-possible-types'."
        (let* ((act) (act-str)
 	      (params (actype:params actype))
 	      (params-no-keywords (actype:param-list actype))
-	      (params-str (and params (concat " " (prin1-to-string params))))
-	      )
+	      (params-str (and params (concat " " (prin1-to-string params)))))
 	 (while (progn
 		  (while (and (setq act-str
 				    (hargs:read
@@ -830,8 +829,7 @@ See also documentation for `hui:link-possible-types'."
 						   "[\(\) \t\n\r\"]")
 					   act-str)
 					  t))
-				   params-no-keywords)))
-		       ))
+				   params-no-keywords)))))
 	   (beep) (message "Action must use at least one parameter.")
 	   (sit-for 3))
 	 (let (head)
@@ -846,8 +844,7 @@ See also documentation for `hui:link-possible-types'."
 			((stringp act)
 			 (setq act (action:kbd-macro act 1)))
 			;; Unrecognized form
-			(t (setq act nil))
-			)))
+			(t (setq act nil)))))
 	 act)))
 
 (defun hui:actype (&optional default-actype prompt)
@@ -1054,8 +1051,7 @@ for with completion of all labeled buttons within the current buffer."
       (widen)
       (narrow-to-region (point) end)
       (sit-for 0)
-      (setq inverse-video nil)
-      )))
+      (setq inverse-video nil))))
 
 (defun hui:hbut-term-unhighlight (start end)
   "For terminals only: Remove any emphasis from hyper-button at START to END."

--- a/hversion.el
+++ b/hversion.el
@@ -143,8 +143,7 @@ Where a part in the term-type is delimited by a `-' or  an `_'."
 			  (equal (getenv "TERM") "NeXT")
 			  (equal (getenv "TERM") "eterm"))
 		      ;; NEXTSTEP add-on support to Emacs
-		      "next")
-		     )))
+		      "next"))))
     (set-frame-parameter frame 'hyperb:window-system
 			 (and term (setq term (substring term 0 (string-match "[-_]" term)))))
     term))

--- a/hvm.el
+++ b/hvm.el
@@ -95,8 +95,7 @@ if that value is non-nil."
   (defalias 'rmail:summ-msg-to   'vm-follow-summary-cursor)
   (defalias 'rmail:summ-new      'vm-summarize)
   (if (called-interactively-p 'interactive)
-      (message "Hyperbole VM mail reader support initialized."))
-  )
+      (message "Hyperbole VM mail reader support initialized.")))
 
 (defun Vm-msg-hdrs-full (toggled)
   "If TOGGLED is non-nil, toggle full/hidden headers, else show full headers."
@@ -390,8 +389,7 @@ Has side-effect of widening buffer."
 	  (point-max))
 	 (vm-show-current-message)
 	 (setq vm-system-state 'reading))
-	(t (error "vm search code is missing, can't continue"))))
-)
+	(t (error "vm search code is missing, can't continue")))))
 
 ;; Hide any Hyperbole button data when reply to or forward a message.
 ;; See "vm-reply.el".
@@ -536,8 +534,7 @@ Has side-effect of widening buffer."
 (defvar Vm-msg-start-regexp "\n\nFrom \\|\n\001\001\001\001"
   "Regular expression that begins a Vm mail message.")
 
-(provide 'hvm)
-)
+(provide 'hvm))
 (error nil))
 
 ;; Local Variables:

--- a/hypb-maintenance.el
+++ b/hypb-maintenance.el
@@ -78,8 +78,7 @@ Point `hypb:web-repo-location' to where the web repo is located."
   (kexport:html "kotl/EXAMPLE.kotl" (concat hypb:web-repo-location "koutline-example.html") nil)
  
   ;; HY-WHY.html
-  (kexport:html "HY-WHY.kotl" (concat hypb:web-repo-location "HY-WHY.html") nil)
-  )
+  (kexport:html "HY-WHY.kotl" (concat hypb:web-repo-location "HY-WHY.html") nil))
 
 (provide 'hypb-maintenance)
 ;;; hypb-maintenance.el ends here

--- a/hyrolo-menu.el
+++ b/hyrolo-menu.el
@@ -44,8 +44,7 @@
     ["Search-for-Regexp" (id-tool-invoke 'hyrolo-grep)  t]
     ["Search-for-String" (id-tool-invoke 'hyrolo-fgrep) t]
     ["Search-for-Word"   (id-tool-invoke 'hyrolo-word)  t]
-    ["Sort-Entries"      (id-tool-invoke 'hyrolo-sort)  t]
-    ))
+    ["Sort-Entries"      (id-tool-invoke 'hyrolo-sort)  t]))
 
 (defconst hyrolo-menu-common-body
   '(
@@ -59,14 +58,12 @@
      ["To-Next-Same-Level"     outline-forward-same-level       t]
      ["To-Previous-Entry"      outline-previous-visible-heading t]
      ["To-Previous-Same-Level" outline-backward-same-level      t]
-     ["Up-a-Level"             outline-up-heading               t]
-     )
+     ["Up-a-Level"             outline-up-heading               t])
     ("Outline"
      ["Hide (Collapse)"        outline-hide-subtree             t]
      ["Show (Expand)"          outline-show-subtree             t]
      ["Show-All"               outline-show-all                 t]
-     ["Show-Only-First-Line"   outline-hide-body                t]
-     ))
+     ["Show-Only-First-Line"   outline-hide-body                t]))
   "The middle menu entries common to all HyRolo menus.")
 
 ;;; This definition is used by InfoDock only.
@@ -79,15 +76,13 @@
       ["Toggle-Read-Only"    read-only-mode                 t]
       ["Write (Save as)"     write-file                     t]
       "----"
-      ["Quit"                (id-tool-quit '(kill-buffer nil))  t]
-      ))
+      ["Quit"                (id-tool-quit '(kill-buffer nil))  t]))
    '(["Edit-Entry-at-Point"  hyrolo-edit-entry         t]
      ["Mail-to-Address"      (id-tool-invoke 'hyrolo-mail-to) t])
    `,@hyrolo-menu-common-body
    '(["Next-Match"          hyrolo-next-match         t]
      ["Previous-Match"      hyrolo-previous-match     t])
-   (list infodock-hyrolo-menu)
-   ))
+   (list infodock-hyrolo-menu)))
 
 ;;; This definition is used by InfoDock and XEmacs.
 (defconst id-popup-hyrolo-menu
@@ -105,8 +100,7 @@
    `,@hyrolo-menu-common-body
    (list infodock-hyrolo-menu)
    '("----"
-     ["Quit"                (id-tool-quit '(hyrolo-quit)) t])
-   ))
+     ["Quit"                (id-tool-quit '(hyrolo-quit)) t])))
 
 ;;; ************************************************************************
 ;;; Public declarations

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -1522,8 +1522,7 @@ the whitespace following the entry hierarchy level.")
    "%s\n"
    "======================================================================\n")
   "Header to insert preceding a file's first rolo entry match when
-file has none of its own.  Used with one argument, the file name."
-  )
+file has none of its own.  Used with one argument, the file name.")
 
 (defconst hyrolo-hdr-regexp "^==="
   "Regular expression to match the first and last lines of rolo file headers.
@@ -1582,8 +1581,7 @@ String search expressions are converted to regular expressions.")
   (define-key hyrolo-mode-map "\C-i"     'hyrolo-next-match)      ;; {TAB}
   (define-key hyrolo-mode-map "\M-\C-i"  'hyrolo-previous-match)  ;; {M-TAB}
   (define-key hyrolo-mode-map [backtab]  'hyrolo-previous-match)  ;; {Shift-TAB}
-  (define-key hyrolo-mode-map "u"        'outline-up-heading)
-  )
+  (define-key hyrolo-mode-map "u"        'outline-up-heading))
 
 ;; Prompt user to rename old personal rolo file to new name, if necessary.
 (unless noninteractive

--- a/kotl/kexport.el
+++ b/kotl/kexport.el
@@ -106,8 +106,7 @@
 	 'kexport:html-file-klink)
    (cons (format "&lt;\\s-*\\([^ \t\n\r,<>]+\\)\\s-*,\\s-*%s[^=&>]*&gt;"
 		 kexport:kcell-partial-reference-regexp)
-	 'kexport:html-file-klink)
-   )
+	 'kexport:html-file-klink))
   "*List of (regexp . replacement-pattern) elements applied in order to the
 contents of each kcell from a koutline exported to HTML format.  Replacement
 pattern may be:

--- a/kotl/kfile.el
+++ b/kotl/kfile.el
@@ -380,8 +380,7 @@ included in the list."
 	     ((equal item 0) nil)
 	     (t (setq cell (kcell-data:to-kcell-v2 (aref cell-data item))
 		      cell-list (cons cell cell-list)
-		      sibling-p t)
-		)))
+		      sibling-p t))))
      kotl-structure)
     (nreverse cell-list)))
 
@@ -441,8 +440,7 @@ hidden."
 	      (progn (narrow-to-region start-text end-text)
 		     (goto-char (point-min)))
 	    (error
-	     "(kfile:narrow-to-kcells): Cannot find start or end of kcells"))
-	  ))))
+	     "(kfile:narrow-to-kcells): Cannot find start or end of kcells"))))))
 
 (defun kfile:print-to-string (object)
   "Return a string containing OBJECT, any Lisp object, in pretty-printed form.

--- a/kotl/kfill.el
+++ b/kotl/kfill.el
@@ -45,8 +45,7 @@
     ("[?!~*+ -]+ " . kfill:hanging-list)
     ;; This keeps normal paragraphs from interacting unpleasantly with
     ;; the types given above.
-    ("[^ \t/#%?!~*+-]" . kfill:normal)
-    )
+    ("[^ \t/#%?!~*+-]" . kfill:normal))
 "Value is an alist of the form
 
    ((REGXP . FUNCTION) ...)

--- a/kotl/kmenu.el
+++ b/kotl/kmenu.el
@@ -62,8 +62,7 @@
       ["Tab-Key-Inserts-Spaces" kotl-mode:toggle-indent-tabs-mode
        :style toggle :selected (not kotl-mode:indent-tabs-mode)]
       ["Tab-Key-Tabs-Over" kotl-mode:toggle-tab-flag
-       :style toggle :selected kotl-mode:tab-flag]
-      )
+       :style toggle :selected kotl-mode:tab-flag])
     (if (boundp 'infodock-go-menu) infodock-go-menu)
     '("Jump-to"
       ["Cell"                kotl-mode:goto-cell            t]
@@ -87,8 +86,7 @@
       ["End-of-Tree"         kotl-mode:end-of-tree          t]
       "----"
       ["First-Cell"          kotl-mode:beginning-of-buffer  t]
-      ["Last-Cell"           kotl-mode:end-of-buffer        t]
-      )
+      ["Last-Cell"           kotl-mode:end-of-buffer        t])
     '("Label-Type"
       ["Alphanumeric (Default)"  (kview:set-label-type kview 'alpha)  t]
       ["Legal"                   (kview:set-label-type kview 'legal)  t]
@@ -97,11 +95,9 @@
       ["Permanent-Idstamp"       (kview:set-label-type kview 'id)     t]
       ;; ["Stars"                   (kview:set-label-type kview 'star) t]
       "----"
-      ["Set-Label-Separator"     kview:set-label-separator  t]
-      )
+      ["Set-Label-Separator"     kview:set-label-separator  t])
     '("Link"
-      ["Add-at-Point"        klink:create                   t]
-      )
+      ["Add-at-Point"        klink:create                   t])
     (if (fboundp 'infodock-options-menu) (infodock-options-menu))
     '("Tree"
       ["Copy-to-Buffer"      kotl-mode:copy-to-buffer       t]
@@ -117,8 +113,7 @@
       ["Copy-After-Cell"     kotl-mode:copy-after           t]
       ["Copy-Before-Cell"    kotl-mode:copy-before          t]
       ["Move-After-Cell"     kotl-mode:move-after           t]
-      ["Move-Before-Cell"    kotl-mode:move-before          t]
-      )
+      ["Move-Before-Cell"    kotl-mode:move-before          t])
     '("View"
       ["Set-View-Spec"       kvspec:activate                t]
       ["Toggle-Blank-Lines"  kvspec:toggle-blank-lines      t]
@@ -139,9 +134,7 @@
       ["Show (Expand)"       kotl-mode:show-tree            t]
       ["Show-All"            kotl-mode:show-all             t]
       ["Show-Subtree"        kotl-mode:show-subtree         t]
-      ["Show-Top-Level-Only" kotl-mode:top-cells            t]
-      )
-    ))
+      ["Show-Top-Level-Only" kotl-mode:top-cells            t])))
   "The middle menu entries common to all Koutliner menus.")
 
 (defconst kotl-menu-common-preamble
@@ -154,8 +147,7 @@
     ["Manual"              (id-info "(hyperbole)Outliner") t]
     "----"
      ;; Delete Koutline menu from all menubars.
-    ["Remove-This-Menu"    (hui-menu-remove Koutline kotl-mode-map) t]
-    ))
+    ["Remove-This-Menu"    (hui-menu-remove Koutline kotl-mode-map) t]))
 
 (defconst kotl-menu-common-postamble
   '("----"
@@ -173,8 +165,7 @@
     ["Export-to-HTML"      kexport:html                   t]
     ["Import-to-Koutline"  kimport:file                   t]
     "----"
-    ["Quit"                (id-tool-quit '(kill-buffer nil))  t]
-    ))
+    ["Quit"                (id-tool-quit '(kill-buffer nil))  t]))
 
 ;;; This definition is used by InfoDock only.
 (defconst id-menubar-kotl

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -434,8 +434,7 @@ Does not delete across cell boundaries."
 		       (setq count (1- count))))
 		 (delete-char 1 kill-flag))
 	       (setq arg (1- arg)
-		     del-count (1+ del-count)))
-	     ))
+		     del-count (1+ del-count)))))
 	  ((< arg 0)
 	   (if (kotl-mode:bocp)
 	       (error "(kotl-mode:delete-char): Beginning of cell")
@@ -691,8 +690,7 @@ but it will be copied to the kill ring and then an error will be signaled."
 		  (kill-append killed (< end start))
 		(kill-new killed))
 	      (setq this-command 'kill-region)
-	      (when read-only (barf-if-buffer-read-only))
-	      )))
+	      (when read-only (barf-if-buffer-read-only)))))
       (error
        "(kotl-mode:kill-region): Bad region or not within a single Koutline cell"))))
 
@@ -1975,8 +1973,7 @@ If at tail cell already, do nothing and return nil."
 	  (progn
 	    (goto-char (mark t))
 	    (pop-mark)
-	    (error "(kotl-mode:up-level): No parent level to which to move")
-	    )))))
+	    (error "(kotl-mode:up-level): No parent level to which to move"))))))
 
 
 ;;; ------------------------------------------------------------------------
@@ -3300,8 +3297,7 @@ Leave point at end of line now residing at START."
        org-force-self-insert
        orgtbl-ctrl-c-ctrl-c
        orgtbl-create-or-convert-from-region
-       orgtbl-self-insert-command
-       )))
+       orgtbl-self-insert-command)))
 
 
   ;; kotl-mode keys

--- a/kotl/kvspec.el
+++ b/kotl/kvspec.el
@@ -320,9 +320,7 @@ If NUM is less than 1 or greater than the number of lines available, the cell re
 
       ;; Do this last since it can trigger an error if partial alpha is
       ;; selected.
-      (kvspec:numbering) ;; n
-
-      )
+      (kvspec:numbering)) ;; n
     (set-buffer-modified-p modified-p)))
 
 ;;; ************************************************************************


### PR DESCRIPTION
## What 

Remove wrapped closing parens

## Why
package-lint complains and not having wrapped ending parens is the convention (and it is easy to fix!)

## Note
This leaves the following warnings and errors:
`kotl-mode.el:3312:61: error: This key sequence is reserved (see Key Binding Conventions in the Emacs Lisp manual)
kotl-mode.el:3314:67: error: This key sequence is reserved (see Key Binding Conventions in the Emacs Lisp manual)
kotl-mode.el:3316:62: error: This key sequence is reserved (see Key Binding Conventions in the Emacs Lisp manual)
kotl-mode.el:3319:62: error: This key sequence is reserved (see Key Binding Conventions in the Emacs Lisp manual)
kotl-mode.el:3321:66: error: This key sequence is reserved (see Key Binding Conventions in the Emacs Lisp manual)
kotl-mode.el:3323:61: error: This key sequence is reserved (see Key Binding Conventions in the Emacs Lisp manual)
kotl-mode.el:3324:61: error: This key sequence is reserved (see Key Binding Conventions in the Emacs Lisp manual)
kotl-mode.el:3325:61: error: This key sequence is reserved (see Key Binding Conventions in the Emacs Lisp manual)
kotl-mode.el:3346:65: error: This key sequence is reserved (see Key Binding Conventions in the Emacs Lisp manual)
kotl-mode.el:3351:65: error: This key sequence is reserved (see Key Binding Conventions in the Emacs Lisp manual)
kotl-mode.el:3352:54: error: This key sequence is reserved (see Key Binding Conventions in the Emacs Lisp manual)
kotl-mode.el:3356:62: error: This key sequence is reserved (see Key Binding Conventions in the Emacs Lisp manual)
kotl-mode.el:3361:62: error: This key sequence is reserved (see Key Binding Conventions in the Emacs Lisp manual)
kotl-mode.el:3367:62: error: This key sequence is reserved (see Key Binding Conventions in the Emacs Lisp manual)
kotl-mode.el:3372:67: error: This key sequence is reserved (see Key Binding Conventions in the Emacs Lisp manual)
kotl-mode.el:3374:60: error: This key sequence is reserved (see Key Binding Conventions in the Emacs Lisp manual)
Entering directory '/home/matslidell/src/hyperbole/'
hargs.el:73:0: error: Define compatibility functions with a prefix, e.g. "hyperbole--find-tag--default", and use `defalias' where they exist.
hgnus.el:83:0: error: Define compatibility functions with a prefix, e.g. "hyperbole--news-reply-yank-original", and use `defalias' where they exist.
hib-debbugs.el:77:1: warning: `eval-after-load' is for use in configurations, and should rarely be used in packages.
hib-doc-id.el:56:4: warning: You should include standard keywords: see the variable `finder-known-keywords'.
hmouse-sh.el:487:7: warning: `with-eval-after-load' is for use in configurations, and should rarely be used in packages.
hmouse-sh.el:525:6: warning: `with-eval-after-load' is for use in configurations, and should rarely be used in packages.
hsettings.el:80:1: warning: `eval-after-load' is for use in configurations, and should rarely be used in packages.
hycontrol.el:333:1: warning: `eval-after-load' is for use in configurations, and should rarely be used in packages.
hycontrol.el:335:1: warning: `eval-after-load' is for use in configurations, and should rarely be used in packages.
hycontrol.el:337:1: warning: `eval-after-load' is for use in configurations, and should rarely be used in packages.
hycontrol.el:904:0: error: Global minor modes should be autoloaded or, rarely, `:require' their defining file (i.e. ":require 'hycontrol"), to support the customization variable of the same name.
hycontrol.el:925:0: error: Global minor modes should be autoloaded or, rarely, `:require' their defining file (i.e. ":require 'hycontrol"), to support the customization variable of the same name.
hui-mouse.el:1730:1: warning: `eval-after-load' is for use in configurations, and should rarely be used in packages.
hui-treemacs.el:45:1: warning: `eval-after-load' is for use in configurations, and should rarely be used in packages.
hui-window.el:255:1: warning: `with-eval-after-load' is for use in configurations, and should rarely be used in packages.
hyperbole.el:327:1: warning: `eval-after-load' is for use in configurations, and should rarely be used in packages.
`