### PR TITLE
Use find-tag--default from etags

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2022-02-05  Mats Lidell  <matsl@gnu.org>
+
+* hargs.el (hargs:find-tag-default): Remove own implementation for
+    find-tag-default and find-tag--default and rely on implementation in
+    Emacs.
+
 2022-02-05  Bob Weiner  <rsw@gnu.org>
 
 * kotl/kexport.el (kexport:buffer): Rename to 'kexport:koutline'.
@@ -38,7 +44,6 @@
 
 * hsmail.el (mail-yank-original): Fix indentation of this overloaded function.
             (message--yank-original-internal): Add overloading of this function.
-
 2022-02-04  Mats Lidell  <matsl@gnu.org>
 
 * test/hargs-tests.el (hargs-get-verify-extension-characters)

--- a/hargs.el
+++ b/hargs.el
@@ -29,6 +29,7 @@
 (require 'hpath)
 (require 'hypb)
 (require 'set)
+(require 'etags)                        ;For `find-tag--default'
 
 ;;; ************************************************************************
 ;;; Public variables
@@ -47,39 +48,7 @@
 ;;; Private functions
 ;;; ************************************************************************
 
-;;; From etags.el, so don't have to load the whole thing.
-(unless (fboundp 'find-tag-default)
-  (defun find-tag-default ()
-    (or (and (boundp 'find-tag-default-hook)
-	     (not (memq find-tag-default-hook '(nil find-tag-default)))
-	     (condition-case data
-		 (funcall find-tag-default-hook)
-	       (error
-		(message "value of find-tag-default-hook signalled error: %s"
-			 data)
-		(sit-for 1)
-		nil)))
-	(save-excursion
-	  (unless (memq (char-syntax (preceding-char)) '(?w ?_))
-	    (while (not (looking-at "\\sw\\|\\s_\\|\\'"))
-	      (forward-char 1)))
-	  (while (looking-at "\\sw\\|\\s_")
-	    (forward-char 1))
-	  (when (re-search-backward "\\sw\\|\\s_" nil t)
-	    (forward-char 1)
-	    (regexp-quote (buffer-substring (point)
-					    (progn (forward-sexp -1)
-						   (while (looking-at "\\s'")
-						     (forward-char 1))
-						   (point)))))))))
-
-(unless (fboundp 'find-tag--default)
-  (defun find-tag--default ()
-    (funcall (or (when (fboundp find-tag-default-function) find-tag-default-function)
-		 (get major-mode 'find-tag-default-function)
-		 'find-tag-default))))
-(defalias 'hargs:find-tag-default 'find-tag--default)
-
+(defalias 'hargs:find-tag-default #'find-tag--default)
 
 (defun hargs:action-get (action modifying)
   "Interactively get list of arguments for ACTION's parameters.


### PR DESCRIPTION
## What

Use find-tag--default from etags.

## Why

Patch from Stefan.  It makes sense to use the etags functionality as we also only provided our own version if user not already had etags loaded. So makes functionality less depending on users environment.
