### PR TITLE
Add hui-copy-to-register tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2022-04-27  Mats Lidell  <matsl@gnu.org>
+
+* test/hui-tests.el (hui--copy-to-register--yank-in-same-kotl)
+    (hui--copy-to-register--yank-in-other-kotl)
+    (hui--copy-to-register--yank-in-other-file)
+    (hui--copy-to-register--yank-in-other-file-other-dir): Add
+    hui-copy-to-register tests.
+
 2022-04-26  Mats Lidell  <matsl@gnu.org>
 
 * test/hui-tests.el (hui--kill-ring-save--yank-in-same-kotl)


### PR DESCRIPTION
## What

Add hui-copy-to-register tests

## Why

`hui-copy-to-register` is a new function. 

## Note

This makes use of, i.e. copies, the `hui-kill-ring-save` test cases. Could maybe merge them but then again it makes it harder to read the tests. Happy to leave that to a later refactoring if we find it necessary.