### PR TITLE
Use 10 digit hash to document git based install (Was: Remove bad test case)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2022-02-03  Mats Lidell  <matsl@gnu.org>
+
+* hypb.el (hypb--installation-type): Return 10 digit git hash.
+
 2022-02-02  Mats Lidell  <matsl@gnu.org>
 
 * hargs.el (hargs:reading-type): Renaming var.

--- a/hypb.el
+++ b/hypb.el
@@ -118,7 +118,9 @@ Global keymap is used unless optional KEYMAP is given."
      ((file-exists-p (expand-file-name ".git" hyperb:dir))
       (ignore-errors
         (let ((default-directory hyperb:dir))
-          (list "git" (shell-command-to-string "git rev-parse HEAD"))))))))
+          (list
+           "git"
+           (substring (shell-command-to-string "git rev-parse HEAD") 0 10))))))))
 
 ;;;###autoload
 (defun hypb:configuration (&optional out-buf)

--- a/test/hypb-tests.el
+++ b/test/hypb-tests.el
@@ -99,8 +99,8 @@
   (let ((hyperb:dir "/a_git_folder"))
     (with-mock
       (mock (file-exists-p "/a_git_folder/.git") => t)
-      (mock (shell-command-to-string "git rev-parse HEAD") => "abcdefg")
-      (should (equal (hypb--installation-type) '("git" "abcdefg")))))
+      (mock (shell-command-to-string "git rev-parse HEAD") => "d43d05a0973e8adcbfdd8c85681dac5de669aaa9")
+      (should (equal (hypb--installation-type) '("git" "d43d05a097")))))
   (let ((hyperb:dir "/a_git_folder"))
     (with-mock
       (mock (file-exists-p "/a_git_folder/.git") => nil)

--- a/test/hypb-tests.el
+++ b/test/hypb-tests.el
@@ -92,26 +92,19 @@
     (should (equal (hypb:replace-match-string "\\`\\|x" "--xx--" "z")
                    "z--zz--"))))
 
-;; RSW 2022-01-29: Comment this out until Mats and I decide how it should work
-;; (ert-deftest hypb--installation-type-test ()
-;;   "Verify installation type alternatives."
-;;   (let ((hyperb:dir "/home/user/.emacs.d/elpa/hyperbole-8.0.0pre0.20220126.1138"))
-;;     (should (equal (hypb--installation-type) '("elpa-devel" "8.0.0pre0.20220126.1138"))))
-;;   (let ((hyperb:dir "/a_git_folder"))
-;;     (with-mock
-;;       (mock (file-exists-p "/a_git_folder/.git") => t)
-;;       (mock (shell-command-to-string "git rev-parse HEAD") => "abcdefg")
-;;       (should (equal (hypb--installation-type) '("git" "abcdefg")))))
-;;   (let ((hyperb:dir "/a_git_folder"))
-;;     (with-mock
-;;       (mock (file-exists-p "/a_git_folder/.git") => t)
-;;       (cl-letf (((symbol-function 'shell-command-to-string)
-;;                  (lambda (_cmd) (error "Something bad happend"))))
-;;         (should (equal (hypb--installation-type) '("git" "abcdefg"))))))
-;;   (let ((hyperb:dir "/a_git_folder"))
-;;     (with-mock
-;;       (mock (file-exists-p "/a_git_folder/.git") => nil)
-;;       (should-not (hypb--installation-type)))))
+(ert-deftest hypb--installation-type-test ()
+  "Verify installation type alternatives."
+  (let ((hyperb:dir "/home/user/.emacs.d/elpa/hyperbole-8.0.0pre0.20220126.1138"))
+    (should (equal (hypb--installation-type) '("elpa-devel" "8.0.0pre0.20220126.1138"))))
+  (let ((hyperb:dir "/a_git_folder"))
+    (with-mock
+      (mock (file-exists-p "/a_git_folder/.git") => t)
+      (mock (shell-command-to-string "git rev-parse HEAD") => "abcdefg")
+      (should (equal (hypb--installation-type) '("git" "abcdefg")))))
+  (let ((hyperb:dir "/a_git_folder"))
+    (with-mock
+      (mock (file-exists-p "/a_git_folder/.git") => nil)
+      (should-not (hypb--installation-type)))))
 
 ;; This file can't be byte-compiled without the `el-mock' package (because of
 ;; the use of the `with-mock' macro), which is not a dependency of Hyperbole.


### PR DESCRIPTION
## What

Use 10 digit git hash to document a git install and remove a bad designed test case

## Why

Use a 10 digit hash instead of a full git hash in the install documentation. 

Does also activate the unit test but with a test removed that was not working and got pushed before by mistake.

