### PR TITLE
Fix completion test case

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2022-01-02  Mats Lidell  <matsl@gnu.org>
 
+* test/hui-tests.el (hui-ebut-create-link-to-info-index-using-completion):
+    Link to emacs info index.
+
 * test/hy-test-helpers.el (hy-test-helpers:action-key-should-call-hpath:find)
     (hy-test-helpers:hypb-function-should-call-hpath:find): Do a string
     match and expand-file-name match.

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -143,11 +143,11 @@ Modifying the button but keeping the label creates a dubbel label."
     (unwind-protect
         (progn
           (find-file file)
-          (should (hact 'kbd-key "C-h h e c hypb-intro-button RET RET link-to-Info-index-item RET (hyperbole)Introduct TAB RET"))
+          (should (hact 'kbd-key "C-h h e c emacs-package-button RET RET link-to-Info-index-item RET (emacs)packag TAB RET"))
           (hy-test-helpers:consume-input-events)
           (should (eq (hattr:get (hbut:at-p) 'actype) 'actypes::link-to-Info-index-item))
-          (should (equal (hattr:get (hbut:at-p) 'args) '("(hyperbole)Introduction")))
-          (should (equal (hattr:get (hbut:at-p) 'lbl-key) "hypb-intro-button")))
+          (should (equal (hattr:get (hbut:at-p) 'args) '("(emacs)Package")))
+          (should (equal (hattr:get (hbut:at-p) 'lbl-key) "emacs-package-button")))
       (progn
         (kill-buffer "*info*")
         (delete-file file)))))


### PR DESCRIPTION
## What

Use a completion that exists. 

## Why

Seems like the previous expansion used in the test case does not exist hence the test case it hangs. Odd that is could pass through yesterday!? Using a page from the emacs info index seems to work and might be more safe than to depend on the hyperbole info pages. The later could maybe not be installed?