### PR TITLE
Allow match on different apropos formats

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2022-07-19  Mats Lidell  <matsl@gnu.org>
+
+* test/demo-tests.el (fast-demo-key-series-shell-apropos): Add optional
+    whitespace after command to accomodate for different versions on
+    apropos.
+
 2022-07-15  Mats Lidell  <matsl@gnu.org>
 
 * test/hypb-tests.el: Remove test cases for hypb:replace-match-string.

--- a/test/demo-tests.el
+++ b/test/demo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     19-Jun-22 at 20:25:19 by Bob Weiner
+;; Last-Mod:     16-Jul-22 at 22:39:30 by Mats Lidell
 ;;
 ;; Copyright (C) 2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -580,13 +580,10 @@ enough files with matching mode loaded."
           (action-key)
           (hy-test-helpers:consume-input-events)
           (with-current-buffer shell-buffer-name
-	    (let ((buf-len (point-max)))
-	      (sleep-for 0.1)
-	      (while (/= buf-len (point-max))
-		(setq buf-len (point-max))
-		(accept-process-output)
-		(sleep-for 0.1)))
-            (should (string-match-p "\ngrep ?\(1\).*-" (buffer-substring-no-properties (point-min) (point-max))))))
+            (with-timeout (5 (ert-fail "Test timed out"))
+              (while (not (string-match-p "\ngrep[ ]*\(1\).*-" (buffer-substring-no-properties (point-min) (point-max))))
+                (accept-process-output (get-buffer-process shell-buffer-name))))
+            (should (string-match-p "\ngrep[ ]*\(1\).*-" (buffer-substring-no-properties (point-min) (point-max))))))
       (set-process-query-on-exit-flag (get-buffer-process shell-buffer-name) nil)
       (kill-buffer shell-buffer-name))))
 

--- a/test/demo-tests.el
+++ b/test/demo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     16-Jul-22 at 22:39:30 by Mats Lidell
+;; Last-Mod:     16-Jul-22 at 22:39:47 by Mats Lidell
 ;;
 ;; Copyright (C) 2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -581,9 +581,9 @@ enough files with matching mode loaded."
           (hy-test-helpers:consume-input-events)
           (with-current-buffer shell-buffer-name
             (with-timeout (5 (ert-fail "Test timed out"))
-              (while (not (string-match-p "\ngrep[ ]*\(1\).*-" (buffer-substring-no-properties (point-min) (point-max))))
+              (while (not (string-match-p "\ngrep ?\(1\).*-" (buffer-substring-no-properties (point-min) (point-max))))
                 (accept-process-output (get-buffer-process shell-buffer-name))))
-            (should (string-match-p "\ngrep[ ]*\(1\).*-" (buffer-substring-no-properties (point-min) (point-max))))))
+            (should (string-match-p "\ngrep ?\(1\).*-" (buffer-substring-no-properties (point-min) (point-max))))))
       (set-process-query-on-exit-flag (get-buffer-process shell-buffer-name) nil)
       (kill-buffer shell-buffer-name))))
 


### PR DESCRIPTION
## What

Allow match on different apropos formats

## Why

Apropos can have white space or none between command and first parentheses.

My apropos looks like this:
```
❯ apropos grep
bzegrep (1)          - search possibly bzip2 compressed files for a regular expression
bzfgrep (1)          - search possibly bzip2 compressed files for a regular expression
bzgrep (1)           - search possibly bzip2 compressed files for a regular expression
[...]
```
In is original form the test loops over the buffer until it is a match or until 5 seconds has passed. In the later case the test case fails. For each loop it tries to get more output from the process. So even if the process is slow and does not produce any output for the match the loop should ensure that it finally gets there. 

I'm not sure about how the `accept-process-output` really works but since you changed the pattern match could it not just be that your version of apropos does not have white space after the command, like this?
```
❯ apropos grep
bzegrep(1)          - search possibly bzip2 compressed files for a regular expression
bzfgrep(1)          - search possibly bzip2 compressed files for a regular expression
bzgrep(1)           - search possibly bzip2 compressed files for a regular expression
[...]
```
And what you saw was the test case just checking the wrong pattern over an over again? If you try this version does it fail on your machine?