### PR TITLE
Use copy-sequence

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2022-02-07  Mats Lidell  <matsl@gnu.org>
+
+* hbut.el (ibut:at-p): Use cl-lib. Thank you Stefan.
+
 2022-02-06  Bob Weiner  <rsw@gnu.org>
 
 * test/hui-tests.el (hui-gbut-modify-link-to-file-button): Some

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
-2022-02-07  Mats Lidell  <matsl@gnu.org>
+2022-02-08  Mats Lidell  <matsl@gnu.org>
 
-* hbut.el (ibut:at-p): Use cl-lib. Thank you Stefan.
+* hbut.el (ibut:at-p): Use copy-sequence, remove dependency on
+    cl-lib. Thanks Stefan Monnier.
 
 2022-02-06  Bob Weiner  <rsw@gnu.org>
 

--- a/hbut.el
+++ b/hbut.el
@@ -3,9 +3,9 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:      5-Feb-22 at 23:17:58 by Bob Weiner
+;; Last-Mod:      7-Feb-22 at 23:03:27 by Mats Lidell
 ;;
-;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
+;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.
@@ -17,8 +17,8 @@
 ;;; Other required Elisp libraries
 ;;; ************************************************************************
 
-;; Require 'cl for `copy-list'
-(eval-and-compile (mapc #'require '(cl elisp-mode help-mode hversion hmoccur
+;; Require `cl-lib' for `cl-copy-list'.
+(eval-and-compile (mapc #'require '(cl-lib elisp-mode help-mode hversion hmoccur
 				    hbmap htz hbdata hact view)))
 
 ;;; ************************************************************************
@@ -1536,7 +1536,7 @@ excluding delimiters, not just one."
 		  (or (hattr:get 'hbut:current 'args)
 		      (not (listp args))
 		      (progn
-			(setq args (copy-list args))
+			(setq args (cl-copy-list args)) ;FIXME: copy-sequence?
 			(when (eq (car args) #'hact)
 			  (setq args (cdr args)))
 			(hattr:set 'hbut:current 'actype

--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:      7-Feb-22 at 23:03:27 by Mats Lidell
+;; Last-Mod:      8-Feb-22 at 23:54:24 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -17,9 +17,8 @@
 ;;; Other required Elisp libraries
 ;;; ************************************************************************
 
-;; Require `cl-lib' for `cl-copy-list'.
-(eval-and-compile (mapc #'require '(cl-lib elisp-mode help-mode hversion hmoccur
-				    hbmap htz hbdata hact view)))
+(eval-and-compile (mapc #'require '(elisp-mode help-mode hversion hmoccur
+                                               hbmap htz hbdata hact view)))
 
 ;;; ************************************************************************
 ;;; Public declarations
@@ -1536,7 +1535,7 @@ excluding delimiters, not just one."
 		  (or (hattr:get 'hbut:current 'args)
 		      (not (listp args))
 		      (progn
-			(setq args (cl-copy-list args)) ;FIXME: copy-sequence?
+			(setq args (copy-sequence args))
 			(when (eq (car args) #'hact)
 			  (setq args (cdr args)))
 			(hattr:set 'hbut:current 'actype


### PR DESCRIPTION
## What

Use copy-sequence.

## Why

copy-sequence is a built in function and we can drop dependency on cl-lib. Suggestion from Stefan.