### PR TITLE
Preload DEMO file to stabilize interactive test case

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2022-03-26  Mats Lidell  <matsl@gnu.org>
+
+* test/hib-kbd-tests.el (kbd-key-hy-demo-factorial-test): Preload DEMO
+    file to avoid race with *ert* display.
+
 2022-03-20  Bob Weiner  <rsw@gnu.org>
 
 * HY-NEWS (New Tree Promotion/Demotion Keys):

--- a/test/hib-kbd-tests.el
+++ b/test/hib-kbd-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:      6-Feb-22 at 00:55:55 by Bob Weiner
+;; Last-Mod:     26-Mar-22 at 11:25:43 by Mats Lidell
 ;;
 ;; Copyright (C) 2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -36,6 +36,11 @@
   (skip-unless (not noninteractive))
   (unwind-protect
       (progn
+        ;; Preload DEMO file to avoid race with *ert* buffer and set
+        ;; *ert* buffer current
+        (hypb:display-file-with-logo "DEMO")
+        (set-buffer "*ert*")
+
         (should (hact 'kbd-key "C-u C-h h d d"))
         (hy-test-helpers:consume-input-events)
         (should (string= (buffer-name (current-buffer)) "DEMO" ))


### PR DESCRIPTION
## What

Preload DEMO file to stabilize interactive test case

## Why

*ert* buffer display comes in during this test case and replaces current buffer. By preloading the DEMO file into emacs it seems like the check for current buffer works and the test case can proceed as planned. 

This behavior was first observed with 29.0.50. This is a quick fix for this problem. Probably we should look for other solutions for running these tests.