### PR TITLE
Remove not valid copyright statement

### DIFF
--- a/test/kexport-tests.el
+++ b/test/kexport-tests.el
@@ -1,13 +1,11 @@
 ;;; kexport-tests.el --- kexport tests            -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2021  Mats Lidell
-
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    10-Oct-21 at 17:30:00
-;; Last-Mod:      5-Feb-22 at 16:24:59 by Bob Weiner
+;; Last-Mod:      1-Mar-22 at 23:23:49 by Mats Lidell
 ;;
-;; Copyright (C) 2021  Free Software Foundation, Inc.
+;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.

--- a/test/kotl-orgtbl-tests.el
+++ b/test/kotl-orgtbl-tests.el
@@ -1,13 +1,11 @@
 ;;; kotl-orgtbl-tests.el --- kotl orgtbl tests            -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2021  Mats Lidell
-
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:     2-Nov-21 at 17:04:30
-;; Last-Mod:      6-Feb-22 at 00:55:05 by Bob Weiner
+;; Last-Mod:      1-Mar-22 at 23:24:01 by Mats Lidell
 ;;
-;; Copyright (C) 2021  Free Software Foundation, Inc.
+;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.

--- a/test/smart-org-tests.el
+++ b/test/smart-org-tests.el
@@ -1,13 +1,11 @@
 ;;; smart-org-tests.el --- smart-org-el tests            -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2021  Mats Lidell
-
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    23-Apr-21 at 22:21:00
-;; Last-Mod:      6-Feb-22 at 00:57:50 by Bob Weiner
+;; Last-Mod:      1-Mar-22 at 23:23:32 by Mats Lidell
 ;;
-;; Copyright (C) 2021  Free Software Foundation, Inc.
+;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.


### PR DESCRIPTION
## What

Remove not valid copyright statement

## Why

The copyright is assigned to FSF but a personal copyright this line crept in some how in multiple places. Removing it now. Thanks @rswgnu for bringing this to my attention.