### PR TITLE
Add target for native byte compilation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2022-06-05  Mats Lidell  <matsl@gnu.org>
+
+* Makefile (eln): Target for native byte compilation.
+
 2022-06-04  Bob Weiner  <rsw@gnu.org>
 
 * test/hpath-tests.el (hpath--should-exist-paths): Fix to handle Hyperbole package installation dirs.

--- a/Makefile
+++ b/Makefile
@@ -303,6 +303,13 @@ bin: src
 	$(RM) *.elc kotl/*.elc
 	$(EMACS_BATCH) --eval="(setq-default byte-compile-warnings '(not docstrings))" \
 		-f batch-byte-compile $(EL_KOTL) $(EL_COMPILE)
+eln: src bin
+	$(EMACS_BATCH) \
+	  --eval="(progn \
+	            (setq-default byte-compile-warnings '(not docstrings)) \
+	            (load \"hyperbole-autoloads\") \
+                    (load \"kotl/kotl-autoloads\"))" \
+		-f batch-native-compile $(EL_KOTL) $(EL_COMPILE)
 
 # Byte compile files but apply a filter for either including or
 # removing warnings.  See variable {C-hv byte-compile-warnings RET} for


### PR DESCRIPTION
## What

Add target for native byte compilation

## Why

It is practical to be able to force native byte compilation so that we know unit tests will pick up the native compiled code and not depend on async native compilation in the background.