### PR TITLE
Remove kotl source buffers modified due to export

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2022-03-05  Mats Lidell  <matsl@gnu.org>
+
+* hypb-maintenance.el: Remove modified source buffers.
+
 2022-03-01  Mats Lidell  <matsl@gnu.org>
 
 * test/kotl-mode-tests.el (kotl-mode-hide-cell): Add test case.

--- a/hypb-maintenance.el
+++ b/hypb-maintenance.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    31-Mar-21 at 21:11:00
-;; Last-Mod:     12-Feb-22 at 14:09:43 by Bob Weiner
+;; Last-Mod:      5-Mar-22 at 16:14:59 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -82,10 +82,18 @@ Point `hypb:web-repo-location' to where the web repo is located."
 	(kill-buffer))))
 
   ;; koutline-example.html
-  (kexport:html "kotl/EXAMPLE.kotl" (concat hypb:web-repo-location "koutline-example.html") nil)
+  (let ((example-src-name "kotl/EXAMPLE.kotl"))
+    (kexport:html example-src-name (concat hypb:web-repo-location "koutline-example.html") nil)
+    (with-current-buffer (get-file-buffer example-src-name)
+      (set-buffer-modified-p nil)
+      (kill-buffer)))
  
   ;; HY-WHY.html
-  (kexport:html "HY-WHY.kotl" (concat hypb:web-repo-location "HY-WHY.html") nil))
+  (let ((hy-why-src-name "HY-WHY.kotl"))
+    (kexport:html hy-why-src-name (concat hypb:web-repo-location "HY-WHY.html") nil)
+    (with-current-buffer (get-file-buffer hy-why-src-name)
+      (set-buffer-modified-p nil)
+      (kill-buffer))))
 
 (provide 'hypb-maintenance)
 ;;; hypb-maintenance.el ends here


### PR DESCRIPTION
## What

Remove kotl source buffers modified due to export

## Why

During export kotl files are modified but we do not what that  to be saved to disk by mistake. 

## Note

@rswgnu Could we do an export that will not change the source file?