### PR TITLE
Use underscore prefix on unused arguments

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2022-02-13  Mats Lidell  <matsl@gnu.org>
+
+* Silence warnings about unused lexical arguments by prefixing names with
+    underscores.
+
 2022-02-12  Bob Weiner  <rsw@gnu.org>
 
 * kotl/klink.el (klink:act): Add save-excursion, so point always ends

--- a/hactypes.el
+++ b/hactypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    23-Sep-91 at 20:34:36
-;; Last-Mod:     12-Feb-22 at 10:38:30 by Bob Weiner
+;; Last-Mod:     13-Feb-22 at 19:48:50 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -437,7 +437,7 @@ the window or as close as possible."
       (hpath:find-line path line-num))
     (move-to-column column-num)))
 
-(defact link-to-gbut (key &optional key-file)
+(defact link-to-gbut (key &optional _key-file)
   "Perform an action given by an existing global button, specified by KEY.
 Optional second arg, KEY-FILE, is not used but is for calling
 compatibility with the `hlink' function."

--- a/hargs.el
+++ b/hargs.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    31-Oct-91 at 23:17:35
-;; Last-Mod:      5-Feb-22 at 21:48:56 by Bob Weiner
+;; Last-Mod:     12-Feb-22 at 10:11:21 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -788,7 +788,7 @@ help when appropriate."
 		   prompt
 		   ;; Match to "0" and visible cell labels only
 		   (cons "0"
-			 (kview:map-tree (lambda (kview) (kcell-view:label)) kview t t))
+			 (kview:map-tree (lambda (_kview) (kcell-view:label)) kview t t))
 		   nil t (kcell-view:visible-label) 'kcell)))
    ;; Get kcell or path reference for use in a link.
    (?L . (klink . (hargs:read prompt nil default nil 'klink)))

--- a/hbdata.el
+++ b/hbdata.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Apr-91
-;; Last-Mod:     24-Jan-22 at 00:18:05 by Bob Weiner
+;; Last-Mod:     12-Feb-22 at 10:12:23 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -82,7 +82,7 @@
   "Return the list of any arguments given in HBDATA."
   (nth 4 hbdata))
 
-(defun hbdata:categ (hbdata)
+(defun hbdata:categ (_hbdata)
   "Return the category of HBDATA's button."
   'explicit)
 
@@ -149,8 +149,7 @@ Search is case-insensitive.  Return list with elements:
 MOD-LBL-KEY nil means create a new entry, otherwise modify existing one.
 Nil BUT-SYM means use 'hbut:current'.  If successful, return a cons of
  (button-data . button-instance-str), else nil."
-  (let* ((but)
-	 (b (hattr:copy (or but-sym 'hbut:current) 'but))
+  (let* ((b (hattr:copy (or but-sym 'hbut:current) 'but))
 	 (l (hattr:get b 'loc))
 	 (key (or mod-lbl-key (hattr:get b 'lbl-key)))
 	 (new-key (if mod-lbl-key (hattr:get b 'lbl-key) key))

--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:      8-Feb-22 at 23:54:24 by Mats Lidell
+;; Last-Mod:     12-Feb-22 at 10:42:20 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -256,7 +256,7 @@ positions at which the button delimiter begins and ends."
 				;; Normalize label spacing
 				(list (ebut:key-to-label (ebut:label-to-key lbl))
 				      start end))
-			    (lambda (lbl start end)
+			    (lambda (lbl _start _end)
 			      ;; Normalize label spacing
 			      (ebut:key-to-label (ebut:label-to-key lbl)))))))
       (if loc-p buts (when buts (apply #'set:create buts))))))
@@ -334,7 +334,7 @@ button is found in the current buffer."
 			      (nth 2 but-key-and-pos)
 			      instance-flag))
 	      (cond ((ebut:map
-		      (lambda (lbl start end)
+		      (lambda (_lbl start end)
 			(delete-region start end)
 			(ebut:delimit
 			 (point)
@@ -524,7 +524,7 @@ enables partial matches."
 Leave point inside the button label.  Return the symbol for the button, else nil."
   (unless lbl-key
     (setq lbl-key (ebut:label-p nil nil nil nil t)))
-  (hbut:funcall (lambda (lbl-key buffer key-src)
+  (hbut:funcall (lambda (lbl-key _buffer _key-src)
 		  ;; Handle a label given rather than a label key
 		  (if (string-match-p "\\s-" lbl-key)
 		      (setq lbl-key (ebut:label-to-key lbl-key)))
@@ -726,7 +726,7 @@ Return the symbol for the button when found, else nil."
       (with-current-buffer (find-file-noselect (gbut:file))
 	(save-restriction
 	  (widen)
-	  (ibut:label-map #'(lambda (label start end) (ibut:label-to-key label))))))))
+	  (ibut:label-map #'(lambda (label _start _end) (ibut:label-to-key label))))))))
 
 ;;; ========================================================================
 ;;; hattr class
@@ -1446,7 +1446,7 @@ source file for the buttons in the menu, if any.")
     (when (hbut:key-src-set-buffer (or key-src (current-buffer)))
       (save-restriction
 	(widen)
-	(ibut:label-map #'(lambda (label start end) (ibut:label-to-key label)))))))
+	(ibut:label-map #'(lambda (label _start _end) (ibut:label-to-key label)))))))
 
 ;;; ========================================================================
 ;;; ibut class - Implicit Hyperbole Buttons
@@ -1608,7 +1608,7 @@ Return nil if no matching button is found."
   (save-excursion
     (unless lbl-key
       (setq lbl-key (ibut:label-p nil nil nil nil t)))
-    (hbut:funcall (lambda (lbl-key buffer key-src)
+    (hbut:funcall (lambda (lbl-key _buffer _key-src)
 		    (goto-char (point-min))
 		    (ibut:next-occurrence lbl-key)
 		    (ibut:at-p))
@@ -1620,8 +1620,8 @@ Return nil if no matching button is found."
     (let ((categ (hattr:get object 'categ)))
       (and categ (string-match "\\`ibtypes::" (symbol-name categ))))))
 
-(defun    ibut:label-map (but-func &optional start-delim end-delim
-				   regexp-match include-delims)
+(defun    ibut:label-map (but-func &optional _start-delim _end-delim
+				   _regexp-match _include-delims)
   "Apply BUT-FUNC to buttons delimited by optional START-DELIM and END-DELIM.
 START-DELIM defaults to ibut:label-start; END-DELIM defaults to ibut:label-end.
 If REGEXP-MATCH is non-nil, only buttons which match this argument are
@@ -1715,7 +1715,7 @@ positions at which the button label delimiter begins and ends."
 				;; Normalize label spacing
 				(list (ibut:key-to-label (ibut:label-to-key lbl))
 				      start end))
-			    (lambda (lbl start end)
+			    (lambda (lbl _start _end)
 			      ;; Normalize label spacing
 			      (ibut:key-to-label (ibut:label-to-key lbl)))))))
       (if loc-p buts (when buts (apply #'set:create buts))))))
@@ -1732,7 +1732,7 @@ positions at which the button label delimiter begins and ends."
 (defalias 'ibut:label-to-key 'hbut:label-to-key)
 (defalias 'map-ibut          'ibut:map)
 
-(defun    ibut:map (but-func &optional start-delim end-delim
+(defun    ibut:map (but-func &optional _start-delim _end-delim
 			     regexp-match include-delims)
   "Apply BUT-FUNC to the labeled implicit buttons in the visible part of the current buffer.
 If REGEXP-MATCH is non-nil, only buttons which match this argument are
@@ -1781,7 +1781,7 @@ Leave point inside the button text or its optional label, if it has one.
 Return the symbol for the button, else nil."
   (unless lbl-key
     (setq lbl-key (ibut:label-p nil nil nil nil t)))
-  (hbut:funcall (lambda (lbl-key buffer key-src)
+  (hbut:funcall (lambda (lbl-key _buffer _key-src)
 		  (when lbl-key
 		    ;; Handle a label given rather than a label key
 		    (when (string-match-p "\\s-" lbl-key)
@@ -1855,14 +1855,11 @@ Return the symbol for the button if found, else nil."
   (unless lbl-key
     (setq lbl-key (ibut:label-p nil nil nil nil t)))
   (hbut:funcall
-   (lambda (lbl-key buffer key-src)
+   (lambda (lbl-key _buffer _key-src)
      (let* ((name-start-end (ibut:label-p nil nil nil t t))
 	    (name-start (nth 1 name-start-end))
 	    (at-name (car name-start-end))
 	    (at-lbl-key (ibut:label-p nil "\"" "\"" nil t))
-	    (opoint (point))
-	    move-flag
-	    start
 	    ibut)
        (cond ((or (and at-name (equal at-name lbl-key))
 		  (and lbl-key (equal at-lbl-key lbl-key)))
@@ -1887,7 +1884,7 @@ Return the symbol for the button if found, else nil."
   (unless lbl-key
     (setq lbl-key (ibut:label-p nil nil nil nil t)))
   (hbut:funcall
-   (lambda (lbl-key buffer key-src)
+   (lambda (lbl-key _buffer _key-src)
      (let* ((name-start-end (ibut:label-p t nil nil t t))
 	    (name-end (nth 2 name-start-end))
 	    (at-name (car name-start-end))
@@ -1939,7 +1936,7 @@ See also `ibut:label-separator-regexp' for all valid characters that may manuall
 ;;; ibtype class - Implicit button types
 ;;; ========================================================================
 
-(defmacro defib (type params doc at-p &optional to-p style)
+(defmacro defib (type _params doc at-p &optional to-p style)
   "Create Hyperbole implicit button TYPE with PARAMS, described by DOC.
 TYPE is an unquoted symbol.  PARAMS are presently ignored.
 

--- a/hib-social.el
+++ b/hib-social.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    20-Jul-16 at 22:41:34
-;; Last-Mod:     12-Feb-22 at 18:51:06 by Bob Weiner
+;; Last-Mod:     13-Feb-22 at 19:49:11 by Mats Lidell
 ;;
 ;; Copyright (C) 2016-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -668,7 +668,7 @@ Return the project directory found or nil if none."
       ;; ...and return it.
       project-dir)))
 
-(defun hibtypes-git-build-or-add-to-repos-cache (project &optional prompt-flag)
+(defun hibtypes-git-build-or-add-to-repos-cache (project &optional _prompt-flag)
   "Store cache of local git repo directories in `hibtypes-git-repos-cache'.
 With optional PROMPT-FLAG non-nil, prompt user whether to build the cache before building.
 Return t if built, nil otherwise."

--- a/hmouse-info.el
+++ b/hmouse-info.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Apr-89
-;; Last-Mod:     24-Jan-22 at 00:18:46 by Bob Weiner
+;; Last-Mod:     12-Feb-22 at 10:42:20 by Mats Lidell
 ;;
 ;; Copyright (C) 1989-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -233,7 +233,7 @@ entry and returns t; otherwise returns nil."
 
 ;;; Much of this is derived in part from "info.el".
 
-(defun Info-build-menu-item-completions (string predicate action)
+(defun Info-build-menu-item-completions (string _predicate action)
   ;; See comments in `Info-complete-menu-item' for free variables used.
   (with-current-buffer Info-complete-menu-buffer
     (save-excursion

--- a/hmouse-tag.el
+++ b/hmouse-tag.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    24-Aug-91
-;; Last-Mod:     24-Jan-22 at 00:18:46 by Bob Weiner
+;; Last-Mod:     12-Feb-22 at 10:42:20 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -474,7 +474,7 @@ Otherwise:
 		    (beep))))))
 
 ;;; The following should be called only if the OO-Browser is available.
-(defun smart-java-oo-browser (&optional junk)
+(defun smart-java-oo-browser (&optional _junk)
   "Jumps to the definition of selected Java construct via OO-Browser support.
 Optional JUNK is ignored.  Does nothing if the OO-Browser is not available.
 
@@ -832,7 +832,7 @@ Otherwise:
 	   (beep)))))))
 
 ;;; The following should be called only if the OO-Browser is available.
-(defun smart-objc-oo-browser (&optional junk)
+(defun smart-objc-oo-browser (&optional _junk)
   "Jump to the definition of selected Objective-C construct via OO-Browser support.
 Optional JUNK is ignored.  Does nothing if the OO-Browser is not available.
 
@@ -940,7 +940,7 @@ in the current directory or any of its ancestor directories."
 		    (beep))))))
 
 ;;; The following should be called only if the OO-Browser is available.
-(defun smart-python-oo-browser (&optional junk)
+(defun smart-python-oo-browser (&optional _junk)
   "Jumps to the definition of selected Python construct via OO-Browser support.
 Optional JUNK is ignored.  Does nothing if the OO-Browser is not available.
 

--- a/hsettings.el
+++ b/hsettings.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Apr-91 at 00:48:49
-;; Last-Mod:     24-Jan-22 at 00:18:47 by Bob Weiner
+;; Last-Mod:     12-Feb-22 at 10:42:19 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -213,7 +213,7 @@ to your personal Emacs initialization file, prior to loading
 Hyperbole, and then restart Emacs."
   :type 'boolean
   :initialize #'custom-initialize-set
-  :set (lambda (symbol value)
+  :set (lambda (_symbol value)
 	 ;; Invert value to produce ARG for hyperbole-toggle-messaging.
 	 (hyperbole-toggle-messaging (if value 0 1)))
   :group 'hyperbole-buttons)

--- a/hsys-www.el
+++ b/hsys-www.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Apr-94 at 17:17:39 by Bob Weiner
-;; Last-Mod:     24-Jan-22 at 00:18:47 by Bob Weiner
+;; Last-Mod:     12-Feb-22 at 10:42:19 by Mats Lidell
 ;;
 ;; Copyright (C) 1994-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -113,7 +113,7 @@ is used.  Valid values of this variable include `browse-url-default-browser' and
     (error "(www-url): `browse-url-browser-function' must be set to a web browser invoking function")))
 
 ;;;###autoload
-(defun www-url-expand-file-name (path &optional dir)
+(defun www-url-expand-file-name (path &optional _dir)
   "Expand PATH in DIR.  Return http urls unchanged."
   (if (listp path)
       (setq dir  (car (cdr path))

--- a/hui-mouse.el
+++ b/hui-mouse.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-89
-;; Last-Mod:     24-Jan-22 at 00:18:48 by Bob Weiner
+;; Last-Mod:     12-Feb-22 at 10:36:40 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -1615,7 +1615,7 @@ If not on a file name, returns nil."
 ;;; smart-org functions
 ;;; ************************************************************************
 
-(defun smart-org (&optional assist-flag)
+(defun smart-org (&optional _assist-flag)
   "If `hsys-org-enable-smart-keys' is non-nil, follow Org mode references, cycles outline visibility and executes code blocks.
 
 When the Action Key is pressed:

--- a/hui-select.el
+++ b/hui-select.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Oct-96 at 02:25:27
-;; Last-Mod:     31-Jan-22 at 00:48:38 by Bob Weiner
+;; Last-Mod:     12-Feb-22 at 10:42:19 by Mats Lidell
 ;;
 ;; Copyright (C) 1996-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -1421,7 +1421,7 @@ list, hui-select-markup-modes."
     (hui-select-set-region (progn (backward-page) (point))
 			   (progn (forward-page) (point)))))
 
-(defun hui-select-buffer (pos)
+(defun hui-select-buffer (_pos)
   "Return (start . end) of the buffer at POS."
   (setq hui-select-previous 'buffer)
   (hui-select-set-region (point-min) (point-max)))

--- a/hyperbole.el
+++ b/hyperbole.el
@@ -5,7 +5,7 @@
 ;; Author:           Bob Weiner
 ;; Maintainer:       Bob Weiner <rsw@gnu.org>, Mats Lidell <matsl@gnu.org>
 ;; Created:          06-Oct-92 at 11:52:51
-;; Last-Mod:     24-Jan-22 at 00:23:14 by Bob Weiner
+;; Last-Mod:     12-Feb-22 at 10:42:19 by Mats Lidell
 ;; Released:         03-May-21
 ;; Version:          8.0.0pre
 ;; Keywords:         comm, convenience, files, frames, hypermedia, languages, mail, matching, mouse, multimedia, outlines, tools, wp
@@ -187,17 +187,17 @@ context (wherever point is).  {C-u \\[hkey-help]} shows what the Assist Key will
   hyperbole-mode-map)
 
 (make-obsolete 'hkey-global-set-key 'hkey-set-key "8.0.0")
-(defun hkey-global-set-key (key command &optional no-add)
+(defun hkey-global-set-key (key command &optional _no-add)
   "Define a Hyperbole KEY bound to COMMAND.  Optional third arg, NO-ADD is ignored."
   (define-key hyperbole-mode-map key command))
 
 (make-obsolete 'hkey-maybe-global-set-key 'hkey-maybe-set-key "8.0.0")
-(defun hkey-maybe-global-set-key (key command &optional no-add)
+(defun hkey-maybe-global-set-key (key command &optional _no-add)
   "Define a Hyperbole KEY bound to COMMAND if KEY is not bound in `hyperbole-mode-map'.
 Third argument NO-ADD is ignored."
   (hkey-maybe-set-key key command))
 
-(defun hkey-maybe-set-key (key command &optional no-add)
+(defun hkey-maybe-set-key (key command &optional _no-add)
   "Define a Hyperbole KEY bound to COMMAND if KEY is not bound in `hyperbole-mode-map'.
 Third argument NO-ADD is ignored."
   (let ((lookup-result (lookup-key hyperbole-mode-map key)))

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Jun-89 at 22:08:29
-;; Last-Mod:     24-Jan-22 at 00:23:35 by Bob Weiner
+;; Last-Mod:     12-Feb-22 at 10:42:19 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -955,7 +955,7 @@ Return number of matching entries found."
     (hyrolo-grep-file hyrolo-file-or-buf regexp max-matches count-only)))
 
 ;; Derived from google-contacts.el.
-(defun hyrolo-google-contacts-insert-data (contacts token contact-prefix-string)
+(defun hyrolo-google-contacts-insert-data (contacts _token contact-prefix-string)
   (if (not contacts)
       ;; No contacts, insert a string and return nil
       (insert "No result.")
@@ -1211,8 +1211,8 @@ Return number of groupings matched."
 	(hyrolo-kill-buffer actual-buf)
 	num-found))))
 
-(defun hyrolo-map-level-1 (actual-buf num-found exact-level-regexp
-				      outline-regexp buffer-read-only level-len func hyrolo-file-or-buf level-regexp max-groupings)
+(defun hyrolo-map-level-1 (_actual-buf num-found _exact-level-regexp
+				      outline-regexp buffer-read-only level-len func _hyrolo-file-or-buf _level-regexp _max-groupings)
   (setq num-found (1+ num-found))
   (let* ((opoint (prog1 (point) (beginning-of-line)))
 	 (grouping-start (point))
@@ -1298,7 +1298,7 @@ HYROLO-BUF may be a file-name, `buffer-name', or buffer."
 	    ", "
 	    (substring name-str (match-beginning first) (match-end first)))))
 
-(defun hyrolo-highlight-matches (regexp start end)
+(defun hyrolo-highlight-matches (regexp start _end)
   "Highlight matches for REGEXP in region from START to END."
   (when (fboundp 'hproperty:but-add)
     (let ((hproperty:but-emphasize-flag))
@@ -1488,7 +1488,7 @@ Return point where matching entry begins or nil if not found."
     (widen)
     found))
 
-(defun hyrolo-to-buffer (buffer &optional other-window-flag frame)
+(defun hyrolo-to-buffer (buffer &optional other-window-flag _frame)
   "Pop to BUFFER."
   (pop-to-buffer buffer other-window-flag))
 

--- a/kotl/kexport.el
+++ b/kotl/kexport.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    26-Feb-98
-;; Last-Mod:      5-Feb-22 at 16:24:59 by Bob Weiner
+;; Last-Mod:     12-Feb-22 at 10:42:20 by Mats Lidell
 ;;
 ;; Copyright (C) 1998-2021  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -461,7 +461,7 @@ hard newlines are not used.  Also converts Urls and Klinks into Html hyperlinks.
 		 "&gt;"))
 	       i is-parent is-last-sibling no-sibling-stack level label contents)
 	  (kview:map-tree
-	   (lambda (kview)
+	   (lambda (_kview)
 	     (setq level (kcell-view:level)
 		   i level
 		   is-parent (kcell-view:child-p)

--- a/kotl/kfile.el
+++ b/kotl/kfile.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    10/31/93
-;; Last-Mod:     29-Jan-22 at 15:24:12 by Bob Weiner
+;; Last-Mod:     12-Feb-22 at 10:42:20 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2021  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -281,7 +281,7 @@ VISIBLE-ONLY-P is non-nil.  Signal an error if kotl is not attached to a file."
       ;; Prepare cell data for saving.
       (kfile:narrow-to-kcells)
       (kview:map-tree
-        (lambda (view)
+        (lambda (_view)
 	  (setq cell (kcell-view:cell))
 	  (aset kcell-data
 		kcell-num
@@ -386,7 +386,7 @@ included in the list."
      kotl-structure)
     (nreverse cell-list)))
 
-(defun kfile:insert-attributes-v2 (kview kcell-list)
+(defun kfile:insert-attributes-v2 (_kview kcell-list)
   "Set cell attributes within KVIEW for each element in KCELL-LIST.
 Assume all cell contents are already in kview and that no cells are
 hidden."
@@ -403,7 +403,7 @@ hidden."
 	    (setq kcell-list (cdr kcell-list)))
 	  (search-forward "\n\n" nil t)))))
 
-(defun kfile:insert-attributes-v3 (kview kcell-vector)
+(defun kfile:insert-attributes-v3 (_kview kcell-vector)
   "Set cell attributes within KVIEW for each element in KCELL-VECTOR.
 Assume all cell contents are already in kview and that no cells are
 hidden."

--- a/kotl/kimport.el
+++ b/kotl/kimport.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Nov-93 at 11:57:05
-;; Last-Mod:      5-Feb-22 at 15:46:39 by Bob Weiner
+;; Last-Mod:     12-Feb-22 at 10:42:20 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2021  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -662,7 +662,7 @@ in IMPORT-FROM, used to show a running tally of the imported entries."
   count)
 
 (defun kimport:text-paragraphs (import-from output-to klabel
-			        output-level count total)
+			        output-level _count total)
   "Insert text paragraphs from IMPORT-FROM into existing OUTPUT-TO.
 First cell is inserted with KLABEL at OUTPUT-LEVEL, as the sibling of the
 previous cell, with the COUNT of inserted paragraphs starting at 0.  TOTAL is

--- a/kotl/klabel.el
+++ b/kotl/klabel.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    17-Apr-94
-;; Last-Mod:     24-Jan-22 at 00:25:18 by Bob Weiner
+;; Last-Mod:     12-Feb-22 at 10:42:20 by Mats Lidell
 ;;
 ;; Copyright (C) 1994-2021  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -80,11 +80,11 @@
 	 (intern-soft (concat "klabel:child-"
 			      (symbol-name label-type))))
 	((eq label-type 'no)
-	 (lambda (label) ""))
+	 (lambda (_label) ""))
 	((eq label-type 'star)
 	 (lambda (label) (concat label "*")))
 	((eq label-type 'id)
-	 (lambda (label) (format "0%s" (or (kview:id-counter kview) ""))))
+	 (lambda (_label) (format "0%s" (or (kview:id-counter kview) ""))))
 	(t (error
 	    "(klabel-type:child): Invalid label type setting: `%s'"
 	    label-type))))
@@ -95,11 +95,11 @@ If the label is \"0\", its first child is computed, otherwise, the next sibling 
   (cond ((memq label-type '(alpha legal partial-alpha))
 	 (intern-soft (concat "klabel:increment-" (symbol-name label-type))))
 	((eq label-type 'no)
-	 (lambda (label) ""))
+	 (lambda (_label) ""))
 	((eq label-type 'star)
 	 (lambda (label) (if (string-equal label "0") "*" label)))
 	((eq label-type 'id)
-	 (lambda (label) (format "0%s" (or (kview:id-increment kview) ""))))
+	 (lambda (_label) (format "0%s" (or (kview:id-increment kview) ""))))
 	(t (error
 	    "(klabel:increment): Invalid label type setting: `%s'" label-type))))
 
@@ -262,7 +262,7 @@ is the display label of the cell preceding the current one and child-p is
 non-nil if cell is to be the child of the preceding cell."
   (or label-type (setq label-type (kview:label-type kview)))
   (cond ((eq label-type 'no)
-	 (lambda (prev-label &optional child-p)
+	 (lambda (_prev-label &optional _child-p)
 	   ""))
 	((eq label-type 'partial-alpha)
 	 (lambda (prev-label &optional child-p)
@@ -271,7 +271,7 @@ non-nil if cell is to be the child of the preceding cell."
 		   "a" "1")
 	     (kotl-label:increment prev-label 1))))
 	((eq label-type 'id)
-	 (lambda (prev-label &optional child-p)
+	 (lambda (_prev-label &optional _child-p)
 	   (kcell-view:idstamp)))
 	(t (intern-soft (concat "klabel-type:"
 				(symbol-name label-type) "-label")))))
@@ -368,7 +368,7 @@ and the start of its contents."
 	(goto-char opoint)
 	(setq current-cell-label nil)))))
 
-(defun klabel-type:set-id (current-cell-label label-sep-len &rest ignore)
+(defun klabel-type:set-id (_current-cell-label label-sep-len &rest _ignore)
   "Set the labels of current cell, its following siblings and their subtrees.
 CURRENT-CELL-LABEL is the label to display for the current cell."
   ;; Only need to do this when switching from one label type to another,
@@ -413,7 +413,7 @@ and the start of its contents."
 	(goto-char opoint)
 	(setq current-cell-label nil)))))
 
-(defun klabel-type:set-no (current-cell-label label-sep-len &rest ignore)
+(defun klabel-type:set-no (_current-cell-label label-sep-len &rest _ignore)
   "Set the labels of current cell, its following siblings and their subtrees.
 CURRENT-CELL-LABEL is the label to display for the current cell."
   ;; Only need to do this when switching from one label type to another,
@@ -463,7 +463,7 @@ and the start of its contents."
 	(goto-char opoint)
 	(setq current-cell-label nil)))))
 
-(defun klabel-type:set-star (current-cell-label label-sep-len &rest ignore)
+(defun klabel-type:set-star (_current-cell-label label-sep-len &rest _ignore)
   "Set the labels of current cell, its following siblings and their subtrees.
 CURRENT-CELL-LABEL is the label to display for the current cell.
 LABEL-SEP-LEN is the length of the separation between a cell's label
@@ -490,7 +490,7 @@ If, however, it is \"0\", then all cell labels are updated."
 	(klabel-type:update-labels-from-point
 	 label-type current-cell-label)))))
 
-(defun klabel-type:update-tree-labels (current-cell-label first-label)
+(defun klabel-type:update-tree-labels (_current-cell-label first-label)
   "Update the labels of current cell and its subtree.
 CURRENT-CELL-LABEL is the label to display for the current cell.
 Use `(klabel-type:update-labels \"0\")' to update all cells in an outline."

--- a/kotl/kproperty.el
+++ b/kotl/kproperty.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    7/27/93
-;; Last-Mod:     24-Jan-22 at 00:25:31 by Bob Weiner
+;; Last-Mod:     12-Feb-22 at 10:42:20 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2021  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -35,7 +35,7 @@
   "Return a list of all non-narrowed buffer positions of kcells with PROPERTY set to VALUE, else nil.
 Use (kcell-view:start <position>) on each returned <position> to get
 the start position of each cell's content."
-  (kproperty:map (lambda (start end) start) property value))
+  (kproperty:map (lambda (start _end) start) property value))
 
 (defalias 'kproperty:get 'get-text-property)
 

--- a/kotl/kview.el
+++ b/kotl/kview.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:     12-Feb-22 at 18:51:04 by Bob Weiner
+;; Last-Mod:     13-Feb-22 at 19:50:05 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2021  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -394,7 +394,7 @@ Return t unless no next cell."
     (goto-char (kcell-view:start nil label-sep-len))
     t))
 
-(defun kcell-view:next-invisible-p (&optional pos label-sep-len)
+(defun kcell-view:next-invisible-p (&optional _pos label-sep-len)
   "Return t if there is a next cell after optional POS or point and it is invisible."
   (save-excursion (and (kcell-view:next nil label-sep-len)
 		       (kcell-view:invisible-p (point) label-sep-len))))
@@ -941,8 +941,7 @@ See also `kview:map-branch' and `kview:map-tree'."
     (with-current-buffer (kview:buffer kview)
       (save-excursion
 	(let ((results)
-	      (label-sep-len (kview:label-separator-length kview))
-	      cell-indent)
+	      (label-sep-len (kview:label-separator-length kview)))
 	  ;; Next line ensures point is in the root of the current tree if
 	  ;; the tree is at all hidden.
 	  (when visible-p (kotl-mode:to-start-of-line))
@@ -1100,7 +1099,7 @@ FILL-P is non-nil.  Leave point at TO-START."
 					 1)
 				      ?\ )))
 	      (kview:map-tree
-	       (lambda (view)
+	       (lambda (_view)
 		 (save-excursion
 		   (beginning-of-line)
 		   (when (looking-at expr)
@@ -1109,7 +1108,7 @@ FILL-P is non-nil.  Leave point at TO-START."
 	  ;;
 	  (when fill-p
 	    ;; Refill cells lacking no-fill attribute.
-	    (kview:map-tree (lambda (view) (kotl-mode:fill-cell nil t))
+	    (kview:map-tree (lambda (_view) (kotl-mode:fill-cell nil t))
 			    kview t))))
     ;;
     (goto-char new-start)

--- a/kotl/kvspec.el
+++ b/kotl/kvspec.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Oct-95 at 15:17:07
-;; Last-Mod:     24-Jan-22 at 00:25:33 by Bob Weiner
+;; Last-Mod:     12-Feb-22 at 10:42:20 by Mats Lidell
 ;;
 ;; Copyright (C) 1995-2021  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -103,7 +103,7 @@ display all levels of cells."
   (if (< levels-to-keep 0)
       (error "(kvspec:levels-to-show): Must display at least one level"))
   (kview:map-tree
-   (lambda (kview)
+   (lambda (_kview)
      (if (/= (kcell-view:level) levels-to-keep)
 	 (kotl-mode:show-tree)
        (kotl-mode:hide-subtree)
@@ -121,7 +121,7 @@ display all levels of cells."
       (error "(kvspec:show-lines-per-cell): Invalid lines per cell, `%d'" num))
   (kview:set-attr kview 'lines-to-show num)
   ;; Now show NUM lines in cells.
-  (kview:map-tree (lambda (kview)
+  (kview:map-tree (lambda (_kview)
 		    (kcell-view:expand (point))
 		    (kvspec:show-lines-this-cell num)) kview t t))
 
@@ -263,7 +263,7 @@ view specs."
 If NUM is less than 1 or greater than the number of lines available, the cell remains fully expanded."
   ;; Use free variable label-sep-len bound in kview:map-* for speed.
   (unless (< num 1)
-    (let ((start (goto-char (kcell-view:start (point) label-sep-len)))
+    (let ((_start (goto-char (kcell-view:start (point) label-sep-len)))
 	  (end (kcell-view:end-contents)))
       ;; Hide all but num lines of the cell.
       (and (search-forward "\n" end t num)

--- a/set.el
+++ b/set.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    26-Sep-91 at 19:24:19
-;; Last-Mod:     24-Jan-22 at 00:24:42 by Bob Weiner
+;; Last-Mod:     12-Feb-22 at 10:42:19 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -74,7 +74,7 @@ Assume SET is a valid set.  With optional ARITY, return only subsets with
 ARITY members."
   (cond ((null arity) 
 	 (setq arity 0)
-	 (cons nil (apply 'nconc (mapcar (lambda (elt) (setq arity (1+ arity)) (set:combinations set arity))
+	 (cons nil (apply 'nconc (mapcar (lambda (_elt) (setq arity (1+ arity)) (set:combinations set arity))
 					 set))))
 	((= arity 1) set)
 	((<= arity 0) '(nil))


### PR DESCRIPTION
## What

Use underscore prefix on unused arguments.

## Why

Unused arguments gives byte compilation warnings which should be avoided.

Part of PR #166 which will be split to make it easier to review and possibly revert in case of problems, 
