### PR TITLE
Don't byte compile test packages with external test dependencies

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2022-05-22  Mats Lidell  <matsl@gnu.org>
+
+* test/kexport-tests.el:
+  test/hmouse-info-tests.el:
+  test/hmouse-drv-tests.el:
+  test/hbut-tests.el: Don't byte compile of test files that depend on
+    external test support packages.
+
 2022-05-16  Bob Weiner  <rsw@gnu.org>
 
 * FAST-DEMO: Change from /usr/bin/bash to /bin/bash.

--- a/test/hbut-tests.el
+++ b/test/hbut-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-may-21 at 09:33:00
-;; Last-Mod:     24-Jan-22 at 00:38:20 by Bob Weiner
+;; Last-Mod:     22-May-22 at 10:57:31 by Mats Lidell
 ;;
 ;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -170,10 +170,11 @@ Needed since hyperbole expands all links to absolute paths and
           (hy-test-helpers-verify-hattr-at-p :actype 'actypes::link-to-file-line-and-column :args (list test-file 2 3) :loc test-file :lbl-key "label"))
       (delete-file test-file))))
 
-;; FIXME: This file can only be byte-compiled when `el-mock' is installed.
-;; Local Variables:
-;; no-byte-compile: t
-;; End:
+;; This file can't be byte-compiled without the `el-mock' package (because of
+;; the use of the `with-mock' macro), which is not a dependency of Hyperbole.
+;;  Local Variables:
+;;  no-byte-compile: t
+;;  End:
 
 (provide 'hbut-tests)
 ;;; hbut-tests.el ends here

--- a/test/hmouse-drv-tests.el
+++ b/test/hmouse-drv-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    28-Feb-21 at 22:52:00
-;; Last-Mod:     15-May-22 at 23:42:24 by Bob Weiner
+;; Last-Mod:     22-May-22 at 11:13:48 by Mats Lidell
 ;;
 ;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -20,6 +20,7 @@
 (require 'ert)
 (require 'hbut)
 (require 'el-mock)
+(require 'with-simulated-input)
 (require 'hy-test-helpers "test/hy-test-helpers")
 
 (ert-deftest hbut-defal ()
@@ -519,8 +520,10 @@ Regression: Looked up path name '-narrow'."
             (action-key)))
       (delete-file el-file))))
 
-;; This file can't be byte-compiled without the `el-mock' package (because of
-;; the use of the `with-mock' macro), which is not a dependency of Hyperbole.
+;; This file can't be byte-compiled without the `el-mock' and
+;; `with-simulated-input' package (because of the use of the
+;; `with-mock' and `with-simulated-input' macro), which is not a
+;; dependency of Hyperbole.
 ;;  Local Variables:
 ;;  no-byte-compile: t
 ;;  End:

--- a/test/hmouse-info-tests.el
+++ b/test/hmouse-info-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    29-Dec-21 at 09:02:00
-;; Last-Mod:     24-Jan-22 at 00:39:27 by Bob Weiner
+;; Last-Mod:     22-May-22 at 11:11:53 by Mats Lidell
 ;;
 ;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -44,10 +44,12 @@
           (should (string-prefix-p "regexp" m t))))
     (kill-buffer "*info*")))
 
-;; FIXME: Can't compile when `with-simulated-input' is absent!
-;; Local Variables:
-;; no-byte-compile: t
-;; End:
+;; This file can't be byte-compiled without the `with-simulated-input'
+;; package (because of the use of the `with-simulated-input' macro),
+;; which is not a dependency of Hyperbole.
+;;  Local Variables:
+;;  no-byte-compile: t
+;;  End:
 
 (provide 'hmouse-info-tests)
 ;;; hmouse-info-tests.el ends here

--- a/test/kexport-tests.el
+++ b/test/kexport-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    10-Oct-21 at 17:30:00
-;; Last-Mod:      1-Mar-22 at 23:23:49 by Mats Lidell
+;; Last-Mod:     22-May-22 at 10:57:14 by Mats Lidell
 ;;
 ;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -138,6 +138,12 @@
           (should (string= (kexport:koutline) html-file)))
       (progn
         (delete-file kotl-file)))))
+
+;; This file can't be byte-compiled without the `el-mock' package (because of
+;; the use of the `with-mock' macro), which is not a dependency of Hyperbole.
+;;  Local Variables:
+;;  no-byte-compile: t
+;;  End:
 
 (provide 'kexport-tests)
 ;;; kexport-tests.el ends here


### PR DESCRIPTION
## What 

Don't byte compile test packages with external test dependencies

## Why

The package manager byte compiles files in the test folder which causes byte compilation errors when installing hyperbole. The test files are only used for testing so is not required for running hyperbole. So these files does not need to be byte compiled by the user, They need not be byte compiled by developers either! ;-)
 