### PR TITLE
Add test cases for kotl-mode:transpose-cells

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2021-12-28  Mats Lidell  <matsl@gnu.org>
+
+* kotl/kotl-mode.el (kotl-mode:exchange-cells): Use cl-copy-list.
+
+* test/kotl-mode-tests.el (kotl-mode-transpose-cell)
+(kotl-mode-transpose-cell-with-mark)
+(kotl-mode-transpose-cell-past-multiple-cells): Add test for
+    kotl-mode:transpose-cells.
+
 2021-12-26  Bob Weiner  <rsw@gnu.org>
 
 * kotl/kotl-mode.el (kotl-mode:exchange-cells): Signal error if invalid type or value

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -2328,7 +2328,7 @@ to one level and kotl-mode:refill-flag is treated as true."
       ;;
       ;; Save cell-2 attributes
       (kotl-mode:goto-cell cell-ref-2 t)
-      (setq kcell-2 (copy-list (kcell-view:cell))
+      (setq kcell-2 (cl-copy-list (kcell-view:cell))
 	    idstamp-2 (kcell-view:idstamp)
 	    contents-2 (kcell-view:contents))
 

--- a/test/kotl-mode-tests.el
+++ b/test/kotl-mode-tests.el
@@ -393,5 +393,75 @@
           (should (string= (kcell-view:label (point)) "1a")))
       (delete-file kotl-file))))
 
+(ert-deftest kotl-mode-transpose-cell ()
+  "Transpose cells and leave point in cell."
+  (let ((kotl-file (make-temp-file "hypb" nil ".kotl")))
+    (unwind-protect
+        (progn
+          (find-file kotl-file)
+          (insert "first")
+          (kotl-mode:add-cell)
+          (insert "second")
+          (kotl-mode:beginning-of-cell)
+          (should (string= (kcell-view:idstamp) "02"))
+          (should (looking-at-p "second"))
+
+          (kotl-mode:transpose-cells 1)
+
+          (should (string= (kcell-view:idstamp) "01"))
+          (should (looking-at-p "first"))))
+      (delete-file kotl-file)))
+
+(ert-deftest kotl-mode-transpose-cell-with-mark ()
+  "Transpose cell with cell with mark and change point to mark."
+  (let ((kotl-file (make-temp-file "hypb" nil ".kotl")))
+    (unwind-protect
+        (progn
+          (find-file kotl-file)
+          (insert "first")
+          (push-mark)
+          (kotl-mode:add-cell)
+          (insert "second")
+          (kotl-mode:add-cell)
+          (insert "third")
+          (kotl-mode:beginning-of-cell)
+          (should (string= (kcell-view:idstamp) "03"))
+          (should (looking-at-p "third"))
+
+          (kotl-mode:transpose-cells 0)
+
+          (should (string= (kcell-view:idstamp) "03"))
+          (should (looking-at-p "third"))
+          (should (kotl-mode:first-cell-p)))
+      (delete-file kotl-file))))
+
+(ert-deftest kotl-mode-transpose-cell-past-multiple-cells ()
+  "Transpose cell past multiple cells."
+  (let ((kotl-file (make-temp-file "hypb" nil ".kotl")))
+    (unwind-protect
+        (progn
+          (find-file kotl-file)
+          (insert "first")
+          (kotl-mode:add-cell)
+          (insert "second")
+          (kotl-mode:add-cell)
+          (insert "third")
+          (kotl-mode:beginning-of-buffer)
+          (should (string= (kcell-view:idstamp) "01"))
+          (should (looking-at-p "first"))
+
+          (kotl-mode:transpose-cells 2)
+
+          ; Point moves to cell two
+          (should (string= (kcell-view:idstamp) "03"))
+          (should (looking-at-p "third"))
+
+          ; Verify first cells was moved last
+          (kotl-mode:end-of-buffer)
+          (should (string= (kcell-view:idstamp) "01"))
+          (kotl-mode:beginning-of-cell)
+          (should (looking-at-p "first")))
+      (delete-file kotl-file))))
+
 (provide 'kotl-mode-tests)
 ;;; kotl-mode-tests.el ends here


### PR DESCRIPTION
## What

Add test cases for kotl-mode:transpose-cells

## Why

Test case in 8.0.0 release todos. 

## Note

* Had to change copy-list to cl-copy-list.
* The resulting position of point after different transpositions does not feel logical. Would it be better if point always stayed with the cell that is moved or stays withing the cell that takes the place of the cell that is moved? The three test cases shows three different behaviors.