### PR TITLE
Remove xemacs compatibility code fragments

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,11 @@
 
 * hact.el (hact): Use defun. Patch from Stefan Monnier. Thanks Stefan.
 
+* kotl/kmenu.el (id-menubar-set): Remove declared unused function.
+    (id-menubar-kotl): Remove unsued InfoDock menu.
+    (kotl-menubar-menu): Remove XEmacs compatibility code.
+    (kotl-mode-hook): Set hook unconditionally.
+
 * hyrolo-menu.el (id-menubar-hyrolo): Remove InfoDock menu.
     (id-menubar-set, mode-popup-menu): Remove unused public declarations.
     (hyrolo-menubar-menu): Remove XEmacs compatibility code.

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,8 @@
 
 2022-04-18  Mats Lidell  <matsl@gnu.org>
 
+* hsettings.el: Remove XEmacs from comment.
+
 * kotl/kotl-mode.el (kotl-mode:fill-paragraph-or-region):
     (kotl-mode-map): Remove XEmacs compatibility code.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,8 @@
 
 * hact.el (hact): Use defun. Patch from Stefan Monnier. Thanks Stefan.
 
+* hmouse-mod.el (hmouse-mod-last-char): Remove XEmacs compatibility code.
+
 * hyrolo.el (hyrolo-prompt):
     (hyrolo-rename): Remove XEmacs dialog box and parameter.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,9 @@
 
 * hact.el (hact): Use defun. Patch from Stefan Monnier. Thanks Stefan.
 
+* hmouse-drv.el (hmouse-use-region-p): Remove XEmacs and InfoDock
+    compatibility code.
+
 * kotl/kmenu.el (id-menubar-set): Remove declared unused function.
     (id-menubar-kotl): Remove unsued InfoDock menu.
     (kotl-menubar-menu): Remove XEmacs compatibility code.

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,11 @@
 
 * hact.el (hact): Use defun. Patch from Stefan Monnier. Thanks Stefan.
 
+2022-04-18  Mats Lidell  <matsl@gnu.org>
+
+* kotl/kotl-mode.el (kotl-mode:fill-paragraph-or-region):
+    (kotl-mode-map): Remove XEmacs compatibility code.
+
 * hmouse-drv.el (hmouse-use-region-p): Remove XEmacs and InfoDock
     compatibility code.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,8 +1,4 @@
-2022-06-18  Mats Lidell  <matsl@gnu.org>
-
-* hact.el (hact): Use defun. Patch from Stefan Monnier. Thanks Stefan.
-
-2022-04-18  Mats Lidell  <matsl@gnu.org>
+2022-06-19  Mats Lidell  <matsl@gnu.org>
 
 * hui-select.el: Remove mention of Emacs versions in comment.
 
@@ -39,6 +35,10 @@
 
 * hui-window.el (hmouse-modeline-event-p): Remove XEmacs and old Emacs
     compatibility code.
+
+2022-06-18  Mats Lidell  <matsl@gnu.org>
+
+* hact.el (hact): Use defun. Patch from Stefan Monnier. Thanks Stefan.
 
 2022-06-16  Mats Lidell  <matsl@gnu.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,8 @@
 
 2022-04-18  Mats Lidell  <matsl@gnu.org>
 
+* hmoccur.el (moccur): Remove XEmacs and InfoDock font-lock code.
+
 * hui-mouse.el: Remove mention of Emacs versions and NEXTSTEP.
 
 * hsettings.el: Remove XEmacs from comment.

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,10 @@
 
 * hact.el (hact): Use defun. Patch from Stefan Monnier. Thanks Stefan.
 
+* hmouse-tag.el (smart-emacs-tags-file): Remove XEmacs, Infodock from doc.
+    (smart-tags-find-p, smart-tags-display, smart-tags-file-list):
+    Remove XEmacs and Infodock compatibility code.
+
 * hmouse-mod.el (hmouse-mod-last-char): Remove XEmacs compatibility code.
 
 * hyrolo.el (hyrolo-prompt):

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,12 @@
 
 * hact.el (hact): Use defun. Patch from Stefan Monnier. Thanks Stefan.
 
+* hyrolo.el (hyrolo-prompt):
+    (hyrolo-rename): Remove XEmacs dialog box and parameter.
+
+* hui-window.el (hmouse-modeline-event-p): Remove XEmacs and old Emacs
+    compatibility code.
+
 2022-06-16  Mats Lidell  <matsl@gnu.org>
 
 * Makefile (hyperbole-autoloads.el, kotl/kotl-autoloads.el): Use

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,8 @@
 
 2022-04-18  Mats Lidell  <matsl@gnu.org>
 
+* hui-select.el: Remove mention of Emacs versions in comment.
+
 * hmoccur.el (moccur): Remove XEmacs and InfoDock font-lock code.
 
 * hui-mouse.el: Remove mention of Emacs versions and NEXTSTEP.

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,8 @@
 
 2022-04-18  Mats Lidell  <matsl@gnu.org>
 
+* hui-mouse.el: Remove mention of Emacs versions and NEXTSTEP.
+
 * hsettings.el: Remove XEmacs from comment.
 
 * kotl/kotl-mode.el (kotl-mode:fill-paragraph-or-region):

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,11 @@
 
 * hact.el (hact): Use defun. Patch from Stefan Monnier. Thanks Stefan.
 
+* hyrolo-menu.el (id-menubar-hyrolo): Remove InfoDock menu.
+    (id-menubar-set, mode-popup-menu): Remove unused public declarations.
+    (hyrolo-menubar-menu): Remove XEmacs compatibility code.
+    (hyrolo-mode-hook): Set hook unconditionally.
+
 * hmouse-tag.el (smart-emacs-tags-file): Remove XEmacs, Infodock from doc.
     (smart-tags-find-p, smart-tags-display, smart-tags-file-list):
     Remove XEmacs and Infodock compatibility code.

--- a/hmoccur.el
+++ b/hmoccur.el
@@ -3,9 +3,9 @@
 ;; Author:       Markus Freericks <Mfx@cs.tu-berlin.de> / Bob Weiner
 ;;
 ;; Orig-Date:     1-Aug-91
-;; Last-Mod:     24-Jan-22 at 00:18:46 by Bob Weiner
+;; Last-Mod:     18-Apr-22 at 00:19:03 by Mats Lidell
 ;;
-;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
+;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.
@@ -84,9 +84,7 @@ serves as a menu to find any of the occurrences in this buffer.
     (insert "Lines matching '" regexp "':\n\n")
     (let ((currbuf) (currfile) (kill-buf)
 	  ;; Disable syntax highlighting of new buffers created by this command.
-	  (font-lock-auto-fontify) ;; For XEmacs and InfoDock
-	  (font-lock-global-modes) ;; For GNU Emacs
-	  )
+	  (font-lock-global-modes))
       (while buffers
 	(setq currbuf (car buffers)
 	      currfile (if (stringp currbuf) currbuf)

--- a/hmouse-drv.el
+++ b/hmouse-drv.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-90
-;; Last-Mod:     22-May-22 at 09:59:49 by Bob Weiner
+;; Last-Mod:     18-Jun-22 at 21:55:43 by Mats Lidell
 ;;
 ;; Copyright (C) 1989-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -1388,12 +1388,8 @@ compute the actual release location and include that."
 
 (defun hmouse-use-region-p ()
   "Return t if there is a non-empty, highlighted region, else nil."
-  ;; Newer GNU Emacs
-  (if (fboundp 'use-region-p)
-      (let ((use-empty-active-region))
-	(use-region-p))
-    ;; Older GNU Emacs
-    (and transient-mark-mode mark-active)))
+  (let ((use-empty-active-region))
+    (use-region-p)))
 
 (defun hmouse-save-region ()
   "Save to `hkey-region' and return any active region within the current buffer.

--- a/hmouse-key.el
+++ b/hmouse-key.el
@@ -3,9 +3,9 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    30-May-94 at 00:11:57
-;; Last-Mod:     24-Jan-22 at 00:18:46 by Bob Weiner
+;; Last-Mod:     17-Apr-22 at 22:10:08 by Mats Lidell
 ;;
-;; Copyright (C) 1994-2021  Free Software Foundation, Inc.
+;; Copyright (C) 1994-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.
@@ -58,7 +58,7 @@ bindings after Smart Key setup."
     ;; Do nothing when running in batch mode.
     (noninteractive)
     ;;
-    ;; GNU Emacs, XEmacs or InfoDock
+    ;; GNU Emacs or InfoDock
     (t
      (mapcar
        (lambda (key-and-binding)

--- a/hmouse-mod.el
+++ b/hmouse-mod.el
@@ -3,9 +3,9 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     8-Oct-92 at 19:08:31
-;; Last-Mod:     17-Apr-22 at 13:09:12 by Bob Weiner
+;; Last-Mod:     17-Apr-22 at 22:38:13 by Mats Lidell
 ;;
-;; Copyright (C) 1992-2021  Free Software Foundation, Inc.
+;; Copyright (C) 1992-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.
@@ -202,10 +202,8 @@ Second argument COUNT is used as a prefix argument to the command."
   (keyboard-quit))
 
 (defun hmouse-mod-last-char ()
-  (cond	((boundp 'last-command-char) ;; XEmacs
-	 (and (>= 0 last-command-char) (< last-command-char 128) last-command-char))
-	((characterp last-command-event) ;; GNU Emacs
-	 last-command-event)))
+  (when (characterp last-command-event)
+    last-command-event))
 
 (provide 'hmouse-mod)
 

--- a/hmouse-tag.el
+++ b/hmouse-tag.el
@@ -3,9 +3,9 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    24-Aug-91
-;; Last-Mod:     12-Feb-22 at 10:42:20 by Mats Lidell
+;; Last-Mod:     17-Apr-22 at 23:15:45 by Mats Lidell
 ;;
-;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
+;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.
@@ -125,7 +125,7 @@ Each directory must end with a directory separator."
 Keyword matched is grouping 1.  Referent is grouping 2.")
 
 (defcustom smart-emacs-tags-file nil
-  "*Full path name of etags file for InfoDock, XEmacs or GNU Emacs source."
+  "*Full path name of etags file for GNU Emacs source."
   :type '(file :must-match t)
   :group 'hyperbole-commands)
 
@@ -1156,17 +1156,7 @@ TAG-SYM may be a function, variable or face."
 			     nil
 			   (and (boundp 'tags-file-name) tags-file-name)))
 	 find-tag-result
-	 ;; For InfoDock and XEmacs
-	 (tags-always-exact t)
-	 (tag-table-alist
-	  (mapcar (lambda (tags-file) (cons "." tags-file))
-		  tags-table-list))
-	 ;; For GNU Emacs
 	 (tags-add-tables nil))
-    ;; For InfoDock (XEmacs may also take this branch), force exact match
-    ;; (otherwise tag might = nil and the following stringp test could fail).
-    (if (featurep 'infodock)
-	(if (stringp tag) (setq tag (list tag))))
     (condition-case ()
 	(and func (funcall func tag) t)
       (error nil))))
@@ -1374,30 +1364,12 @@ See the \"${hyperb:dir}/smart-clib-sym\" script for more information."
 	 (tags-file-name (unless tags-table-list
 			   (when (boundp 'tags-file-name) tags-file-name)))
 	 find-tag-result
-	 ;; For InfoDock and XEmacs
-	 (tags-always-exact t)
-	 (tag-table-alist
-	  (mapcar (lambda (tags-file) (cons "." tags-file))
-		  tags-table-list))
-	 ;; For GNU Emacs
 	 (tags-add-tables nil))
-    ;; For InfoDock (XEmacs may also take this branch), force exact match
-    ;; when `next' is false (otherwise tag would = nil and the following
-    ;; stringp test would fail).
-    (and (featurep 'infodock) (stringp tag) (setq tag (list tag)))
     (cond ((and func (or tags-table-list tags-file-name) (setq find-tag-result (funcall func tag)))
-	   (cond ((eq func 'find-tag-internal)
-		  ;; InfoDock and XEmacs
-		  (hpath:display-buffer (car find-tag-result))
-		  (goto-char (cdr find-tag-result)))
-		 ((or (eq (type-of find-tag-result) 'xref-item)
+	   (cond ((or (eq (type-of find-tag-result) 'xref-item)
 		      (vectorp find-tag-result))
-		  ;; Newer GNU Emacs with xref.el
 		  (hpath:display-buffer (xref-item-buffer find-tag-result))
 		  (goto-char (xref-item-position find-tag-result)))
-		 ((bufferp find-tag-result)
-		  ;; Older GNU Emacs
-		  (hpath:display-buffer find-tag-result))
 		 (t
 		  ;; Emacs with some unknown version of tags.
 		  ;; Signals an error if tag is not found which is caught by
@@ -1465,12 +1437,6 @@ to look.  If no tags file is found, an error is signaled."
 	   ;; GNU Emacs in other cases
 	   (tags-table-check-computed-list)
 	   tags-table-computed-list)
-	  ((fboundp 'buffer-tag-table-list)
-	   ;; InfoDock and XEmacs
-	   (buffer-tag-table-list))
-	  ((when (boundp 'buffer-tag-table) buffer-tag-table)
-	   ;; InfoDock and XEmacs
-	   (list buffer-tag-table))
 	  ((when (boundp 'tags-file-name) tags-file-name)
 	   (list tags-file-name))
 	  (t (error "Needed tags file not found; see `man etags' for how to build one")))))

--- a/hsettings.el
+++ b/hsettings.el
@@ -3,9 +3,9 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Apr-91 at 00:48:49
-;; Last-Mod:     24-Apr-22 at 13:14:18 by Bob Weiner
+;; Last-Mod:     18-Jun-22 at 21:56:43 by Mats Lidell
 ;;
-;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
+;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.
@@ -259,7 +259,7 @@ then runs the search."
   :group 'hyperbole-commands)
 
 ;;; ************************************************************************
-;;; GNU EMACS AND XEMACS CONFIGURATION
+;;; GNU EMACS CONFIGURATION
 ;;; ************************************************************************
 
 ;; No-op unless set by one of the conditionals below.

--- a/hui-mouse.el
+++ b/hui-mouse.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-89
-;; Last-Mod:      5-Jun-22 at 17:59:48 by Bob Weiner
+;; Last-Mod:     18-Jun-22 at 21:57:35 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -20,12 +20,12 @@
 ;;  If you want to use your shift-middle mouse button to select Hyperbole menu
 ;;  items and Hyperbole buttons, follow these instructions.
 ;;
-;;  If you plan to use a mouse only with the X window system (XEmacs, GNU Emacs
-;;  19, or InfoDock), macOS, or NEXTSTEP, and you want to use the
-;;  shift-middle and shift-right buttons, you need not do any mouse
-;;  configuration.  Your Emacs executable must have been built so as to
-;;  include the mouse support files for your window system, however.  These
-;;  are in the Emacs "src" directory: for X - "x*.c", for macOS - "ns*.c".
+;;  If you plan to use a mouse only with the X window system or macOS
+;;  and you want to use the shift-middle and shift-right buttons, you
+;;  need not do any mouse configuration.  Your Emacs executable must
+;;  have been built so as to include the mouse support files for your
+;;  window system, however.  These are in the Emacs "src" directory:
+;;  for X - "x*.c", for macOS - "ns*.c".
 ;;
 ;;  To use a different mouse key or a different window system, modify the
 ;;  mouse key bindings in "hmouse-sh.el".

--- a/hui-select.el
+++ b/hui-select.el
@@ -3,9 +3,9 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Oct-96 at 02:25:27
-;; Last-Mod:      5-Jun-22 at 17:59:19 by Bob Weiner
+;; Last-Mod:     18-Jun-22 at 21:58:08 by Mats Lidell
 ;;
-;; Copyright (C) 1996-2021  Free Software Foundation, Inc.
+;; Copyright (C) 1996-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.
@@ -75,9 +75,8 @@
 ;;   ---------------
 ;;   SETUP IF USED SEPARATELY FROM HYPERBOLE (otherwise ignore):
 ;;
-;;   To autoload this package under Emacs, XEmacs or InfoDock via
-;;   mouse usage, add the following line to one of your initialization
-;;   files.
+;;   To autoload this package via mouse usage add the following line
+;;   to one of your initialization files.
 ;;
 ;;      (hui-select-initialize)
 ;;

--- a/hui-window.el
+++ b/hui-window.el
@@ -3,9 +3,9 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Sep-92
-;; Last-Mod:      5-Jun-22 at 17:59:19 by Bob Weiner
+;; Last-Mod:     18-Jun-22 at 21:53:08 by Mats Lidell
 ;;
-;; Copyright (C) 1992-2021  Free Software Foundation, Inc.
+;; Copyright (C) 1992-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.
@@ -988,7 +988,7 @@ window, its frame may have been moved by a bottommost modeline drag."
        (not (or (hmouse-drag-horizontally) (hmouse-drag-vertically) (hmouse-drag-diagonally)))))
 
 (defun hmouse-emacs-modeline-event-p (event)
-  "GNU Emacs: Return non-nil if EVENT happened on a window mode line."
+  "Return non-nil if EVENT happened on a window mode line."
   (or (and (eventp event) (eq (posn-area (event-start event)) 'mode-line))
       ;; If drag release was to an unselected frame mode-line, on
       ;; click-to-focus systems, the release event will not include
@@ -1006,22 +1006,7 @@ window, its frame may have been moved by a bottommost modeline drag."
     (when (and (hyperb:window-system) event
 	       (not (posnp event))
 	       (not (markerp event)))
-      (cond
-       ;; Modern GNU Emacs
-       ((fboundp 'posn-area)
-	(hmouse-emacs-modeline-event-p event))
-       ;; XEmacs
-       ((fboundp 'event-over-modeline-p)
-	(event-over-modeline-p event))
-       ;; Early Emacs
-       (t
-	(let* ((w (smart-window-of-coords event))
-	       (mode-ln (if w (nth 3 (window-edges w))))
-	       (last-press-y (hmouse-y-coord event)))
-	  ;; Mode-line is always 1 less than the bottom of the window, unless it
-	  ;; is a minibuffer window which does not have a modeline.
-	  (if (not (eq w (minibuffer-window))) (setq mode-ln (1- mode-ln)))
-	  (and last-press-y mode-ln (= last-press-y mode-ln)))))))
+      (hmouse-emacs-modeline-event-p event)))
 
 (defun hmouse-modeline-depress ()
   "Return non-nil if Action Key was depressed on a window mode line.

--- a/hyrolo-menu.el
+++ b/hyrolo-menu.el
@@ -3,9 +3,9 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    28-Oct-94 at 10:59:44
-;; Last-Mod:     24-Jan-22 at 00:23:35 by Bob Weiner
+;; Last-Mod:     17-Apr-22 at 23:44:09 by Mats Lidell
 ;;
-;; Copyright (C) 1994-2021  Free Software Foundation, Inc.
+;; Copyright (C) 1994-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.
@@ -67,25 +67,6 @@
      ["Show-Only-First-Line"   outline-hide-body                t]))
   "The middle menu entries common to all HyRolo menus.")
 
-;;; This definition is used by InfoDock only.
-(defconst id-menubar-hyrolo
-  (append
-   '(("Rolo"
-      ["Help"                describe-mode                  t]
-      ["Manual"              (id-info "(hyperbole)Rolo Keys") t]
-      "----"
-      ["Toggle-Read-Only"    read-only-mode                 t]
-      ["Write (Save as)"     write-file                     t]
-      "----"
-      ["Quit"                (id-tool-quit '(kill-buffer nil))  t]))
-   '(["Edit-Entry-at-Point"  hyrolo-edit-entry         t]
-     ["Mail-to-Address"      (id-tool-invoke 'hyrolo-mail-to) t])
-   `,@hyrolo-menu-common-body
-   '(["Next-Match"          hyrolo-next-match         t]
-     ["Previous-Match"      hyrolo-previous-match     t])
-   (list infodock-hyrolo-menu)))
-
-;;; This definition is used by InfoDock and XEmacs.
 (defconst id-popup-hyrolo-menu
   (append
    '("Rolo"
@@ -104,45 +85,27 @@
      ["Quit"                (id-tool-quit '(hyrolo-quit)) t])))
 
 ;;; ************************************************************************
-;;; Public declarations
-;;; ************************************************************************
-
-(declare-function id-menubar-set "ext:infodock")
-
-(defvar mode-popup-menu)
-
-;;; ************************************************************************
 ;;; Public functions
 ;;; ************************************************************************
 
-;;; This definition is used only by Emacs.
 (defun hyrolo-menubar-menu ()
   "Add a HyRolo menu to the rolo match buffer menubar."
-  (cond ((fboundp 'popup-mode-menu)
-	 (setq mode-popup-menu id-popup-hyrolo-menu))
-	(t
-	 (define-key hyrolo-mode-map [C-down-mouse-3] 'hyrolo-popup-menu)
-	 (define-key hyrolo-mode-map [C-mouse-3] nil)))
+  (define-key hyrolo-mode-map [C-down-mouse-3] 'hyrolo-popup-menu)
+  (define-key hyrolo-mode-map [C-mouse-3] nil)
   (unless (global-key-binding [menu-bar Rolo])
     (easy-menu-define nil hyrolo-mode-map "Rolo Menubar Menu" id-popup-hyrolo-menu)
     ;; Force a menu-bar update.
     (force-mode-line-update)))
 
-;;; This definition is used only by XEmacs and Emacs.
 (defun hyrolo-popup-menu (event)
   "Popup the Hyperbole Rolo match buffer menu."
   (interactive "@e")
   (mouse-set-point event)
   (popup-menu id-popup-hyrolo-menu))
 
-(cond ((featurep 'infodock)
-       ;; InfoDock under a window system
-       (require 'id-menubars)
-       (id-menubar-set 'hyrolo-mode 'id-menubar-hyrolo))
-      (t
-       ;; Emacs or XEmacs under a window system
-       (add-hook 'hyrolo-mode-hook #'hyrolo-menubar-menu)))
+(add-hook 'hyrolo-mode-hook #'hyrolo-menubar-menu)
 
 (provide 'hyrolo-menu)
 
 ;;; hyrolo-menu.el ends here
+oo

--- a/hyrolo-menu.el
+++ b/hyrolo-menu.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    28-Oct-94 at 10:59:44
-;; Last-Mod:     17-Apr-22 at 23:44:09 by Mats Lidell
+;; Last-Mod:     18-Apr-22 at 00:29:31 by Mats Lidell
 ;;
 ;; Copyright (C) 1994-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -108,4 +108,3 @@
 (provide 'hyrolo-menu)
 
 ;;; hyrolo-menu.el ends here
-oo

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -3,9 +3,9 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Jun-89 at 22:08:29
-;; Last-Mod:     15-May-22 at 22:28:48 by Bob Weiner
+;; Last-Mod:     18-Jun-22 at 21:53:51 by Mats Lidell
 ;;
-;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
+;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.
@@ -655,14 +655,9 @@ With a prefix argument of LEVELS-TO-SHOW > 0, show the first lines of entries on
       (error
        "(hyrolo-previous-match): No prior matches for \"%s\"" hyrolo-match-regexp))))
 
-(defun hyrolo-prompt (keyboard-function dialog-box-function prompt)
-  "Use KEYBOARD-FUNCTION or DIALOG-BOX-FUNCTION, if available, to PROMPT for a yes/no answer.
-XEmacs only."
-  (if (and (fboundp 'device-type) (not (eq (device-type) 'tty))
-	   (fboundp 'yes-or-no-p-maybe-dialog-box))
-      ;; Graphical XEmacs
-      (funcall dialog-box-function prompt)
-    (funcall keyboard-function prompt)))
+(defun hyrolo-prompt (keyboard-function prompt)
+  "Use KEYBOARD-FUNCTION to PROMPT for a yes/no answer."
+  (funcall keyboard-function prompt))
 
 (defun hyrolo-quit ()
   "Quit from the rolo match buffer and restore the prior frame display."
@@ -681,7 +676,7 @@ XEmacs only."
 	   (file-readable-p old-file)
 	   (progn (beep)
 		  (or (hyrolo-prompt
-		       'y-or-n-p 'yes-or-no-p-dialog-box
+		       'y-or-n-p
 		       (format "(hyrolo-rename): Rename \"%s\" to the new standard \"%s\"? "
 			       old-file new-file))
 		      ;; Setup to get rolo matches from OLD-FILE.

--- a/kotl/kmenu.el
+++ b/kotl/kmenu.el
@@ -3,9 +3,9 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    28-Mar-94 at 11:22:09
-;; Last-Mod:      5-Feb-22 at 22:33:45 by Bob Weiner
+;; Last-Mod:     17-Apr-22 at 23:51:03 by Mats Lidell
 ;;
-;; Copyright (C) 1994-2021  Free Software Foundation, Inc.
+;; Copyright (C) 1994-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.
@@ -18,12 +18,6 @@
 ;;; ************************************************************************
 
 (require 'easymenu)
-
-;;; ************************************************************************
-;;; Public declarations
-;;; ************************************************************************
-
-(declare-function id-menubar-set "ext:infodock")
 
 ;;; ************************************************************************
 ;;; Public variables
@@ -170,14 +164,6 @@
     "----"
     ["Quit"                (id-tool-quit '(kill-buffer nil))  t]))
 
-;;; This definition is used by InfoDock only.
-(defconst id-menubar-kotl
-  (cons
-   (append kotl-menu-common-preamble
-	   kotl-menu-common-postamble)
-   kotl-menu-common-body))
-
-;;; This definition is used by InfoDock, XEmacs and GNU Emacs.
 (defconst id-popup-kotl-menu
    (append kotl-menu-common-preamble
 	   `("----"
@@ -185,41 +171,25 @@
 	   kotl-menu-common-postamble))
 
 ;;; ************************************************************************
-;;; Public declarations
-;;; ************************************************************************
-(defvar mode-popup-menu)                ; InfoDock
-
-;;; ************************************************************************
 ;;; Public functions
 ;;; ************************************************************************
 
-;;; This definition is used only by XEmacs and Emacs.
 (defun kotl-menubar-menu ()
   "Add a Koutline menu to the menubar for each koutline buffer."
-  (cond ((fboundp 'popup-mode-menu)
-	 (setq mode-popup-menu id-popup-kotl-menu))
-	(t
-	 (define-key kotl-mode-map [C-down-mouse-3] 'kotl-popup-menu)
-	 (define-key kotl-mode-map [C-mouse-3] nil)))
+  (define-key kotl-mode-map [C-down-mouse-3] 'kotl-popup-menu)
+  (define-key kotl-mode-map [C-mouse-3] nil)
   (unless (global-key-binding [menu-bar Koutline])
     (easy-menu-define nil kotl-mode-map "Koutline Menubar Menu" id-popup-kotl-menu)
     ;; Force a menu-bar update.
     (force-mode-line-update)))
 
-;;; This definition is used only by XEmacs and Emacs.
 (defun kotl-popup-menu (event)
   "Popup the Koutline buffer menu."
   (interactive "@e")
   (mouse-set-point event)
   (popup-menu id-popup-kotl-menu))
 
-(cond ((featurep 'infodock)
-       ;; InfoDock under a window system
-       (require 'id-menubars)
-       (id-menubar-set 'kotl-mode 'id-menubar-kotl))
-      (t
-       ;; Emacs or XEmacs under a window system
-       (add-hook 'kotl-mode-hook #'kotl-menubar-menu)))
+(add-hook 'kotl-mode-hook #'kotl-menubar-menu)
 
 (provide 'kmenu)
 

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -3,9 +3,9 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:      5-Jun-22 at 17:59:19 by Bob Weiner
+;; Last-Mod:     18-Jun-22 at 21:56:13 by Mats Lidell
 ;;
-;; Copyright (C) 1993-2021  Free Software Foundation, Inc.
+;; Copyright (C) 1993-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.
@@ -620,9 +620,6 @@ Ignore any non-nil no-fill attribute attached to the cell."
       (set-marker opoint nil)
       (set-marker start nil)
       (set-marker end nil))))
-
-;; XEmacs binds this to {M-q}.
-(defalias 'kotl-mode:fill-paragraph-or-region 'kotl-mode:fill-paragraph)
 
 (defun kotl-mode:fill-tree (&optional top-p)
   "Refill each cell within the tree whose root is at point.
@@ -3549,12 +3546,8 @@ Leave point at end of line now residing at START."
   (define-key kotl-mode-map "\C-c\C-h"  'kotl-mode:hide-tree)
   ;; Since the next key binds M-BS, it may already have a local binding,
   ;; in which case we don't want to bind it here.
-  (if (string-match "XEmacs" emacs-version)
-      (unless (lookup-key kotl-mode-map '[(meta backspace)])
-	(define-key kotl-mode-map '[(meta backspace)] 'kotl-mode:hide-subtree))
-    ;; Do this under GNU Emacs only or will overwrite M-BS binding above.
-    (unless (lookup-key kotl-mode-map "\M-\C-h")
-      (define-key kotl-mode-map "\M-\C-h"   'kotl-mode:hide-subtree)))
+  (unless (lookup-key kotl-mode-map "\M-\C-h")
+    (define-key kotl-mode-map "\M-\C-h"   'kotl-mode:hide-subtree))
   ;; Override this global binding for set-selective-display with a similar
   ;; function appropriate for kotl-mode.
   (define-key kotl-mode-map "\C-x$"     'kotl-mode:hide-sublevels)


### PR DESCRIPTION
## What

Remove `XEmacs` compatibility code fragments

## Why 

We don't support `XEmacs` so the compatibility code that is left gets in the way (clutters the code) and some times even causes warnings which we want to reduce to a minimum.

## Note

I took one step further here and since `XEmacs` in many cases is similar to `InfoDock` I removed that too. I know it is not 100% true and I also know you might want to bring `InfoDock` back to life some day. But we have version control to support that and I guess a future `InfoDock` would be based on a modern `GNU Emacs` so most of the old code would not be useful. If you do not agree please advice how I should deal with the parts where `InfoDock` is mentioned. (`InfoDock` can still be mentioned here and there since I have gone over the code looking for `XEmacs` references.)

**The PR can probably best be reviewed a commit at a time or a file at the time. Should be mostly the same except for the `ChangeLog` entries.**

All tests passes but I do not think our test covers most of the parts that has been touched so review with that in mind.

I have not touched `mouse-sh.el` since that looks really old and scary. Do you have some insights into what of that is really used and worth keeping.

There is also a part in `kotl-mode.el` where the naming of two functions are explained since there was a byte compiler error for those functions in `XEmacs`. I kept that as a reminder that these functions now could maybe be given their proper names instead. But that will be a longer PR so leaving that for later. On the other hand why not just keep the names and forget about the reason for them being a bit off!?