### PR TITLE
Add hypb--installation-type with test and use it

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
-2022-01-25  Bob Weiner  <rsw@gnu.org>
+2022-01-28  Mats Lidell  <matsl@gnu.org>
 
+* test/hypb-tests.el (hypb--installation-type-test): Add unit test.
+
+* hypb.el (hypb--installation-type, hypb:configuration): Add function to
+    provide installation type and version number and use it.
+
+2022-01-25  Bob Weiner  <rsw@gnu.org>
 
 * kotl/kotl-mode.el (kotl-mode:copy-region-to-buffer): Fix interactive args listed in wrong
     order.

--- a/hypb.el
+++ b/hypb.el
@@ -3,9 +3,9 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     6-Oct-91 at 03:42:38
-;; Last-Mod:     24-Jan-22 at 00:21:55 by Bob Weiner
+;; Last-Mod:     28-Jan-22 at 23:49:07 by Mats Lidell
 ;;
-;; Copyright (C) 1991-2019  Free Software Foundation, Inc.
+;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.
@@ -107,6 +107,19 @@ Global keymap is used unless optional KEYMAP is given."
 	        "}"))
     (error "(hypb:cmd-key-string): Invalid cmd-sym arg: %s" cmd-sym)))
 
+(defun hypb--installation-type ()
+  "Return type of Hyperbole installation."
+  (let ((hypb-dir-name (file-name-nondirectory (directory-file-name hyperb:dir))))
+    (cond
+     ;; elpa-devel install -- hyperbole-8.0.0pre0.20220126.1138
+     ((string-match "hyperbole-\\([.[:digit:]]+pre[.[:digit:]]+\\).*" hypb-dir-name)
+      (list "elpa-devel" (match-string 1 hypb-dir-name)))
+     ;; git
+     ((file-exists-p (expand-file-name ".git" hyperb:dir))
+      (ignore-errors
+        (let ((default-directory hyperb:dir))
+          (list "git" (shell-command-to-string "git rev-parse HEAD"))))))))
+
 ;;;###autoload
 (defun hypb:configuration (&optional out-buf)
   "Insert Emacs configuration information at the end of optional OUT-BUF or the current buffer."
@@ -147,6 +160,9 @@ Global keymap is used unless optional KEYMAP is given."
                                (concat "PIEmail " pm-version))))))
       (when (and (boundp 'hnews:reader) (boundp 'gnus-version) hnews:reader)
         (insert (format "\tNews Reader: %s\n" gnus-version)))
+      (let ((install-type (hypb--installation-type)))
+        (when install-type
+          (insert (format "\tInstall:     %s, %s" (car install-type) (cadr install-type)))))
       (insert "\n")
       ;; Insert recent Hyperbole debugging messages if any.
       (when (get-buffer "*Messages*")

--- a/test/hypb-tests.el
+++ b/test/hypb-tests.el
@@ -3,9 +3,9 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:     5-Apr-21 at 18:53:10
-;; Last-Mod:     24-Jan-22 at 00:41:04 by Bob Weiner
+;; Last-Mod:     28-Jan-22 at 23:49:07 by Mats Lidell
 ;;
-;; Copyright (C) 2021  Free Software Foundation, Inc.
+;; Copyright (C) 2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.
@@ -19,6 +19,7 @@
 (require 'hypb)
 (require 'hbut)
 (require 'ert)
+(require 'el-mock)
 
 ;; Test for replace-regexp-in-string copied from emacs src
 (ert-deftest hypb:replace-match-string-test ()
@@ -90,6 +91,32 @@
                    "a bbba"))
     (should (equal (hypb:replace-match-string "\\`\\|x" "--xx--" "z")
                    "z--zz--"))))
+
+(ert-deftest hypb--installation-type-test ()
+  "Verify installation type alternatives."
+  (let ((hyperb:dir "/home/user/.emacs.d/elpa/hyperbole-8.0.0pre0.20220126.1138"))
+    (should (equal (hypb--installation-type) '("elpa-devel" "8.0.0pre0.20220126.1138"))))
+  (let ((hyperb:dir "/a_git_folder"))
+    (with-mock
+      (mock (file-exists-p "/a_git_folder/.git") => t)
+      (mock (shell-command-to-string "git rev-parse HEAD") => "abcdefg")
+      (should (equal (hypb--installation-type) '("git" "abcdefg")))))
+  (let ((hyperb:dir "/a_git_folder"))
+    (with-mock
+      (mock (file-exists-p "/a_git_folder/.git") => t)
+      (cl-letf (((symbol-function 'shell-command-to-string)
+                 (lambda (_cmd) (error "Something bad happend"))))
+        (should (equal (hypb--installation-type) '("git" "abcdefg"))))))
+  (let ((hyperb:dir "/a_git_folder"))
+    (with-mock
+      (mock (file-exists-p "/a_git_folder/.git") => nil)
+      (should-not (hypb--installation-type)))))
+
+;; This file can't be byte-compiled without the `el-mock' package (because of
+;; the use of the `with-mock' macro), which is not a dependency of Hyperbole.
+;;  Local Variables:
+;;  no-byte-compile: t
+;;  End:
 
 (provide 'hypb-tests)
 ;;; hypb-tests.el ends here


### PR DESCRIPTION
## What

Add hypb--installation-type with test and use it

## Why

Attempt to provide some extra info about a users install method and version. Provides checks for `elpa devel` pre-release and `git` install.

## Note

Depends on version number containing text pre and that a git user has git installed.
