### PR TITLE
Do not leave files in tmp folder after tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2022-01-15  Mats Lidell  <matsl@gnu.org>
+
+* Makefile (test-ert, test-all): Turn off auto-save.
+
+* test/hbut-tests.el (gbut-program-link-to-directory): Remove temp file.
+
 2022-01-15  Bob Weiner  <rsw@gnu.org>
 
 * hpath.el (hpath:absolute-arguments): Check that each arg is non-nil

--- a/Makefile
+++ b/Makefile
@@ -409,15 +409,15 @@ LOAD_TEST_ERT_FILES=$(patsubst %,(load-file \"%\"),${TEST_ERT_FILES})
 
 test-ert:
 	@echo "# Tests: $(TEST_ERT_FILES)"
-	$(EMACS_BATCH) --eval "(load-file \"test/hy-test-dependencies.el\")" --eval "(progn $(LOAD_TEST_ERT_FILES) (ert-run-tests-batch-and-exit))"
+	$(EMACS_BATCH) --eval "(load-file \"test/hy-test-dependencies.el\")" --eval "(let ((auto-save-default)) $(LOAD_TEST_ERT_FILES) (ert-run-tests-batch-and-exit))"
 
 all-tests: test-all
 test-all:
 	@echo "# Tests: $(TEST_ERT_FILES)"
 ifeq ($(TERM), dumb)
-	TERM=vt100 DISPLAY=$(DISPLAY) $(EMACS) --quick $(PRELOADS) --eval "(load-file \"test/hy-test-dependencies.el\")" --eval "(progn $(LOAD_TEST_ERT_FILES) (ert-run-tests-interactively t))"
+	TERM=vt100 DISPLAY=$(DISPLAY) $(EMACS) --quick $(PRELOADS) --eval "(load-file \"test/hy-test-dependencies.el\")" --eval "(let ((auto-save-default)) $(LOAD_TEST_ERT_FILES) (ert-run-tests-interactively t))"
 else
-	$(EMACS) --quick $(PRELOADS) --eval "(load-file \"test/hy-test-dependencies.el\")" --eval "(progn $(LOAD_TEST_ERT_FILES) (ert-run-tests-interactively t))"
+	$(EMACS) --quick $(PRELOADS) --eval "(load-file \"test/hy-test-dependencies.el\")" --eval "(let ((auto-save-default)) $(LOAD_TEST_ERT_FILES) (ert-run-tests-interactively t))"
 endif
 
 # Hyperbole install tests - Verify that hyperbole can be installed

--- a/test/hbut-tests.el
+++ b/test/hbut-tests.el
@@ -98,7 +98,8 @@ Needed since hyperbole expands all links to absolute paths and
 	  (with-current-buffer test-buffer
             (should (eq (hattr:get (hbut:at-p) 'actype) 'actypes::link-to-directory))
             (hbut-tests:should-match-tmp-folder (hattr:get (hbut:at-p) 'args))
-            (should (equal (hattr:get (hbut:at-p) 'lbl-key) "global")))))))
+            (should (equal (hattr:get (hbut:at-p) 'lbl-key) "global"))))
+      (delete-file test-file))))
 
 (ert-deftest hypb:program-create-ebut-in-buffer ()
   "Create button with hypb:program in buffer."


### PR DESCRIPTION
## What

Do not leave files in tmp folder after tests

## Why

Tests should leave a clean environment when they are done. Fixes one missing delete of a temp file. Turns off auto-save because many tests results in auto-saves being created.