### PR TITLE
Add test for root cell file attribute on copied file

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2022-01-22  Mats Lidell  <matsl@gnu.org>
+
+* test/kotl-mode-tests.el
+    (kotl-mode-copy-kotl-file-updates-root-id-attributes): Verify that
+    root cell attribute for file name is updated.
+
 2022-01-20  Bob Weiner  <rsw@gnu.org>
 
 * kotl/kview.el (kview:create): Ensure top-level 0 cell file attribute is always updated

--- a/test/kotl-mode-tests.el
+++ b/test/kotl-mode-tests.el
@@ -463,5 +463,23 @@
           (should (looking-at-p "first")))
       (delete-file kotl-file))))
 
+(ert-deftest kotl-mode-copy-kotl-file-updates-root-id-attributes ()
+  "Verify root id-attribute is updated when kotl mode is copied."
+  (let ((kotl-file (make-temp-file "hypb" nil ".kotl"))
+        (new-name (concat (make-temp-name (concat temporary-file-directory "hypb")) ".kotl")))
+    (unwind-protect
+        (progn
+          (find-file kotl-file)
+          (insert "a cell")
+          (save-buffer)
+          (should (string= (kcell:get-attr (kcell-view:cell-from-ref 0) 'file) kotl-file))
+
+          (copy-file kotl-file new-name)
+          (find-file new-name)
+          (should (string= (kcell:get-attr (kcell-view:cell-from-ref 0) 'file) new-name)))
+      (progn
+        (delete-file kotl-file)
+        (delete-file new-name)))))
+
 (provide 'kotl-mode-tests)
 ;;; kotl-mode-tests.el ends here


### PR DESCRIPTION
## What

Add test for root cell file attribute on copied file.

## Why

Verification of newly added functionality.

