### PR TITLE
Add files to website that are linked from README.md

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2022-05-02  Mats Lidell  <matsl@gnu.org>
+
+* hypb-maintenance.el (hypb:web-repo-update): Add files to website that
+    are linked from hyperbole.html. i.e. README.md.
+
 2022-05-01  Bob Weiner  <rsw@gnu.org>
 
 * Update release number to 8.0.0.

--- a/hypb-maintenance.el
+++ b/hypb-maintenance.el
@@ -3,9 +3,9 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    31-Mar-21 at 21:11:00
-;; Last-Mod:     12-Mar-22 at 15:14:34 by Bob Weiner
+;; Last-Mod:      2-May-22 at 00:11:09 by Mats Lidell
 ;;
-;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
+;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.
@@ -61,10 +61,15 @@ Point `hypb:web-repo-location' to where the web repo is located."
   ;; hyperbole.html
   (copy-file "README.md.html" (concat hypb:web-repo-location "hyperbole.html") t)
 
-  ;; DEMO DEMO-ROLO.otl
+  ;; DEMO DEMO-ROLO.otl HY-ABOUT INSTALL HY-COPY COPYING MANIFEST
   (copy-file "DEMO" hypb:web-repo-location t)
   (copy-file "DEMO-ROLO.otl" hypb:web-repo-location t)
   (copy-file "FAST-DEMO" hypb:web-repo-location t)
+  (copy-file "HY-ABOUT" hypb:web-repo-location t)
+  (copy-file "INSTALL" hypb:web-repo-location t)
+  (copy-file "HY-COPY" hypb:web-repo-location t)
+  (copy-file "COPYING" hypb:web-repo-location t)
+  (copy-file "MANIFEST" hypb:web-repo-location t)
 
   ;; man recursive
   (copy-directory "man" hypb:web-repo-location nil t nil)


### PR DESCRIPTION
## What

Add files to website that are linked from README.md

## Why

These are linked from `README.md` so need to be there.

## Note

These are copied as simple text files so no formatting. Not sure it will work well in all browsers.

There are a some elisp files that are linked too as well. Easiest would be to copy them as well but I left that for now since I ran out of time and I'm not sure if that is a good approach. Maybe we should consider to link to these files in the savannah repo? That comes with some drawback too so another reason to not rush it.

And yes. I have pushed the updated files to the website so it should be mostly good now. (Except for the links to the src files that is.)