### PR TITLE
Add target for interactive test run with summary output

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2022-02-19  Mats Lidell  <matsl@gnu.org>
+
+* Makefile (test-all-output): Add target for interactive tests with
+    summary output.
+
 2022-02-18  Mats Lidell  <matsl@gnu.org>
 
 * test/kcell-tests.el (kcell-tests--ref-to-id): Add test for

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:     13-Feb-22 at 10:35:20 by Bob Weiner
+# Last-Mod:     19-Feb-22 at 10:43:51 by Mats Lidell
 #
 # Copyright (C) 1994-2021  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -449,6 +449,9 @@ else
         # Typical case, run emacs normally
 	$(EMACS) --quick $(PRELOADS) --eval "(load-file \"test/hy-test-dependencies.el\")" --eval "(let ((auto-save-default)) $(LOAD_TEST_ERT_FILES) (ert-run-tests-interactively t))"
 endif
+
+test-all-output:
+	$(EMACS) --quick $(PRELOADS) --eval "(load-file \"test/hy-test-dependencies.el\")" --eval "(let ((auto-save-default) (ert-quiet t)) $(LOAD_TEST_ERT_FILES) (ert-run-tests-interactively t) (with-current-buffer \"*ert*\" (append-to-file (point-min) (point-max) \"ERT-OUTPUT\")) (kill-emacs))"
 
 # Hyperbole install tests - Verify that hyperbole can be installed
 # using different sources. See folder "install-test"


### PR DESCRIPTION
## What

Add target for interactive test run with summary output

## Why

Useful for running the interactive test runs in "batch mode". 

When running `make test-all-output` the run is terminated when all tests are done and the `*ert* buffer contents is appended to a file `ERT-OUTPUT`. That can look like this:

```
Selector: t
Passed:  220
Failed:  0
Skipped: 0
Total:   220/220

Started at:   2022-02-19 23:51:50+0100
Finished.
Finished at:  2022-02-19 23:52:08+0100

............................................................................................................................................................................................................................
```
