### PR TITLE
Add hyrolo sort test

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2021-12-30  Mats Lidell  <matsl@gnu.org>
+
+* test/hyrolo-tests.el (hyrolo-sort-test): Add hyrolo sort test.
+
 2021-12-29  Mats Lidell  <matsl@gnu.org>
 
 * test/hmouse-info-tests.el (hmouse-info-read-index-with-completion)

--- a/test/hyrolo-tests.el
+++ b/test/hyrolo-tests.el
@@ -181,5 +181,36 @@
              (should (string-match "No following same-level heading" (cadr err)))))))
     (hyrolo-demo-quit)))
 
+(ert-deftest hyrolo-sort-test ()
+  "Rolo files can be sorted."
+  (let ((hyrolo-file (make-temp-file "hypb" nil ".otl")))
+    (unwind-protect
+        (let ((hyrolo-file-list (list hyrolo-file)))
+          (find-file hyrolo-file)
+          (insert "===\nHdr\n===\n")
+          (goto-char (point-min))
+          (should (looking-at "==="))
+          (hyrolo-add "c")
+          (hyrolo-add "b")
+          (hyrolo-add "a")
+          (hyrolo-add "b/d")
+
+          ; Verify insertion order and following date on separate line
+          (goto-char (point-min))
+          (should (looking-at "==="))
+          (dolist (insertion-order '("c" "b" "d" "a"))
+            (goto-char (1+ (should (search-forward insertion-order))))
+            (should (looking-at-p "^\t[0-9/]+$")))
+
+          (hyrolo-sort)
+
+          ; Verify sorted order and following date on separate line
+          (goto-char (point-min))
+          (should (looking-at "==="))
+          (dolist (sorted-order '("a" "b" "d" "c"))
+            (goto-char (1+ (should (search-forward sorted-order))))
+            (should (looking-at-p "^\t[0-9/]+$"))))
+      (delete-file hyrolo-file))))
+
 (provide 'hyrolo-tests)
 ;;; hyrolo-tests.el ends here


### PR DESCRIPTION
## What

Add hyrolo sort test

## Why

Hyperbole 8.0.0 release todo.

## Note

There is problem with the sorting that this test finds. The date for the first sorted item gets ahead of the item. See example below where the date for item `a` is on the line before. When that is fixed this test should work.

```
===
Hdr
===
	12/30/2021
*   a
*   b
	12/30/2021
**   d
	12/30/2021
*   c
	12/30/2021
``` 