### PR TITLE
Add test for ebut creation to Info index using completion

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2022-01-02  Mats Lidell  <matsl@gnu.org>
+
+* test/hui-tests.el (hui-ebut-create-link-to-info-index-using-completion):
+    New test case.
+
 2022-01-01  Bob Weiner  <rsw@gnu.org>
 
 * test/hpath-tests.el (hpath:prepend-ls-directory-test):

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -136,6 +136,22 @@ Modifying the button but keeping the label creates a dubbel label."
           (should (equal (hattr:get (hbut:at-p) 'lbl-key) "label")))
       (delete-file file))))
 
+(ert-deftest hui-ebut-create-link-to-info-index-using-completion ()
+  "Create an ebut with link to Info index using completion for the index item."
+  (skip-unless (not noninteractive))
+  (let ((file (make-temp-file "hypb_" nil ".txt")))
+    (unwind-protect
+        (progn
+          (find-file file)
+          (should (hact 'kbd-key "C-h h e c label RET RET link-to-Info-index-item RET (hyperbole)Introduct TAB RET"))
+          (hy-test-helpers:consume-input-events)
+          (should (eq (hattr:get (hbut:at-p) 'actype) 'actypes::link-to-Info-index-item))
+          (should (equal (hattr:get (hbut:at-p) 'args) '("(hyperbole)Introduction")))
+          (should (equal (hattr:get (hbut:at-p) 'lbl-key) "label")))
+      (progn
+        (kill-buffer "*info*")
+        (delete-file file)))))
+
 ;; This file can't be byte-compiled without `with-simulated-input' which
 ;; is not part of the actual dependencies, so:
 ;;   Local Variables:

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -143,11 +143,11 @@ Modifying the button but keeping the label creates a dubbel label."
     (unwind-protect
         (progn
           (find-file file)
-          (should (hact 'kbd-key "C-h h e c label RET RET link-to-Info-index-item RET (hyperbole)Introduct TAB RET"))
+          (should (hact 'kbd-key "C-h h e c hypb-intro-button RET RET link-to-Info-index-item RET (hyperbole)Introduct TAB RET"))
           (hy-test-helpers:consume-input-events)
           (should (eq (hattr:get (hbut:at-p) 'actype) 'actypes::link-to-Info-index-item))
           (should (equal (hattr:get (hbut:at-p) 'args) '("(hyperbole)Introduction")))
-          (should (equal (hattr:get (hbut:at-p) 'lbl-key) "label")))
+          (should (equal (hattr:get (hbut:at-p) 'lbl-key) "hypb-intro-button")))
       (progn
         (kill-buffer "*info*")
         (delete-file file)))))


### PR DESCRIPTION
## What

Add test for ebut creation to Info index using completion.

## Why

In Hyperbole 8.0.0. todos.

## Note

Depends on not having any completion package loaded but does not try to enforce or work around that. So will likely fail when running in an existing Emacs with users preferences loaded. So best to run it using the make target.