### PR TITLE
Example of doc changes to be within 80 char limit

### DIFF
--- a/hact.el
+++ b/hact.el
@@ -49,11 +49,12 @@ The type categories are either 'actypes or 'ibtypes.")
   (plist-get symtable 'name))
 
 (defsubst symtable:select (type-category)
-  "Inline the return of the symtable for TYPE-CATEGORY, one of 'actypes or 'ibtypes."
+  "Inline the return of the symtable for TYPE-CATEGORY.
+TYPE-CATEGORY is one of `actypes' or `ibtypes'."
   (plist-get symtable:category-plist type-category))
 
 (defun    symtable:operate (operation symbol-or-name symtable)
-  "Call hash-table function OPERATION with Hyperbole SYMBOL-OR-NAME as key upon SYMTABLE.
+  "Call hash-table function OPERATION with SYMBOL-OR-NAME as key upon SYMTABLE.
 Trigger an error if SYMBOL-OR-NAME cannot be mapped to an existing Elisp
 symbol or if SYMTABLE is invalid."
   (let ((name (cond ((stringp symbol-or-name)
@@ -112,12 +113,12 @@ with the `ibtypes::' prefix and one without.  The value for both
 keys is the Elisp symbol for the type, which includes the prefix.")
 
 (defsubst symtable:actype-p (symbol-or-name)
-  "Return the Elisp symbol given by SYMBOL-OR-NAME if it is a Hyperbole action type name, else nil."
+  "Return the symbol given by SYMBOL-OR-NAME if it is a action type."
   (when (or (symbolp symbol-or-name) (stringp symbol-or-name))
     (symtable:get symbol-or-name symtable:actypes)))
 
 (defsubst symtable:ibtype-p (symbol-or-name)
-  "Return the Elisp symbol given by SYMBOL-OR-NAME if it is a Hyperbole implicit button type name, else nil."
+  "Return the symbol given by SYMBOL-OR-NAME if it is an implicit button type."
   (when (or (symbolp symbol-or-name) (stringp symbol-or-name))
     (symtable:get symbol-or-name symtable:ibtypes)))
 
@@ -130,12 +131,12 @@ Caller must ensure SYMBOL-OR-NAME is a symbol or string."
 (defalias 'symtable:delete #'symtable:remove)
 
 (defun    symtable:get (symbol-or-name symtable)
-  "Return the Elisp symbol given by Hyperbole SYMBOL-OR-NAME if it is in existing SYMTABLE, else nil.
+  "Return the symbol given by SYMBOL-OR-NAME if it is in existing SYMTABLE.
 Caller must ensure SYMBOL-OR-NAME is a symbol or string."
   (symtable:operate #'gethash symbol-or-name symtable))
 
 (defun    symtable:remove (symbol-or-name symtable)
-  "Remove the Elisp symbol given by Hyperbole SYMBOL-OR-NAME if it is in existing SYMTABLE.
+  "Remove the symbol given by SYMBOL-OR-NAME if it is in existing SYMTABLE.
 Always return nil.
 Caller must ensure SYMBOL-OR-NAME is a symbol or string."
   (symtable:operate #'remhash symbol-or-name symtable))
@@ -247,7 +248,7 @@ Return the Hyperbole symbol for the TYPE if it existed, else nil."
   (documentation type))
 
 (defun    htype:names (type-category &optional sym)
-  "Return a list of the current definition names for TYPE-CATEGORY in priority order.
+  "Return a list of current definition names for TYPE-CATEGORY in priority order.
 Definition names do not contain the category prefix.
 TYPE-CATEGORY should be `actypes', `ibtypes' or nil for all.
 When optional SYM is given, returns the name for that symbol only, if any."
@@ -264,7 +265,8 @@ When optional SYM is given, returns the name for that symbol only, if any."
 ;;; ------------------------------------------------------------------------
 
 (defun   htype:symbol (type type-category)
-  "Return possibly new Hyperbole type symbol composed from TYPE and TYPE-CATEGORY (both symbols)."
+  "Return possibly new Hyperbole type symbol composed from TYPE and TYPE-CATEGORY.
+TYPE and TYPE-CATEGORY are both symbols."
   (intern (concat (symbol-name type-category) "::" (symbol-name type))))
 
 ;;; ========================================================================
@@ -302,7 +304,8 @@ When optional SYM is given, returns the name for that symbol only, if any."
   (list 'execute-kbd-macro macro repeat-count))
 
 (defun action:params-emacs (def)
-  "Return the argument list for the function DEF which may be a symbol or a function body."
+  "Return the argument list for the function DEF.
+DEF may be a symbol or a function body."
   (let ((params (help-function-arglist def t)))
     (cond ((listp params) ;; includes nil
 	   params)
@@ -392,7 +395,7 @@ performing ACTION."
 
 (defun    actype:def-symbol (actype)
   "Return the abbreviated symbol for ACTYPE used in its `defact'.
-ACTYPE must be a symbol or string that begins with 'actype::' or nil
+ACTYPE must be a symbol or string that begins with `actype::' or nil
 is returned."
   (let ((name (if (stringp actype)
 		  actype
@@ -422,7 +425,8 @@ performing ACTION."
 	  (hhist:add hist-elt))))))
 
 (defun    actype:action (actype)
-  "Return action part of ACTYPE (a bound function symbol, symbol name or function body).
+  "Return action part of ACTYPE.
+ACTYPE is a bound function symbol, symbol name or function body.
 ACTYPE may be a Hyperbole actype or Emacs Lisp function."
   (let (actname
 	action)

--- a/hact.el
+++ b/hact.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:     30-May-22 at 13:55:46 by Bob Weiner
+;; Last-Mod:     20-Jul-22 at 19:16:16 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -54,7 +54,7 @@ TYPE-CATEGORY is one of `actypes' or `ibtypes'."
   (plist-get symtable:category-plist type-category))
 
 (defun    symtable:operate (operation symbol-or-name symtable)
-  "Call hash-table function OPERATION with SYMBOL-OR-NAME as key upon SYMTABLE.
+  "Call hash-table OPERATION with Hyperbole SYMBOL-OR-NAME key for SYMTABLE.
 Trigger an error if SYMBOL-OR-NAME cannot be mapped to an existing Elisp
 symbol or if SYMTABLE is invalid."
   (let ((name (cond ((stringp symbol-or-name)
@@ -113,12 +113,12 @@ with the `ibtypes::' prefix and one without.  The value for both
 keys is the Elisp symbol for the type, which includes the prefix.")
 
 (defsubst symtable:actype-p (symbol-or-name)
-  "Return the symbol given by SYMBOL-OR-NAME if it is a action type."
+  "Return SYMBOL-OR-NAME if it is a Hyperbole action type, else nil."
   (when (or (symbolp symbol-or-name) (stringp symbol-or-name))
     (symtable:get symbol-or-name symtable:actypes)))
 
 (defsubst symtable:ibtype-p (symbol-or-name)
-  "Return the symbol given by SYMBOL-OR-NAME if it is an implicit button type."
+  "Return SYMBOL-OR-NAME if it is a Hyperbole implicit button type, else nil."
   (when (or (symbolp symbol-or-name) (stringp symbol-or-name))
     (symtable:get symbol-or-name symtable:ibtypes)))
 
@@ -131,7 +131,7 @@ Caller must ensure SYMBOL-OR-NAME is a symbol or string."
 (defalias 'symtable:delete #'symtable:remove)
 
 (defun    symtable:get (symbol-or-name symtable)
-  "Return the symbol given by SYMBOL-OR-NAME if it is in existing SYMTABLE.
+  "Remove SYMBOL-OR-NAME if it is in existing SYMTABLE.
 Caller must ensure SYMBOL-OR-NAME is a symbol or string."
   (symtable:operate #'gethash symbol-or-name symtable))
 

--- a/hactypes.el
+++ b/hactypes.el
@@ -68,7 +68,7 @@ Return any non-nil value or t."
   (or (symbol-value var) t))
 
 (defact eval-elisp (lisp-expr)
-  "Evaluate a Lisp expression LISP-EXPR for its side-effects and return any non-nil value."
+  "Evaluate a LISP-EXPR for its side-effects and return any non-nil value."
   (interactive "xLisp to eval: ")
   (eval lisp-expr t))
 
@@ -205,11 +205,12 @@ kill the last output to the shell buffer before executing SHELL-CMD."
     (message msg)))
 
 (defact hyp-config (&optional out-buf)
-  "Insert Hyperbole configuration information at the end of the current buffer or within optional OUT-BUF."
+  "Insert Hyperbole configuration information at the end of the current buffer.
+Insert in optional OUT-BUF if specified."
   (hypb:configuration out-buf))
 
 (defact hyp-request (&optional out-buf)
-  "Insert into optional OUT-BUF a description of how to subscribe or unsubscribe from a Hyperbole mail list via email."
+  "Insert into optional OUT-BUF how to (un)subscribe from a Hyperbole mail list."
   (save-excursion
     (and out-buf (set-buffer out-buf))
     ;; Allows for insertion prior to user's email signature
@@ -275,7 +276,7 @@ This type of link is for use within a single editor session.  Use
   (hpath:find directory))
 
 (defact link-to-ebut (key &optional key-file)
-  "Perform action given by an explicit button, specified by KEY and optional KEY-FILE.
+  "Perform explicit button action specified by KEY and optional KEY-FILE.
 Interactively, KEY-FILE defaults to the current buffer's file name."
   (interactive
    (let (but-lbl
@@ -469,7 +470,8 @@ suffix."
     (hypb:error "(link-to-Info-index-entry): Invalid Info index item: `%s'" index-item)))
 
 (defact link-to-Info-node (string)
-  "Display an Info node given by STRING or if not found, try to display it as an Info index item.
+  "Display an Info node given by STRING.
+If not found, try to display it as an Info index item.
 STRING must be a string of the form \"(filename)name\".  During
 button creation, completion for both filename and node names is
 available.  Filename may be given without the .info suffix."
@@ -483,7 +485,7 @@ available.  Filename may be given without the .info suffix."
     (hypb:error "(link-to-Info-node): Invalid Info node: `%s'" string)))
 
 (defact link-to-ibut (key &optional but-src point)
-  "Perform an action given by an implicit button, specified by KEY, optional BUT-SRC and POINT.
+  "Perform implicit button action specified by KEY, optional BUT-SRC and POINT.
 BUT-SRC defaults to the current buffer's file or if there is no
 attached file, then to its buffer name.  POINT defaults to the
 current point.

--- a/hargs.el
+++ b/hargs.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    31-Oct-91 at 23:17:35
-;; Last-Mod:     15-Jul-22 at 22:07:35 by Mats Lidell
+;; Last-Mod:     18-Jul-22 at 21:49:36 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -75,12 +75,14 @@ Convert NUL characters to colons for use with grep lines."
 (defun hargs:delimited (start-delim end-delim
 			&optional start-regexp-flag end-regexp-flag
 			list-positions-flag exclude-regexp)
-  "Return a normalized, single line, delimited string that point is within the first line of, or nil.
+  "Return a delimited string that point is within the first line of, or nil.
+The string is normalized, single line.
 START-DELIM and END-DELIM are strings that specify the argument
 delimiters.  With optional START-REGEXP-FLAG non-nil, START-DELIM is
 treated as a regular expression.  END-REGEXP-FLAG is similar.
-With optional LIST-POSITIONS-FLAG, return list of (string-matched start-pos end-pos).
-With optional EXCLUDE-REGEXP, any matched string is ignored if it matches this regexp."
+With optional LIST-POSITIONS-FLAG, return list of (string-matched
+start-pos end-pos).  With optional EXCLUDE-REGEXP, any matched
+string is ignored if it matches this regexp."
   (let* ((opoint (point))
 	 (line-begin (line-beginning-position))
 	 ;; This initial limit if the forward search limit for start delimiters

--- a/hargs.el
+++ b/hargs.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    31-Oct-91 at 23:17:35
-;; Last-Mod:     18-Jul-22 at 21:49:36 by Mats Lidell
+;; Last-Mod:     20-Jul-22 at 19:17:13 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -76,7 +76,7 @@ Convert NUL characters to colons for use with grep lines."
 			&optional start-regexp-flag end-regexp-flag
 			list-positions-flag exclude-regexp)
   "Return a delimited string that point is within the first line of, or nil.
-The string is normalized, single line.
+The string is normalized and reduced to a single line.
 START-DELIM and END-DELIM are strings that specify the argument
 delimiters.  With optional START-REGEXP-FLAG non-nil, START-DELIM is
 treated as a regular expression.  END-REGEXP-FLAG is similar.

--- a/hbdata.el
+++ b/hbdata.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Apr-91
-;; Last-Mod:     10-May-22 at 00:24:16 by Bob Weiner
+;; Last-Mod:      8-Jul-22 at 22:47:23 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -146,9 +146,10 @@ Search is case-insensitive.  Return list with elements:
 ;;; ------------------------------------------------------------------------
 
 (defun hbdata:build (&optional mod-lbl-key but-sym)
-  "Construct button data from optional MOD-LBL-KEY and BUT-SYM; modify BUT-SYM attributes.
-MOD-LBL-KEY nil means create a new entry, otherwise modify existing one.
-Nil BUT-SYM means use 'hbut:current'.  If successful, return a cons of
+  "Construct button data from optional MOD-LBL-KEY and BUT-SYM.
+Modify BUT-SYM attributes.  MOD-LBL-KEY nil means create a new
+entry, otherwise modify existing one.  Nil BUT-SYM means use
+'hbut:current'.  If successful, return a cons of
  (button-data . button-instance-str), else nil."
   (let* ((b (hattr:copy (or but-sym 'hbut:current) 'but))
 	 (l (hattr:get b 'loc))
@@ -222,7 +223,7 @@ Nil BUT-SYM means use 'hbut:current'.  If successful, return a cons of
   "Return button data entry given by LBL-KEY, KEY-SRC and optional DIRECTORY.
 Return nil if no matching entry is found.
 A button data entry is a list of attribute values.  Use methods from
-class 'hbdata' to operate on the entry."
+class `hbdata' to operate on the entry."
   (hbdata:apply-entry
    (lambda () (read (current-buffer)))
    lbl-key key-src directory))
@@ -253,7 +254,7 @@ Utilize arguments LBL-KEY, KEY-SRC and optional DIRECTORY."
 (defun hbdata:delete-entry (lbl-key key-src &optional directory)
   "Delete button data entry given by LBL-KEY, KEY-SRC and optional DIRECTORY.
 Return entry deleted (a list of attribute values) or nil.
-Use methods from class 'hbdata' to operate on the entry.
+Use methods from class `hbdata' to operate on the entry.
 If the hbdata buffer is blank/empty, kill it and remove the associated file."
   (hbdata:apply-entry
    (lambda ()
@@ -288,7 +289,7 @@ If the hbdata buffer is blank/empty, kill it and remove the associated file."
   "Return button data entry indexed by BUT-KEY, KEY-SRC, optional DIRECTORY.
 Return nil if entry is not found.  Leave point at start of entry when
 successful or where entry should be inserted if unsuccessful.
-A button entry is a list.  Use methods from class 'hbdata' to operate on the
+A button entry is a list.  Use methods from class `hbdata' to operate on the
 entry.  Optional INSTANCE non-nil means search for any button instance matching
 but-key."
   (let ((pos-entry-cons
@@ -309,9 +310,10 @@ but-key."
 
 (defun hbdata:apply-entry (func lbl-key key-src &optional directory
 			   create-flag instance-flag)
-  "Invoke FUNC with point at hbdata entry given by LBL-KEY, KEY-SRC, optional DIRECTORY.
-With optional CREATE-FLAG, if no such line exists, insert a new file entry at the
-beginning of the hbdata file (which is created if necessary).
+  "Invoke FUNC with point at hbdata entry.
+Hbdata is given by LBL-KEY, KEY-SRC and optional DIRECTORY.
+With optional CREATE-FLAG, if no such line exists, insert a new file entry at
+the beginning of the hbdata file (which is created if necessary).
 INSTANCE-FLAG non-nil means search for any button instance matching LBL-KEY and
 call FUNC with point right after any 'ebut:instance-sep' in match.
 Return value of evaluation when a matching entry is found or nil."

--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:     15-Jul-22 at 22:07:35 by Mats Lidell
+;; Last-Mod:     18-Jul-22 at 21:49:49 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -204,7 +204,7 @@ Return nil if no matching button is found."
 (defalias 'ebut:key-to-label       #'hbut:key-to-label)
 
 (defun    ebut:label-p (&optional as-label start-delim end-delim pos-flag two-lines-flag)
-  "Return key for the Hyperbole explicit button label that point is within, else nil.
+  "Return key for the explicit button label that point is within, else nil.
 This is the normalized key form of the explicit button's label.
 
 Assume point is within the first line of any button label.  All
@@ -297,7 +297,7 @@ positions at which the button delimiter begins and ends."
 (defalias 'map-ebut #'ebut:map)
 
 (defun    ebut:map (but-func &optional regexp-match include-delims)
-  "Apply BUT-FUNC to the explicit buttons in the visible part of the current buffer.
+  "Apply BUT-FUNC to the explicit buttons in the visible part of current buffer.
 If REGEXP-MATCH is non-nil, only buttons which match this argument are
 considered.
 
@@ -322,7 +322,7 @@ move to the first occurrence of the button."
       (goto-char (+ (match-beginning 0) (length ebut:start)))))
 
 (defun    ebut:operate (curr-label new-label)
-  "Operate on and modify properties of a new or existing explicit button given by CURR-LABEL.
+  "Operate on and modify properties of an explicit button given by CURR-LABEL.
 When NEW-LABEL is non-nil, this is substituted for CURR-LABEL and the
 associated button is modified.  Otherwise, a new button is created.
 
@@ -431,7 +431,8 @@ button is found in the current buffer."
 
 
 (defun    ebut:program (label actype &rest args)
-  "Programmatically create an explicit Hyperbole button at point from LABEL, ACTYPE (action type), and optional actype ARGS.
+  "Programmatically create an explicit Hyperbole button at point.
+Create button from LABEL, ACTYPE (action type), and optional actype ARGS.
 Insert LABEL text at point surrounded by <( )> delimiters, adding any
 necessary instance number of the button after the LABEL.  ACTYPE may
 be a Hyperbole action type name (from defact) or an Emacs Lisp
@@ -461,9 +462,9 @@ For interactive creation, use `hui:ebut-create' instead."
 
 (defun    ebut:search (string out-buf &optional match-part)
   "Write explicit button lines matching STRING to OUT-BUF.
-Search across all files into which the user has previously saved explicit buttons.
-By default, find matches for whole button labels only; optional MATCH-PART
-enables partial matches."
+Search across all files into which the user has previously saved
+explicit buttons.  By default, find matches for whole button
+labels only; optional MATCH-PART enables partial matches."
   (let*  ((buffers (mapcar (lambda (dir)
 			     (expand-file-name hattr:filename dir))
 			   (hbmap:dir-list)))
@@ -539,8 +540,10 @@ enables partial matches."
     total))
 
 (defun    ebut:to (lbl-key)
-  "Find the nearest explicit button with LBL-KEY (a label or label key) within the visible portion of the current buffer.
-Leave point inside the button label.  Return the symbol for the button, else nil."
+  "Find the nearest explicit button with LBL-KEY (a label or label key).
+Search within the visible portion of the current buffer.  Leave
+point inside the button label.  Return the symbol for the button,
+else nil."
   (unless lbl-key
     (setq lbl-key (ebut:label-p nil nil nil nil t)))
   (hbut:funcall (lambda (lbl-key _buffer _key-src)
@@ -639,7 +642,8 @@ Return entry deleted (a list of attribute values) or nil."
   (hbut:delete lbl-key nil (gbut:file)))
 
 (defun    gbut:ebut-program (label actype &rest args)
-  "Programmatically create a global explicit Hyperbole button at point from LABEL, ACTYPE (action type), and optional actype ARGS.
+  "Programmatically create a global explicit Hyperbole button at point.
+Create button from LABEL, ACTYPE (action type), and optional actype ARGS.
 Insert LABEL text at the end of the personal/global button file
 surrounded by <( )> delimiters, adding any necessary instance
 number of the button after the LABEL.  ACTYPE may be a Hyperbole
@@ -658,11 +662,12 @@ For interactive creation, use `hui:gbut-create' instead."
 	(eval `(ebut:program ',label ',actype ,@args))))))
 
 (defun    gbut:file ()
-  "Return the absolute filename that stores Hyperbole global buttons (those accessed by name)."
+  "Return filename that store global buttons (those accessed by name).
+The filename is absolute."
   (expand-file-name hbmap:filename hbmap:dir-user))
 
 (defun    gbut:get (&optional lbl-key)
-  "Return global Hyperbole button symbol given by optional LBL-KEY if found in (gbut:file).
+  "Return global button symbol given by optional LBL-KEY if found in (gbut:file).
 
 Retrieve any button data, convert into a button object and return a symbol
 which references the button.
@@ -704,7 +709,8 @@ to two lines."
     (hbut:label-p as-label start-delim end-delim pos-flag two-lines-flag)))
 
 (defun    gbut:to (lbl-key)
-  "Find the global button with LBL-KEY (a label or label key) within the visible portion of the global button file.
+  "Find the global button with LBL-KEY (a label or label key).
+Find it within the visible portion of the global button file.
 Leave point inside the button label, if it has one.
 Return the symbol for the button when found, else nil."
   (when (file-readable-p (gbut:file))
@@ -881,7 +887,7 @@ Use the function, (hbut:max-len), to read the proper value.")
 
 (defun    hbut:act (&optional hbut)
   "Perform action for optional explicit or implicit Hyperbole button symbol HBUT.
-Default is 'hbut:current."
+Default is `hbut:current'."
   (interactive (list (hbut:get (hargs:read-match "Activate labeled Hyperbole button: "
 						 (nconc (ebut:alist) (ibut:alist))
 						 nil t nil 'hbut))))
@@ -1037,7 +1043,7 @@ Ignore email-related buffers."
   label)
 
 (defun    hbut:delete (&optional lbl-key buffer key-src)
-  "Delete explicit or labeled implicit Hyperbole button symbol given by LBL-KEY and BUFFER.
+  "Delete explicit or labeled implicit button symbol given by LBL-KEY and BUFFER.
 KEY-SRC is given when retrieving global buttons and is the full source pathname.
 
 Return a symbol which references the button or nil if not deleted.
@@ -1052,7 +1058,8 @@ BUFFER defaults to the current buffer."
 	(ibut:delete lbl-key)))))
 
 (defun    hbut:funcall (func &optional lbl-key buffer key-src)
-  "Move to an implicit button and return the result of calling FUNC with optional argument values of LBL-KEY, BUFFER and KEY-SRC.
+  "Move to an implicit button and return the result of calling FUNC.
+Call FUNC with optional argument values of LBL-KEY, BUFFER and KEY-SRC.
 The implicit button used is given by LBL-KEY (a label or label key)
 within BUFFER or KEY-SRC (full path to global button file).  Use
 `save-excursion' around this call to prevent permanent movement of
@@ -1077,7 +1084,7 @@ point when desired."
       (funcall func lbl-key buffer key-src))))
 
 (defun    hbut:get (&optional lbl-key buffer key-src)
-  "Return explicit or labeled implicit Hyperbole button symbol given by LBL-KEY and BUFFER.
+  "Return explicit or labeled implicit button symbol given by LBL-KEY and BUFFER.
 KEY-SRC is given when retrieving global buttons and is the full source pathname.
 
 Return a symbol which references the button or nil if not found.
@@ -1164,7 +1171,8 @@ represent the output of particular document formatters."
 	    ((current-buffer))))))
 
 (defun    hbut:key-src-set-buffer (src)
-  "Set buffer to SRC, a buffer, buffer name, file, directory or symlink and return SRC or nil if invalid."
+  "Set buffer to SRC, a buffer, buffer name, file, directory or symlink.
+Return SRC or nil if invalid."
   (cond ((null src) nil)
 	((or (bufferp src) (get-buffer src))
 	 (set-buffer src)
@@ -1267,9 +1275,10 @@ whitespace sequences with `_'."
 
 (defun    hbut:map (but-func &optional start-delim end-delim
 			     regexp-match include-delims)
-  "Apply BUT-FUNC to a set of Hyperbole buttons in the visible part of the current buffer.
-The set of buttons are those whose labels are delimited by optional START-DELIM and
-END-DELIM and that match any optional REGEXP-MATCH.
+  "Apply BUT-FUNC to a set of buttons in the visible part of the current buffer.
+The set of buttons are those whose labels are delimited by
+optional START-DELIM and END-DELIM and that match any optional
+REGEXP-MATCH.
 
 START-DELIM defaults to ebut:start; END-DELIM defaults to ebut:end.
 If END-DELIM is a symbol, e.g. t, then treat START-DELIM as a regular
@@ -1317,7 +1326,9 @@ calls `hbut:modify-syntax'.")
 
 ;;;###autoload
 (defun    hbut:modify-syntax ()
-  "Modify syntactic character pairs in hbut:syntax-table and help-mode-syntax-table for use with implicit button activations."
+  "Modify syntactic character pairs.
+Modify `hbut:syntax-table' and `help-mode-syntax-table'.  For use
+with implicit button activations."
   ;; Treat angle brackets as opening and closing delimiters for ease
   ;; of matching.
   (mapc (lambda (syntax-table)
@@ -1330,7 +1341,7 @@ calls `hbut:modify-syntax'.")
   nil)
 
 (defun    hbut:outside-comment-p ()
-  "Return t if within a programming language buffer and prior regexp match is outside a comment, else nil."
+  "True within a programming language buffer and prior match is outside a comment."
   (when (and (derived-mode-p 'prog-mode)
 	     (not (eq major-mode 'lisp-interaction-mode))
 	     (not (memq major-mode hui-select-markup-modes)))
@@ -1354,8 +1365,10 @@ calls `hbut:modify-syntax'.")
 Takes an optional ARG interpreted as follows:
   a button symbol - report on that button;
   nil             - report on button at point, if any;
-  integer > 0     - report on all explicit buttons in buffer, in lexicographical order;
-  integer < 1     - report on all explicit buttons in buffer, in occurrence order.
+  integer > 0     - report on all explicit buttons in buffer,
+                    in lexicographical order;
+  integer < 1     - report on all explicit buttons in buffer,
+                    in occurrence order.
 
 Return number of buttons reported on or nil if none."
   (setq arg (cond ((or (integerp arg) (symbolp arg)) arg)
@@ -1423,8 +1436,10 @@ If a file, always return a full path if optional FULL is non-nil."
 (defalias 'hbut:summarize 'hbut:report)
 
 (defun    hbut:to (lbl-key)
-  "Find the nearest explicit button or labeled/named implicit button with LBL-KEY (a label or label key) within the visible portion of the current buffer.
-Leave point inside the button label.  Return the symbol for the button, else nil."
+  "Find the nearest explicit button or labeled/named implicit button.
+Button given by LBL-KEY (a label or label key) and within the
+visible portion of the current buffer.  Leave point inside the
+button label.  Return the symbol for the button, else nil."
   (or (ebut:to lbl-key) (ibut:to lbl-key)))
 
 (defvar   hbut:current nil
@@ -1446,7 +1461,8 @@ source file for the buttons in the menu, if any.")
   (nconc (hbut:ebut-key-list) (hbut:ibut-key-list)))
 
 (defun    hbut:ebut-key-list (&optional key-src)
-  "Return a list of explicit button label keys from optional KEY-SRC or the current buffer."
+  "Return a list of explicit button label keys.
+Keys in optional KEY-SRC or the current buffer."
   (save-excursion
     (if (hbdata:to-entry-buf (or key-src (buffer-file-name)))
 	(let (hbuts)
@@ -1460,7 +1476,8 @@ source file for the buttons in the menu, if any.")
 	    hbuts)))))
 
 (defun    hbut:ibut-key-list (&optional key-src)
-  "Return a list of implicit button label keys from optional KEY-SRC or the current buffer."
+  "Return a list of implicit button label keys.
+Keys in optional KEY-SRC or the current buffer."
   (save-excursion
     (when (hbut:key-src-set-buffer (or key-src (current-buffer)))
       (save-restriction
@@ -1654,7 +1671,7 @@ expression which matches an entire button string."
   (hbut:map but-func ibut:label-start ibut:label-end))
 
 (defun    ibut:rename (old-lbl new-lbl)
-  "Rename a label preceding the text of a Hyperbole implicit button in the current buffer from OLD-LBL to NEW-LBL.
+  "Rename an implicit button label in the current buffer from OLD-LBL to NEW-LBL.
 Return t if the label is changed, else nil.
 
 Signal an error when no such button is found in the current buffer.
@@ -1675,7 +1692,7 @@ current."
 	(t (error "(ibut:rename): Button '%s' not found in visible portion of buffer." old-lbl))))
 
 (defun    ibut:label-p (&optional as-label start-delim end-delim pos-flag two-lines-flag)
-  "Return key for the Hyperbole implicit button label that point is within, else nil.
+  "Return key for the implicit button label that point is within, else nil.
 This is the normalized key form of an optional label that may
 precede an implicit button.  Use `ibut:at-p' instead to test if
 point is on either the implicit button text itself or the label.
@@ -1693,12 +1710,14 @@ constrain label search to two lines."
 		  (or end-delim ibut:label-end) pos-flag two-lines-flag)))
 
 (defun    ibut:label-regexp (lbl-key &optional no-delim)
-  "Unnormalize ibutton LBL-KEY.  Return regular expression matching delimited button label.
+  "Unnormalize ibutton LBL-KEY.
+Return regular expression matching delimited button label.
 Optional NO-DELIM leaves off delimiters, leading and trailing space."
   (hbut:label-regexp lbl-key no-delim ibut:label-start ibut:label-end))
 
 (defun    ibut:label-set (label &optional start end)
-  "Set current implicit button attributes from LABEL and optional START, END positions.
+  "Set current implicit button attributes.
+Get attributes from LABEL and optional START, END positions.
 Return label.  When START and END are given, they specify the
 region in the buffer to flash when this implicit button is
 activated or queried for its attributes.  If LABEL is a list, it
@@ -1752,9 +1771,10 @@ positions at which the button label delimiter begins and ends."
 
 (defun    ibut:map (but-func &optional _start-delim _end-delim
 			     regexp-match include-delims)
-  "Apply BUT-FUNC to the labeled implicit buttons in the visible part of the current buffer.
-If REGEXP-MATCH is non-nil, only buttons which match this argument are
-considered.
+  "Apply BUT-FUNC to the labeled implicit buttons.
+Button is in the visible part of the current buffer.  If
+REGEXP-MATCH is non-nil, only buttons which match this argument
+are considered.
 
 BUT-FUNC must take precisely three arguments: the button label, the
 start position of the delimited button label and its end position (positions
@@ -1762,8 +1782,8 @@ include delimiters when INCLUDE-DELIMS is non-nil)."
   (hbut:map but-func ibut:label-start ibut:label-end regexp-match include-delims))
 
 (defun    ibut:next-occurrence (lbl-key &optional buffer)
-  "Move point to next occurrence of an implicit button with LBL-KEY in optional BUFFER.
-BUFFER defaults to current buffer.  It may be a buffer name.
+  "Move point to next occurrence of an implicit button with LBL-KEY.
+Optional BUFFER defaults to current buffer.  It may be a buffer name.
 Return non-nil iff occurrence is found.
 
 Remember to use (goto-char (point-min)) before calling this in order to
@@ -1777,8 +1797,8 @@ move to the first occurrence of the button."
     (goto-char (+ (match-beginning 0) (length ibut:label-start)))))
 
 (defun    ibut:previous-occurrence (lbl-key &optional buffer)
-  "Move point to previous occurrence of an implicit button with LBL-KEY in optional BUFFER.
-BUFFER defaults to current buffer.  It may be a buffer name.
+  "Move point to previous occurrence of an implicit button with LBL-KEY.
+Optional BUFFER defaults to current buffer.  It may be a buffer name.
 Return non-nil iff occurrence is found.
 
 Remember to use (goto-char (point-max)) before calling this to search
@@ -1794,7 +1814,8 @@ the whole buffer."
 (defalias 'ibut:summarize 'hbut:report)
 
 (defun    ibut:to (lbl-key)
-  "Find the nearest implicit button with LBL-KEY (a label or label key) within the visible portion of the current buffer.
+  "Find the nearest implicit button with LBL-KEY (a label or label key).
+Find within the visible portion of the current buffer.
 Leave point inside the button text or its optional label, if it has one.
 Return the symbol for the button, else nil."
   (unless lbl-key
@@ -1840,9 +1861,10 @@ Return the symbol for the button, else nil."
 		lbl-key))
 
 (defun    ibut:at-to-name-p (&optional ibut)
-  "If point is on an implicit button, optional IBUT, move to the start of its name, if any (past opening delimiter).
-When found, set the name and lbl-key properties of IBUT.
-Return t if name is found, else nil."
+  "Move to start of an implicit buttons name, if any (past opening delimiter).
+Point is on an implicit button or optional IBUT.  When found, set
+the name and lbl-key properties of IBUT.  Return t if name is
+found, else nil."
   (let ((opoint (point))
 	move-flag
 	name
@@ -1864,10 +1886,14 @@ Return t if name is found, else nil."
     move-flag))
 
 (defun    ibut:to-name (lbl-key)
-  "Find the nearest implicit button with LBL-KEY (a label or label key) within the visible portion of the current buffer and move to the start of its delimited button name (after opening delimiter).
-This will find an implicit button if point is within its name or text
-or if LBL-KEY is a name/name-key of an existing implicit button.  It
-will not find other unnamed implicit buttons.
+  "Move to the start of the nearest implicit buttons delimited button name.
+Find the nearest implicit button with LBL-KEY (a label or label
+key), within the visible portion of the current buffer and move
+to the start of its delimited button name (after opening
+delimiter).  This will find an implicit button if point is within
+its name or text or if LBL-KEY is a name/name-key of an existing
+implicit button.  It will not find other unnamed implicit
+buttons.
 
 Return the symbol for the button if found, else nil."
   (unless lbl-key
@@ -1893,10 +1919,13 @@ Return the symbol for the button if found, else nil."
    lbl-key))
 
 (defun    ibut:to-text (lbl-key)
-  "Find the nearest implicit button with LBL-KEY (a label or label key) within the visible portion of the current buffer and move to within its button text.
-This will find an implicit button if point is within its name or text
-or if LBL-KEY is a name/name-key of an existing implicit button.  It
-will not find other unnamed implicit buttons.
+  "Move to within nearest implicit button text.
+Find the nearest implicit button with LBL-KEY (a label or label
+key) within the visible portion of the current buffer and move to
+within its button text.  This will find an implicit button if
+point is within its name or text or if LBL-KEY is a name/name-key
+of an existing implicit button.  It will not find other unnamed
+implicit buttons.
 
 Return the symbol for the button if found, else nil."
   (unless lbl-key
@@ -1944,11 +1973,14 @@ Return the symbol for the button if found, else nil."
   "String matching the end of a Hyperbole implicit button label.")
 
 (defvar   ibut:label-separator " "
-  "String inserted immediately after a newly created implicit button label to separate it from the implicit button text.
-See also `ibut:label-separator-regexp' for all valid characters that may manually inserted to separate an implicit button label from its text.")
+  "String inserted immediately after a newly created implicit button label.
+This separates it from the implicit button text.  See also
+`ibut:label-separator-regexp' for all valid characters that may
+manually inserted to separate an implicit button label from its
+text.")
 
 (defvar   ibut:label-separator-regexp "\\s-*[-:=]*\\s-+"
-  "Regular expression that separates an implicit button label from its implicit button text.")
+  "Regular expression that separates an implicit button label from its button text.")
 
 ;;; ========================================================================
 ;;; ibtype class - Implicit button types
@@ -2004,7 +2036,7 @@ type for ibtype is presently undefined."
 (defalias 'ibtype:create #'defib)
 
 (defun ibtype:activate-link (referent)
-  "Activate a Hyperbole implicit link `referent', either a key series, a URL or a path."
+  "Activate an implicit link REFERENT, either a key series, a URL or a path."
   (when referent
     (let ((key-series (kbd-key:is-p referent)))
       (if key-series
@@ -2017,7 +2049,10 @@ type for ibtype is presently undefined."
 
 (defmacro defil (type start-delim end-delim text-regexp link-expr
 		 &optional start-regexp-flag end-regexp-flag doc)
-  "Create Hyperbole implicit button link type from: TYPE (an uquoted symbol), START-DELIM and END-DELIM (strings), TEXT-REGEXP and LINK-EXPR.
+  "Create an implicit button link type.
+Use: TYPE (an unquoted symbol), START-DELIM and END-DELIM (strings),
+TEXT-REGEXP and LINK-EXPR.
+
 With optional START-REGEXP-FLAG non-nil, START-DELIM is treated
 as a regular expression.  END-REGEXP-FLAG treats END-DELIM as a
 regular expression.  Hyperbole automatically creates a doc string
@@ -2042,8 +2077,8 @@ the whole button text (\\\\&) or any numbered grouping from
 TEXT-REGEXP, e.g. \\\\1, may be referenced in the LINK-EXPR to
 form the link referent.
 
-Here is a sample use case.  Let's create a button type whose
-buttons perform a grep-like function over a current repo's git
+Here is a sample use case.  Let us create a button type whose
+buttons perform a grep-like function over a current repositorys git
 log entries.  The buttons use this format: [<text to match>].
 
 The following defines the button type called search-git-log which
@@ -2058,8 +2093,8 @@ an Action Key press on a button of the form:
 
   ;; [<test release>]
 
-will display one line per commit whose change set matches 'test
-release'.  An Action Key press on any such line will then display the
+will display one line per commit whose change set matches \"test
+release\".  An Action Key press on any such line will then display the
 commit changes."
   (declare (debug
             (&define name stringp stringp stringp [&or stringp lambda-list]
@@ -2107,9 +2142,12 @@ commit changes."
 			(if (stringp ,link-expr) (regexp-quote ,link-expr) ,link-expr)))))))
 
 (defmacro defal (type link-expr &optional doc)
-  "Create Hyperbole action button link TYPE (an unquoted symbol) whose buttons look like: <TYPE link-text> where link-text is substituted into LINK-EXPR as grouping 1 (specified either as %s or \\\\1).
-Hyperbole automatically creates a doc string for the type but you can
-override this by providing an optional DOC string.
+  "Create an action button link TYPE (an unquoted symbol).
+The buttons look like: <TYPE link-text> where link-text is
+substituted into LINK-EXPR as grouping 1 (specified either as %s
+or \\\\1).  Hyperbole automatically creates a doc string for the
+type but you can override this by providing an optional DOC
+string.
 
 LINK-EXPR may be:
   (1) a brace-delimited key series;
@@ -2164,7 +2202,7 @@ use `defib'."
 
 (defun    ibtype:def-symbol (ibtype)
   "Return the abbreviated symbol for IBTYPE used in its `defib'.
-IBTYPE must be a symbol or string that begins with 'ibtype::' or nil
+IBTYPE must be a symbol or string that begins with `ibtype::' or nil
 is returned."
   (let ((name (if (stringp ibtype)
 		  ibtype

--- a/hhist.el
+++ b/hhist.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    24-Apr-91 at 03:36:23
-;; Last-Mod:     17-Apr-22 at 12:41:30 by Bob Weiner
+;; Last-Mod:      9-Jul-22 at 01:00:43 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -25,8 +25,9 @@
 ;;; ************************************************************************
 
 (defun hhist:add (elt)
-  "Add ELT to hyper-history list if not the same as current or prior location (frame configuration).
-ELT must have been created via a call to 'hhist:element' prior to
+  "Add ELT to hyper-history list.
+Do not add if not the same as current or prior location (frame configuration).
+ELT must have been created via a call to `hhist:element' prior to
 changing the current frame configuration somehow."
   ;; Even though this next line looks useless, it cures a problem with
   ;; window buffer correspondences on startup, so don't remove it.

--- a/hib-debbugs.el
+++ b/hib-debbugs.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Jun-16 at 14:24:53
-;; Last-Mod:     24-Jan-22 at 00:18:32 by Bob Weiner
+;; Last-Mod:      9-Jul-22 at 00:33:19 by Mats Lidell
 ;;
 ;; Copyright (C) 2016, 2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -96,7 +96,7 @@
 ;;; ************************************************************************
 
 (defib debbugs-gnu-query ()
-  "Display the results of a Debbugs query based on a bug reference string around point.
+  "Display the results of a Debbugs query from a bug reference string around point.
 This works in most types of buffers.  If the query includes a
 single id number, display the original message submission for
 that id and allow browsing of the followup discussion.  Accepts
@@ -124,7 +124,8 @@ Note that `issue' or `debbugs' may be used as well in place of `bug'."
     (debbugs-gnu-show-discussion)))
 
 (defun debbugs-gnu-query:help (_but)
-  "Make a GNU debbugs id number at point (optionally prefixed with a # sign) display the pretty pretted status of the bug id.
+  "Make a GNU display the pretty pretted status of the bug id.
+The id number can optionally be prefixed with a # sign.
 Ignore other types of GNU debbugs query strings."
   (if (and (debbugs-version-sufficient-p)
 	   (debbugs-query:at-p)
@@ -139,7 +140,7 @@ Ignore other types of GNU debbugs query strings."
       (hact 'smart-debbugs-gnu)))
 
 (defun debbugs-gnu-mode:help (&optional _but)
-  "Make a Gnu debbugs listing entry at point pretty print the status of the issue to a window below."
+  "Pretty print the status of a Debbugs listing entry to a window below."
   (condition-case ()
       (let ((display-buffer-overriding-action
 	     '(display-buffer-below-selected . nil)))
@@ -160,12 +161,15 @@ Ignore other types of GNU debbugs query strings."
     (call-interactively (key-binding "\C-m")))
 
 (defun debbugs-gnu-query:string (url-query-string)
-  "Parse and apply attributes from URL-QUERY-STRING to display the results of a Gnu debbugs query.
-URL-QUERY-STRING must be a valid URL query string (part after the question
-mark) of debbugs attributes and values, i.e. \"attr1=val1&attr2=val2&attr3=val3\"
-URL encoded characters are decoded.  An optional prefix of \"bug#<id-number>?\"
-may also be included at the front of the string to limit the query to a particular
-issue number.  Note that `issue' or `debbugs' may be used as well in place of `bug'."
+  "Display the results of a Gnu debbugs query.
+Parse and apply attributes from URL-QUERY-STRING.
+URL-QUERY-STRING must be a valid URL query string (part after the
+question mark) of debbugs attributes and values,
+i.e. \"attr1=val1&attr2=val2&attr3=val3\" URL encoded characters
+are decoded.  An optional prefix of \"bug#<id-number>?\" may also
+be included at the front of the string to limit the query to a
+particular issue number.  Note that `issue' or `debbugs' may be
+used as well in place of `bug'."
   (let* ((case-fold-search t)
 	 (id (when (string-match "\\`\\(bug\\|debbugs\\|issue\\)\\s-?#?\\s-?\\(\\([1-9][0-9]*\\)\\|\\?\\)+"
 				 url-query-string)
@@ -181,10 +185,11 @@ issue number.  Note that `issue' or `debbugs' may be used as well in place of `b
     (debbugs-gnu-query:list attr-pair-list)))
 
 (defun debbugs-gnu-query:list (query-attribute-list)
-  "Apply attributes from QUERY-ATTRIBUTE-LIST to display the results of a Gnu debbugs query.
-Each element of the list should be of the form (attribute . attribute-value).
-Attribute may be a symbol or a string.  Common attributes include: status,
-severity, and package."
+  "Display the results of a Gnu debbugs query.
+Apply attributes from QUERY-ATTRIBUTE-LIST to.  Each element of
+the list should be of the form (attribute . attribute-value).
+Attribute may be a symbol or a string.  Common attributes
+include: status, severity, and package."
   (require 'debbugs-gnu)
   (setq debbugs-gnu-current-query nil)
   (dolist (attr query-attribute-list)
@@ -196,7 +201,8 @@ severity, and package."
   (debbugs-gnu-show-reports))
 
 (defun smart-debbugs-gnu ()
-  "Display the discussion on the issue at point when the Action Key is pressed on a Gnu Debbugs listing entry ."
+  "Display the discussion on the issue at point.
+When the Action Key is pressed on a Gnu Debbugs listing entry."
   (debbugs-gnu-show-discussion))
 
 ;; (let ((entries (cdar tabulated-list-entries)))
@@ -229,8 +235,9 @@ attributes."
 	      ;; (looking-at "[ \t\n\r\f]*\\(bug\\|debbugs\\|issue\\)?[ \t\n\r\f]*#\\([1-9][0-9]*\\)[\].,;?!\)\>\}]?\\([ \t\n\r\f]\\|\\'\\)")
 
 (defun debbugs-query:status (id)
-  "Pretty print to `standard-output' the status attributes of debbugs ID (a positive integer).
-Ignore nil valued attributes.  Return t unless no attributes are printed."
+  "Pretty print to `standard-output' the status attributes of debbugs ID.
+Debbugs ID is a positive integer.  Ignore nil valued attributes.
+Return t unless no attributes are printed."
   (require 'debbugs-gnu)
   ;; The (car (debbugs-get-status id)) is a list of (attribute . value) pairs which we sort below.
   (let ((attrib-list
@@ -254,7 +261,8 @@ Ignore nil valued attributes.  Return t unless no attributes are printed."
 	has-attr))))
 
 (defun debbugs-version-sufficient-p ()
-  "Return t iff debbugs version is sufficient for use with Hyperbole (greater than equal to 0.9.7)."
+  "Return t iff debbugs version is sufficient for use with Hyperbole.
+Must be greater than equal to 0.9.7."
   (save-excursion
     (let* ((debbugs-src (locate-file "debbugs" load-path '(".el")))
 	   (visiting-debbugs-src (when debbugs-src (get-file-buffer debbugs-src)))

--- a/hib-debbugs.el
+++ b/hib-debbugs.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Jun-16 at 14:24:53
-;; Last-Mod:      9-Jul-22 at 00:33:19 by Mats Lidell
+;; Last-Mod:     20-Jul-22 at 19:23:07 by Mats Lidell
 ;;
 ;; Copyright (C) 2016, 2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -124,7 +124,7 @@ Note that `issue' or `debbugs' may be used as well in place of `bug'."
     (debbugs-gnu-show-discussion)))
 
 (defun debbugs-gnu-query:help (_but)
-  "Make a GNU display the pretty pretted status of the bug id.
+  "Make a Gnu debbugs id number at point display the pretty-printed bug status.
 The id number can optionally be prefixed with a # sign.
 Ignore other types of GNU debbugs query strings."
   (if (and (debbugs-version-sufficient-p)
@@ -140,7 +140,7 @@ Ignore other types of GNU debbugs query strings."
       (hact 'smart-debbugs-gnu)))
 
 (defun debbugs-gnu-mode:help (&optional _but)
-  "Pretty print the status of a Debbugs listing entry to a window below."
+  "Make a Gnu debbugs listing at point pretty-print its status to a window below."
   (condition-case ()
       (let ((display-buffer-overriding-action
 	     '(display-buffer-below-selected . nil)))
@@ -161,8 +161,7 @@ Ignore other types of GNU debbugs query strings."
     (call-interactively (key-binding "\C-m")))
 
 (defun debbugs-gnu-query:string (url-query-string)
-  "Display the results of a Gnu debbugs query.
-Parse and apply attributes from URL-QUERY-STRING.
+  "Show the results of a Gnu debbugs query with attributes from URL-QUERY-STRING.
 URL-QUERY-STRING must be a valid URL query string (part after the
 question mark) of debbugs attributes and values,
 i.e. \"attr1=val1&attr2=val2&attr3=val3\" URL encoded characters
@@ -185,9 +184,8 @@ used as well in place of `bug'."
     (debbugs-gnu-query:list attr-pair-list)))
 
 (defun debbugs-gnu-query:list (query-attribute-list)
-  "Display the results of a Gnu debbugs query.
-Apply attributes from QUERY-ATTRIBUTE-LIST to.  Each element of
-the list should be of the form (attribute . attribute-value).
+  "Show the results of a Gnu debbugs query with QUERY-ATTRIBUTE-LIST attributes.
+Each element of the list should be of the form (attribute . attribute-value).
 Attribute may be a symbol or a string.  Common attributes
 include: status, severity, and package."
   (require 'debbugs-gnu)

--- a/hib-doc-id.el
+++ b/hib-doc-id.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    30-Sep-92 at 19:39:59
-;; Last-Mod:     24-Jan-22 at 00:18:32 by Bob Weiner
+;; Last-Mod:      9-Jul-22 at 00:36:20 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -93,7 +93,7 @@
     (concat "ID:[ \t]*"
 	    (regexp-quote doc-id-start) "[ \t]*" (regexp-quote doc-id)
 	    "[ \t]*" (regexp-quote doc-id-end)))
-  "Function of one argument that returns regexp which matches only within DOC-ID's index entry.")
+  "Function that returns regexp which matches only within DOC-ID's index entry.")
 
 (defvar doc-id-p (lambda (str)
 		   (and (stringp str)
@@ -103,7 +103,8 @@
   "Value is a function with a boolean result that tests whether `str' is a doc id.")
 
 (defvar doc-id-online-regexp "^Online-Loc:[ \t]*\"\\([^\"\t\r\n\f]+\\)\""
-  "Regexp whose 1st grouping matches a double quoted index entry implicit button that displays an online document.")
+  "Regexp whose 1st grouping matches a double quoted index entry.
+The match is an implicit button that displays an online document.")
 
 ;;; ************************************************************************
 ;;; Public implicit button types

--- a/hib-kbd.el
+++ b/hib-kbd.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    22-Nov-91 at 01:37:57
-;; Last-Mod:     15-Jul-22 at 23:21:33 by Mats Lidell
+;; Last-Mod:     18-Jul-22 at 21:49:59 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -44,19 +44,20 @@
     "divide" "down" "end" "enter" "esc" "home" "left" "insert"
     "multiply" "newline" "next" "prior" "return" "ret" "right" "rtn"
     "subtract" "tab" "up")
-  "List of dedicated keyboard key names which may be used with modifier keys.  Function keys are handled elsewhere.")
+  "List of dedicated keyboard key names which may be used with modifier keys.
+Function keys are handled elsewhere.")
 
 (defvar kbd-key:named-key-regexp
   (concat
    (mapconcat 'downcase kbd-key:named-key-list "\\|")
    "\\|"
    (mapconcat 'upcase kbd-key:named-key-list "\\|"))
-  "Regexp that matches to any of the dedicated keyboard key names in lower or uppercase.")
+  "Regexp that matches the dedicated keyboard key names in lower or uppercase.")
 
 (defvar kbd-key:modified-key-regexp
   (concat "\\(\\[?\\([ACHMS]-\\|kp-\\)+\\)[ \t\n\r\f]*\\(\\(<?\\<" kbd-key:named-key-regexp "\\>>?"
 	  "\\|<?[fF][0-9][0-9]?>?\\|<[a-zA-Z0-9]+>\\|.\\)\\]?\\)")
-  "Regexp matching to a single modified keyboard key within a human-readable string.
+  "Regexp matching a single modified keyboard key within a human-readable string.
 Group 1 matches to the set of modifier keys.  Group 3 matches to the unmodified key.")
 
 ;;; ************************************************************************
@@ -81,9 +82,11 @@ Return t if the sequence appears to be valid, else nil."
   (kbd-key:act key-series))
 
 (defib kbd-key ()
-  "Execute a key series (series of key sequences) around point, delimited by curly braces, {}.
-Key sequences should be in human readable form, e.g. {C-x C-b}, or what `key-description' returns.
-Forms such as {\C-b}, {\^b}, and {^M} will not be recognized.
+  "Execute a key series (series of key sequences) around point.
+The key series is delimited by curly braces, {}.  Key sequences
+should be in human readable form, e.g. {C-x C-b}, or what
+`key-description' returns.  Forms such as {\C-b}, {\^b}, and {^M}
+will not be recognized.
 
 Any key sequence within the series must be a string of one of the following:
   a Hyperbole minibuffer menu item key sequence,
@@ -163,7 +166,8 @@ Return t if KEY-SERIES appears valid, else nil."
 	   t))))
 
 (defun kbd-key:execute (key-series)
-   "Execute a possibly non-normalized KEY-SERIES with or without curly brace delimiters.
+  "Execute a possibly non-normalized KEY-SERIES.
+The KEY-SERIES can be with or without curly brace delimiters.
 Return t if KEY-SERIES is a valid key series that is executed, else nil."
   (interactive "sKey series to execute: ")
   (when (and key-series
@@ -189,13 +193,15 @@ Return t if KEY-SERIES is a valid key series that is executed, else nil."
 		 helm-flag orig-binding))))))
 
 (defun kbd-key:maybe-enable-helm (helm-flag orig-M-x-binding)
-  "Enable helm-mode if HELM-FLAG is non-nil.  Restore M-x binding to ORIG-M-X-BINDING."
+  "Enable helm-mode if HELM-FLAG is non-nil.
+Restore M-x binding to ORIG-M-X-BINDING."
   (when helm-flag (helm-mode 1))
   (global-set-key [?\M-x] orig-M-x-binding))
 
 (defun kbd-key:key-series-to-events (key-series)
-  "Insert the key-series as a series of keyboard events into Emacs' unread input stream.
-Emacs then executes them when its command-loop regains control."
+  "Insert the key-series as a series of keyboard events.
+The events are inserted into Emacs unread input stream.  Emacs
+then executes them when its command-loop regains control."
   (setq unread-command-events (nconc unread-command-events
 				     (listify-key-sequence
 				      (kbd-key:kbd key-series)))))
@@ -233,9 +239,12 @@ With optional prefix arg FULL, display full documentation for command."
       (kbd-key:doc kbd-key t))))
 
 (defun kbd-key:is-p (str)
-  "If STR is a curly-brace {} delimited key series, return the non-delimited, normalized form, else nil.
-Key sequences should be in human readable form, e.g. {C-x C-b}, or what `key-description' returns.
-Forms such as {\C-b}, {\^b}, and {^M} will not be recognized.
+  "Return the non-delimited, normalized form, of a delimited key series, STR.
+When STR is a curly-brace {} delimited key series, a
+non-delimited, normalized form is returned, else nil.  Key
+sequences should be in human readable form, e.g. {C-x C-b}, or
+what `key-description' returns.  Forms such as {\C-b}, {\^b}, and
+{^M} will not be recognized.
 
 Any key sequence within the series must be a string of one of the following:
   a Hyperbole minibuffer menu item key sequence,
@@ -264,9 +273,10 @@ Any key sequence within the series must be a string of one of the following:
 	 key-series)))
 
 (defun kbd-key:normalize (key-series)
-  "Normalize a human-readable string of keyboard keys, KEY-SERIES (without any surrounding {}).
-Return the normalized but still human-readable format.
-Use `kbd-key:key-series-to-events' to add the key series to Emacs'
+  "Normalize a human-readable string of keyboard keys, KEY-SERIES.
+The KEY-SERIES is without any surrounding {}.  Return the
+normalized but still human-readable format.  Use
+`kbd-key:key-series-to-events' to add the key series to Emacs'
 keyboad input queue, as if they had been typed by the user."
   (interactive "kKeyboard key sequence to normalize (no {}): ")
   ;;
@@ -327,7 +337,8 @@ keyboad input queue, as if they had been typed by the user."
 	(t (error "(kbd-key:normalize): requires a string argument, not `%s'" key-series))))
 
 (defun kbd-key:remove-delimiters (str start-delim end-delim)
-  "Return STR sans START-DELIM and END-DELIM (strings) iff it starts and ends with these delimiters."
+  "Return STR sans START-DELIM and END-DELIM (strings).
+Return iff it starts and ends with these delimiters."
   (when (and (string-match (format "\\`%s" (regexp-quote start-delim)) str)
 	     (string-match (format "%s\\'"  (regexp-quote end-delim)) str))
     (string-trim str start-delim end-delim)))
@@ -447,12 +458,13 @@ For an approximate inverse of this, see `key-description'."
       res)))
 
 (defun kbd-key:extended-command-p (key-series)
-  "Return non-nil if the string KEY-SERIES is a normalized extended command invocation, i.e. M-x command."
+  "Return non-nil if the KEY-SERIES is a normalized extended command invocation.
+A command of the form M-x command."
   (when (stringp key-series)
     (string-match kbd-key:extended-command-prefix key-series)))
 
 (defun kbd-key:hyperbole-hycontrol-key-p (key-series)
-  "Return t if normalized, non-nil KEY-SERIES is given when in a HyControl mode, else nil.
+  "True if normalized, non-nil KEY-SERIES is given when in a HyControl mode.
 Allows for multiple key sequences strung together."
   (and key-series
        (featurep 'hycontrol)

--- a/hmouse-tag.el
+++ b/hmouse-tag.el
@@ -1446,7 +1446,8 @@ to look.  If no tags file is found, an error is signaled."
 ;;; ************************************************************************
 
 (defun smart-tags-noselect-function ()
-  "Return the best available function for finding a tag definition without selecting it."
+  "Return the best available function for finding a tag definition.
+The function does not select the tag definition."
   (car (delq nil (mapcar (lambda (func) (if (fboundp func) func))
 			 #'(xref-definition find-tag-noselect find-tag-internal)))))
 

--- a/kotl/kcell.el
+++ b/kotl/kcell.el
@@ -59,8 +59,9 @@ not already there."
    plist))
 
 (defun kcell:create-top (&optional top-cell-attributes)
-  "Return a new koutline top cell with optional property list of TOP-CELL-ATTRIBUTES.
-The idstamp of the top cell is always 0 and this cell stores the idstamp-counter."
+  "Return a new top cell with optional property list of TOP-CELL-ATTRIBUTES.
+The idstamp of the top cell is always 0 and this cell stores the
+idstamp-counter."
   (kcell:create top-cell-attributes))
 
 (defalias 'kcell:get-attr 'plist-get)
@@ -73,7 +74,7 @@ The idstamp of the top cell is always 0 and this cell stores the idstamp-counter
 
 ;;;###autoload
 (defun kcell:ref-to-id (cell-ref &optional kviewspec-flag)
-  "When CELL-REF is valid, return a CELL-REF string converted to a cell idstamp (integer).
+  "Return a CELL-REF string converted to a cell idstamp (integer).
 If CELL-REF contains both a relative and a permanent id, the permanent id is
 returned.  If CELL-REF is invalid, nil is returned.
 
@@ -184,7 +185,7 @@ Augment capabilities not yet implemented and ignored for now:
 ;;;
 
 (defun kcell-data:create (cell idstamp)
-  "Given a kotl CELL and IDSTAMP (an integer), return a kcell-data structure to write to a file.
+  "Given a kotl CELL and IDSTAMP (an integer), return a kcell-data structure.
 If CELL, its idstamp, or its property list are nil, this repairs the cell by
 assuming it is the cell at point and filling in the missing information."
    (let ((plist (kcell:plist cell)))

--- a/kotl/kexport.el
+++ b/kotl/kexport.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    26-Feb-98
-;; Last-Mod:     15-Jul-22 at 23:24:27 by Mats Lidell
+;; Last-Mod:     18-Jul-22 at 21:50:10 by Mats Lidell
 ;;
 ;; Copyright (C) 1998-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -36,14 +36,15 @@
 ;;; ************************************************************************
 
 (defvar kexport:input-filename nil
-  "This is automatically set to the full pathname of the file presently being exported.")
+  "This is automatically set to the full pathname of the exported file.")
 
 (defvar kexport:output-filename nil
-  "This is automatically set to the full pathname of the file presently being exported.")
+  "This is automatically set to the full pathname of the exported file.")
 
 (defcustom kexport:html-body-attributes
   "BGCOLOR=\"#FFFFFF\"" ;; white background
-  "*String of HTML attributes attached to the <BODY> tag of an HTML exported koutline file."
+  "*String of HTML attributes attached to the <BODY> tag.
+Part of an HTML exported koutline file."
   :type 'string
   :group 'hyperbole-koutliner)
 
@@ -55,7 +56,8 @@
   :group 'hyperbole-koutliner)
 
 (defcustom kexport:html-keywords nil
-  "*String of comma separated keywords to include with an HTML-exported document, or nil for none."
+  "*String of comma separated keywords to include with an HTML-exported document.
+If nil, use no keywords."
   :type '(choice (const nil)
 		 (string))
   :group 'hyperbole-koutliner)
@@ -108,9 +110,9 @@
    (cons (format "&lt;\\s-*\\([^ \t\n\r,<>]+\\)\\s-*,\\s-*%s[^=&>]*&gt;"
 		 kexport:kcell-partial-reference-regexp)
 	 'kexport:html-file-klink))
-  "*List of (regexp . replacement-pattern) elements applied in order to the
-contents of each kcell from a koutline exported to HTML format.  Replacement
-pattern may be:
+  "*List of (regexp . replacement-pattern) elements applied in order.
+The elements are applied to the contents of each kcell from a
+koutline exported to HTML format.  Replacement pattern may be:
   a string with references to regexp's grouping numbers, e.g. \\1, or
   a function of one argument (it is passed the string being replaced in)
   which returns the modified string.  The function may use expressions such
@@ -160,7 +162,7 @@ li {
   font-size: 0;
 }
 </style>\n"
-  "CSS that styles collapsible HTML-exported Koutline parent cells")
+  "CSS that styles collapsible HTML-exported Koutline parent cells.")
 
 (defconst kexport:font-awesome-css-include-with-menus
   "<style>
@@ -294,7 +296,7 @@ menuitem > menu > menuitem.hover > menu > menuitem{
 }
 /* End Drop-down menu CSS */
 </style>\n"
-  "CSS that styles collapsible HTML-exported Koutline parent cells and menus")
+  "CSS that styles collapsible HTML-exported Koutline parent cells and menus.")
 
 (defconst kexport:font-awesome-collapsible-javascript
   "<script>
@@ -322,7 +324,7 @@ for (i = 0; i < coll.length; i++) {
   });
 }
 </script>\n"
-  "JavaScript which expands/collapses HTML-exported Koutline parent cells")
+  "JavaScript which expands/collapses HTML-exported Koutline parent cells.")
 
 ;;; ************************************************************************
 ;;; Public functions
@@ -330,11 +332,12 @@ for (i = 0; i < coll.length; i++) {
 
 ;;;###autoload
 (defun kexport:koutline (&optional soft-newlines-flag)
-  "Export the current buffer's koutline to the same named file with a \".html\" suffix.
+  "Export current buffer's koutline to the same named file with a \".html\" suffix.
 Return the pathname of the html file created.
 
-By default, this retains newlines within cells as they are.  With optional prefix arg, SOFT-NEWLINES-FLAG,
-hard newlines are not used.  Also converts Urls and Klinks into Html hyperlinks."
+By default, this retains newlines within cells as they are.  With
+optional prefix arg, SOFT-NEWLINES-FLAG, hard newlines are not
+used.  Also converts Urls and Klinks into Html hyperlinks."
   (interactive "P")
   (let ((export-from buffer-file-name)
   	(output-to (concat (file-name-sans-extension buffer-file-name) ".html")))
@@ -343,11 +346,13 @@ hard newlines are not used.  Also converts Urls and Klinks into Html hyperlinks.
 
 ;;;###autoload
 (defun kexport:display (&optional soft-newlines-flag)
-  "Export the current buffer's koutline to the same named file with a \".html\" suffix and display it in a web browser.
+  "Export the current buffer's koutline and display it in a web browser.
+The buffer is exported to the same named file with a \".html\" suffix.
 Return the pathname of the html file created.
 
-By default, this retains newlines within cells as they are.  With optional prefix arg, SOFT-NEWLINES-FLAG,
-hard newlines are not used.  Also converts Urls and Klinks into Html hyperlinks."
+By default, this retains newlines within cells as they are.  With
+optional prefix arg, SOFT-NEWLINES-FLAG, hard newlines are not
+used.  Also converts Urls and Klinks into Html hyperlinks."
   (interactive "P")
   (let ((html-file (kexport:koutline soft-newlines-flag)))
     (hact 'www-url (concat "file://" html-file))
@@ -356,8 +361,9 @@ hard newlines are not used.  Also converts Urls and Klinks into Html hyperlinks.
 ;;;###autoload
 (defun kexport:html (export-from output-to &optional soft-newlines-flag)
   "Export a koutline buffer or file in EXPORT-FROM to html format in OUTPUT-TO.
-By default, this retains newlines within cells as they are.  With optional prefix arg, SOFT-NEWLINES-FLAG,
-hard newlines are not used.  Also converts Urls and Klinks into Html hyperlinks.
+By default, this retains newlines within cells as they are.  With
+optional prefix arg, SOFT-NEWLINES-FLAG, hard newlines are not
+used.  Also converts Urls and Klinks into Html hyperlinks.
 !! STILL TODO:
   Make delimited pathnames into file links (but not if within klinks).
   Copy attributes stored in cell 0 and attributes from each cell."

--- a/kotl/kfile.el
+++ b/kotl/kfile.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    10/31/93
-;; Last-Mod:      5-Jun-22 at 17:59:19 by Bob Weiner
+;; Last-Mod:      4-Jul-22 at 23:24:42 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2021  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -66,7 +66,9 @@ Return the new kview."
 
 ;;;###autoload
 (defun kfile:is-p ()
-  "Iff current buffer contains an unformatted or formatted koutline, return file format version string, else nil."
+  "Iff current buffer contain a koutline, return file format version string.
+If not a koutline return nil.  This works both for unformatted
+and formatted koutlines."
   (let (ver-string)
     (save-excursion
       (save-restriction
@@ -100,8 +102,8 @@ Return the new kview."
 ;;; ************************************************************************
 
 (defun kfile:create (buffer)
-  "Create a new koutline file attached to BUFFER, with a single empty level 1 kotl cell.
-Return file's kview."
+  "Create a new koutline file attached to BUFFER and return file's kview.
+File is created with a single empty level 1 kotl cell."
   (or buffer (setq buffer (current-buffer)))
   (unless (bufferp buffer)
     (error "(kfile:create): Invalid buffer argument, %s" buffer))
@@ -156,9 +158,10 @@ Return file's kview."
     view))
 
 (defun kfile:read (buffer existing-file-p &optional ver-string)
-  "Create a new kotl view by reading BUFFER or create an empty view when EXISTING-FILE-P is nil.
-Optional VER-STRING is the outline format version number for the BUFFER that
-was previously read by calling `kfile:is-p'.
+  "Create a new kotl view by reading BUFFER.
+Create an empty view when EXISTING-FILE-P is nil.  Optional
+VER-STRING is the outline format version number for the BUFFER
+that was previously read by calling `kfile:is-p'.
 
 Return the new view."
   (cond ((not (bufferp buffer))

--- a/kotl/kfill.el
+++ b/kotl/kfill.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    23-Jan-94
-;; Last-Mod:     17-Apr-22 at 12:25:45 by Bob Weiner
+;; Last-Mod:      4-Jul-22 at 23:34:12 by Mats Lidell
 ;;
 ;; Copyright (C) 1994-2021  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -104,7 +104,9 @@ If there isn’t room, go as far as possible (no error).  Always return 0."
       (do-auto-fill))))
 
 (defun kfill:fill-paragraph (&optional arg skip-prefix-remove)
-  "Fill paragraph at or after point when in kotl-mode.  Prefix ARG means justify as well."
+  "Fill paragraph at or after point when in kotl-mode.
+Prefix ARG means justify as well.  If SKIP-PREFIX-REMOVE is not
+nil, keep the paragraph prefix."
   (interactive (progn
 		 (barf-if-buffer-read-only)
 		 (list (when current-prefix-arg 'full) nil)))
@@ -140,10 +142,11 @@ If there isn’t room, go as far as possible (no error).  Always return 0."
 ;;; Redefine this built-in function so that it sets `prior-fill-prefix' also.
 ;;;
 (defun set-fill-prefix (&optional turn-off)
-  "Set `fill-prefix' to the current line up to point or remove it if optional TURN-OFF flag is non-nil.
-Also sets `prior-fill-prefix' to the previous value of `fill-prefix'.
-Filling removes any prior fill prefix, adjusts line lengths and then adds the
-fill prefix at the beginning of each line."
+  "Set `fill-prefix' to the current line up to point.
+Remove it if optional TURN-OFF flag is non-nil.  Also sets
+`prior-fill-prefix' to the previous value of `fill-prefix'.
+Filling removes any prior fill prefix, adjusts line lengths and
+then adds the fill prefix at the beginning of each line."
   (interactive)
   (setq prior-fill-prefix fill-prefix)
   (let ((left-margin-pos (save-excursion (move-to-left-margin) (point))))

--- a/kotl/kimport.el
+++ b/kotl/kimport.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Nov-93 at 11:57:05
-;; Last-Mod:     15-Jul-22 at 23:24:41 by Mats Lidell
+;; Last-Mod:     18-Jul-22 at 21:50:27 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -33,7 +33,7 @@
 This determines the type of importation done on a file when `kimport:file' is
 called if the major mode of the import file matches the car of an element in
 this list.  If there is no match, then `kimport:suffix-alist' is checked.  If
-that yields no match, the element in this list whose car is 't is used.  It
+that yields no match, the element in this list whose car is t is used.  It
 normally does an import of a koutline or text file.
 
 Each importation-function must take two arguments, a buffer/file to import
@@ -68,7 +68,8 @@ imported cells as the initial set of children of the current cell, if any.
            (see https://dougengelbart.org/content/view/148/).")
 
 (defconst kimport:star-heading "^\\(\\*+\\)"
-  "Regular expression matching a star outline heading with the number of stars given by groupoing 1.")
+  "Regular expression matching a star outline heading.
+The number of stars is given by groupoing 1.")
 
 ;;; ************************************************************************
 ;;; Public functions
@@ -76,7 +77,7 @@ imported cells as the initial set of children of the current cell, if any.
 
 ;;;###autoload
 (defun kimport:file (import-from output-to &optional children-p)
-  "Import a buffer or file IMPORT-FROM into the koutline in buffer or file OUTPUT-TO.
+  "Import a buffer or file IMPORT-FROM into a koutline in buffer or file OUTPUT-TO.
 
 Any suffix in IMPORT-FROM's buffer name is used to determine the type of
 importation.  All others are imported as text, one paragraph per cell.
@@ -430,7 +431,8 @@ The variable, `paragraph-start,' is used to determine paragraphs."
 
 (defun kimport:aug-post-statements (import-from output-to klabel output-level
  			            import-level count total)
-  "Insert post-numbered Augment statements (contents only) from IMPORT-FROM into existing OUTPUT-TO.
+  "Insert post-numbered Augment statements (contents only) from IMPORT-FROM.
+Is inserted in existing OUTPUT-TO.
 
 KLABEL is the label to use for the first imported statement.
 OUTPUT-LEVEL is the level at which to insert the first statement.
@@ -484,11 +486,13 @@ in IMPORT-FROM, used to show a running tally of the imported statements."
 
 ;;;###autoload
 (defun kimport:copy-and-set-buffer (source)
-  "Copy and untabify SOURCE, set copy buffer as current buffer for this command and return the copy buffer.
-SOURCE may be a buffer name, a buffer or a file name.
-If SOURCE buffer name begins with a space, it is not copied under the
-assumption that it already has been.  If SOURCE is a koutline, it is not
-copied since there is no need to copy it to import it."
+  "Copy and untabify SOURCE.
+Set copy buffer as current buffer for this command and return the
+copy buffer.  SOURCE may be a buffer name, a buffer or a file
+name.  If SOURCE buffer name begins with a space, it is not
+copied under the assumption that it already has been.  If SOURCE
+is a koutline, it is not copied since there is no need to copy it
+to import it."
   (setq source (set-buffer (or (get-buffer source)
 			       (find-file-noselect source))))
   (let ((mode (or (if (boundp 'kotl-previous-mode) kotl-previous-mode)
@@ -575,7 +579,8 @@ will be added as children of the cell where this function leaves point
 
 (defun kimport:kcells (import-from output-to klabel output-level
 		       import-level count total)
-  "Insert visible koutline cells (contents and attributes) from IMPORT-FROM into existing OUTPUT-TO.
+  "Insert visible koutline cells (contents and attributes) from IMPORT-FROM.
+Insert into existing OUTPUT-TO.
 
 KLABEL is the label to use for the first imported cell.
 OUTPUT-LEVEL is the level at which to insert the first cell.

--- a/kotl/klabel.el
+++ b/kotl/klabel.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    17-Apr-94
-;; Last-Mod:     17-Jul-22 at 11:13:30 by Mats Lidell
+;; Last-Mod:     18-Jul-22 at 21:58:23 by Mats Lidell
 ;;
 ;; Copyright (C) 1994-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -44,7 +44,8 @@
   (funcall (kview:get-attr kview 'label-increment) label))
 
 (defun klabel:format (label)
-  "Format a generic cell LABEL (a string) and return it in the proper display type for the current kview."
+  "Format a generic cell LABEL (a string) and return the display type.
+Return the proper display type for the current kview."
   (let ((label-type (or (kview:get-attr kview 'label-type) kview:default-label-type)))
     (cond ((memq label-type '(alpha id legal partial-alpha))
 	   label)
@@ -90,8 +91,10 @@
 	    label-type))))
 
 (defun klabel-type:increment (label-type)
-  "Return a function that takes a single label argument and computes the next cell label of LABEL-TYPE.
-If the label is \"0\", its first child is computed, otherwise, the next sibling is computed."
+  "Return a function and compute the next cell label of LABEL-TYPE.
+The function takes a single label argument.  If the label is
+\"0\", its first child is computed, otherwise, the next sibling
+is computed."
   (cond ((memq label-type '(alpha legal partial-alpha))
 	 (intern-soft (concat "klabel:increment-" (symbol-name label-type))))
 	((eq label-type 'no)
@@ -255,11 +258,13 @@ First visible outline cell is level 1."
 ;;
 (defun klabel-type:function (&optional label-type)
   "Return function which will return display label for current cell.
-Label format is optional LABEL-TYPE or the default label type for the current view.
+Label format is optional LABEL-TYPE or the default label type for
+the current view.
 
-Function signature is: (func prev-label &optional child-p), where prev-label
-is the display label of the cell preceding the current one and child-p is
-non-nil if cell is to be the child of the preceding cell."
+Function signature is: (func prev-label &optional child-p), where
+prev-label is the display label of the cell preceding the current
+one and child-p is non-nil if cell is to be the child of the
+preceding cell."
   (or label-type (setq label-type (kview:label-type kview)))
   (cond ((eq label-type 'no)
 	 (lambda (_prev-label &optional _child-p)
@@ -478,7 +483,7 @@ and the start of its contents."
 		  (kcell-view:next nil lbl-sep-len)))))
 
 (defun klabel-type:update-labels (current-cell-label)
-  "Update the labels of current cell, its following siblings and their subtrees if need be.
+  "Update the labels of current cell, its siblings and their subtrees if need be.
 CURRENT-CELL-LABEL is the label to display for the current cell.
 If, however, it is \"0\", then all cell labels are updated."
   (let ((label-type (kview:label-type kview)))
@@ -615,8 +620,8 @@ N may be an integer or a string containing an integer."
 ;;; ************************************************************************
 
 (defun klabel:set (new-label &optional lbl-sep-len)
-  "Replace label displayed in cell at point with NEW-LABEL, which may be a different label type.
-Return NEW-LABEL string."
+  "Replace label displayed in cell at point with NEW-LABEL.
+The label type may be different.  Return NEW-LABEL string."
   (let ((modified (buffer-modified-p))
 	(buffer-read-only)
 	(thru-label (- (kcell-view:indent nil lbl-sep-len)

--- a/kotl/klink.el
+++ b/kotl/klink.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Nov-93 at 12:15:16
-;; Last-Mod:     15-Jul-22 at 23:24:53 by Mats Lidell
+;; Last-Mod:     18-Jul-22 at 21:50:46 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -85,9 +85,12 @@
 ;;; ************************************************************************
 
 (defun klink:absolute (label-and-pos)
-  "With point in a klink's source buffer and LABEL-AND-POS a list of (klink-label, klink-start, klink-end) including delimiters, return an absolute klink string.
-Klink is of the form: \"<absolute-file-name, cell-ref>\".
-See documentation for `kcell:ref-to-id' for valid cell-ref formats."
+  "Return an absolute klink string.
+With point in a klink's source buffer and LABEL-AND-POS a list
+of (klink-label, klink-start, klink-end) including delimiters,
+return an absolute klink string.  Klink is of the form:
+\"<absolute-file-name, cell-ref>\".  See documentation for
+`kcell:ref-to-id' for valid cell-ref formats."
   (when (and (derived-mode-p 'kotl-mode) label-and-pos (listp label-and-pos))
     (let* ((file-and-cell-ref (klink:parse (car label-and-pos)))
 	   (file (or (car file-and-cell-ref) buffer-file-name))
@@ -199,8 +202,9 @@ link-end-position, (including delimiters)."
       label-and-pos)))
 
 (defun klink:set-yank-handler (klink)
-  "Add yank-handler to KLINK so link is made relative when yanked into the same koutline or the same directory.
-Return the modified KLINK."
+  "Add yank-handler to KLINK and return the modified KLINK.
+Link is made relative when yanked into the same koutline or the
+same directory."
   (add-text-properties 0 (length klink)
 		       (list 'yank-handler '(klink:yank-handler)
 			     'yank-excluded-properties (cons 'yank-handler (get-text-property 0 'yank-excluded-properties klink)))

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:     17-Jul-22 at 16:25:03 by Mats Lidell
+;; Last-Mod:     18-Jul-22 at 21:51:00 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -31,15 +31,18 @@
   "Default mode of koutline buffers prior to invocation of kotl-mode.")
 
 (defcustom kotl-mode:shrink-region-flag nil
-  "*If non-nil, Koutliner commands automatically shrink the region to within the visible bounds of a single cell before editing it.
-The region then falls within the first visible cell that was part of the
-region or that followed it.  Default value is nil."
+  "*Non-nil means Koutliner commands automatically shrink the region.
+The region is shrinked within the visible bounds of a single cell
+before editing it.  The region then falls within the first
+visible cell that was part of the region or that followed it.
+Default value is nil."
   :type 'boolean
   :group 'hyperbole-koutliner)
 
 (defcustom kotl-mode:refill-flag nil
-  "*Automatically refill cells during move, copy, promotion and demotion operations when non-nil.
-Default value is nil.  Cells with a `no-fill' attribute are never refilled
+  "*Non-nil means automatically refill cells during operations.
+Operations are move, copy, promotion and demotion.  Default value
+is nil.  Cells with a `no-fill' attribute are never refilled
 during such operations, regardless of the value of this flag."
   :type 'boolean
   :group 'hyperbole-koutliner)
@@ -52,18 +55,22 @@ Nil means {\\[kotl-mode:tab-command]} demotes the current tree and
   :group 'hyperbole-koutliner)
 
 (defcustom kotl-mode:indent-tabs-mode t
-  "*Non-nil means {\\[kotl-mode:tab-command]} may insert literal tab characters rather than space characters when `kotl-mode:tab-flag' is non-nil.
-Default value is t.  The value of this variable is local to each Koutline buffer."
+  "*Non-nil means {\\[kotl-mode:tab-command]} may insert literal tab characters.
+Tab characters are inserted rather than space characters when
+`kotl-mode:tab-flag' is non-nil.  Default value is t.  The value
+of this variable is local to each Koutline buffer."
   :type 'boolean
   :group 'hyperbole-koutliner)
 
 ;; Define these newer Emacs variables if Emacs has not already done so.
 (defvar yank-window-start nil)
 (defvar yank-undo-function nil
-  "If non-nil, the function used by `yank-pop' to delete the last stretch of yanked text.
-Function is called with two parameters, START and END corresponding to
-the value of the mark and point; it is guaranteed that START <= END.
-Normally set from the UNDO element of a yank-handler; see `insert-for-yank'.")
+  "If non-nil, the function used by `yank-pop'.
+It is used to delete the last stretch of yanked text.  Function
+is called with two parameters, START and END corresponding to the
+value of the mark and point; it is guaranteed that START <= END.
+Normally set from the UNDO element of a yank-handler; see
+`insert-for-yank'.")
 
 ;;; ************************************************************************
 ;;; Public functions
@@ -193,9 +200,10 @@ It provides the following keys:
 
 ;;;###autoload
 (defun kotl-mode:example (&optional example replace-flag)
-  "Display the optional Koutliner EXAMPLE file for demonstration and editing use by a user.
-With optional REPLACE-FLAG non-nil, archive any existing file,
-and replace it with the latest Hyperbole EXAMPLE.
+  "Display the optional Koutliner EXAMPLE file.
+This is for demonstration and editing use by a user.  With
+optional REPLACE-FLAG non-nil, archive any existing file, and
+replace it with the latest Hyperbole EXAMPLE.
 
 EXAMPLE may be a file or directory name (\"EXAMPLE.kotl\" is appended).
 
@@ -326,7 +334,8 @@ See `center-line' for more info."
     (kotl-mode:to-valid-position)))
 
 (defun kotl-mode:copy-kcell-reference-to-register (klink register)
-  "Copy a KLINK at point or if in a kcell, a klink to that kcell, to a REGISTER named by a single character."
+  "Copy a KLINK at point or if in a kcell, a klink to that kcell, to a REGISTER.
+The REGISTER is named by a single character."
   (interactive
    (let ((klink (klink:absolute (klink:at-p))))
      (list
@@ -340,12 +349,15 @@ See `center-line' for more info."
     (user-error "(kotl-mode:copy-kcell-reference-to-register): Point is not within a Koutliner klink or kcell")))
 
 (defun kotl-mode:copy-absolute-kcell-link-to-kill-ring (&optional pos)
-  "Add an absolute kcell reference (from optional POS or point) for use outside the outline as a new kill ring entry."
+  "Add an absolute kcell reference to the kill ring.
+The kcell reference is from optional POS or point.  It is for use
+outside the outline."
   (interactive "d")
   (kill-new (kcell-view:absolute-reference pos)))
 
 (defun kotl-mode:copy-relative-kcell-link-to-kill-ring (&optional pos)
-  "Add a relative kcell reference (from optional POS or point) as a new kill ring entry."
+  "Add a relative kcell reference to the kill ring.
+The kcell reference is from optional POS or point."
   (interactive "d")
   (kill-new (kcell-view:reference pos)))
 
@@ -396,7 +408,7 @@ Do not delete across cell boundaries."
   (kotl-mode:delete-char (- arg) kill-flag))
 
 (defun kotl-mode:delete-blank-lines ()
-  "On blank line within a cell, delete all surrounding blank lines, leaving just one.
+  "On blank line in a cell, delete all surrounding blank lines, leaving just one.
 On isolated blank line, delete that one.
 On nonblank line, delete all blank lines that follow it.
 
@@ -519,7 +531,8 @@ With prefix ARG non-nil, join this line to the following line."
 	 (goto-char opoint))))))
 
 (defun kotl-mode:skip-filling-p (interactive-flag)
-  "Return t if filling is to be skipped due to a no-fill attribute or with point in a table, else return nil."
+  "Return t if filling is to be skipped, or nil.
+This can be due to a no-fill attribute or with point in a table."
   (not (cond ((and (fboundp #'org-at-table-p) (org-at-table-p))
 	      (when interactive-flag
 		(beep)
@@ -681,7 +694,7 @@ With optional prefix argument TOP-P non-nil, refill all cells in the outline."
 
 (defun kotl-mode:kill-region (start end &optional copy-p)
   "Kill region between START and END within a single kcell.
-With optional COPY-P equal to 't, copy region to kill ring but does not
+With optional COPY-P equal to t, copy region to kill ring but does not
 kill it.  With COPY-P any other non-nil value, return region as a
 string without affecting kill ring.
 
@@ -1014,10 +1027,12 @@ or after point and around or after mark are interchanged."
   (transpose-subr 'kotl-mode:forward-word (prefix-numeric-value arg)))
 
 (defun kotl-mode:untab-command (arg)
-  "Delete backwards by ARG tab stops or promote the current tree a maximum of ARG levels.
-Which command is run depends on the value of `kotl-mode:tab-flag'.  Toggle
-its value by sending this command an explicit ARG of 1.  Use nil for ARG to
-run the untab command once.
+  "Delete backwards or promote the current tree.
+Delete backwards by ARG tab stops or promote the current tree a
+maximum of ARG levels.  Which command is run depends on the value
+of `kotl-mode:tab-flag'.  Toggle its value by sending this
+command an explicit ARG of 1.  Use nil for ARG to run the untab
+command once.
 
 See also the documentation strings for `kotl-mode:delete-backward-char' and
 `kotl-mode:promote-tree'."
@@ -1830,7 +1845,7 @@ for CELL-REF."
     found))
 
 (defun kotl-mode:head-cell ()
-  "Move point to the start of the first visible cell at the same level as current cell.
+  "Move point to the start of first visible cell at same level as current cell.
 If at head cell already, do nothing and return nil."
   (interactive "p")
   (kotl-mode:maintain-region-highlight)
@@ -1863,7 +1878,7 @@ The paragraph marked is the one that contains point or follows point."
   (kotl-mode:to-valid-position))
 
 (defun kotl-mode:mark-whole-buffer ()
-  "Put point at first editable character in buffer and mark at the last such character."
+  "Put point at first editable character in buffer and mark at last such character."
   (interactive)
   (push-mark (point))
   (kotl-mode:end-of-buffer)
@@ -1910,8 +1925,9 @@ The paragraph marked is the one that contains point or follows point."
   (point))
 
 (defun kotl-mode:next-tree ()
-  "Move past current tree to the start of the next tree, or to the start of the last cell in tree if no next tree.
-Return non-nil iff there is a next tree within the koutline."
+  "Move past current tree to the start of the next tree.
+If no next tree go to the start of the last cell in tree.  Return
+non-nil iff there is a next tree within the koutline."
   (let ((start-indent (kcell-view:indent))
 	(lbl-sep-len (kview:label-separator-length kview))
 	(same-tree t))
@@ -1984,7 +2000,8 @@ Return non-nil iff there is a next tree within the koutline."
     (scroll-up arg)))
 
 (defun kotl-mode:tail-cell ()
-  "Move point to the start of the last visible cell at the same level as current cell and return t.
+  "Move point to start of last visible cell at same level as current cell.
+Return t if successfull.
 If at tail cell already, do nothing and return nil."
   (interactive "p")
   (kotl-mode:maintain-region-highlight)
@@ -2193,12 +2210,15 @@ If assist-key is pressed:
   (kotl-mode:add-cell -1))
 
 (defun kotl-mode:add-cell (&optional relative-level contents plist no-fill)
-  "Add a cell following current cell at optional RELATIVE-LEVEL with CONTENTS string, attributes in PLIST, a property list, and NO-FILL flag to prevent any filling of CONTENTS.
+  "Add a cell.
+Add cell following current cell at optional RELATIVE-LEVEL with
+CONTENTS string, attributes in PLIST, a property list, and
+NO-FILL flag to prevent any filling of CONTENTS.
 
 Optional prefix arg RELATIVE-LEVEL means either:
 
  1. add as the next sibling if nil or >= 0;
- 2. as the first child if equal to '(4), given by the universal argument, {C-u};
+ 2. as the first child if equal to (4), given by the universal argument, {C-u};
  3. otherwise, as the first sibling of the current cell's parent.
 
 If added as the next sibling of the current level, then RELATIVE-LEVEL is
@@ -2629,7 +2649,9 @@ confirmation."
 				 (kcell-view:label pos)))))
 
 (defun kotl-mode:set-or-remove-cell-attribute (arg)
-  "With numeric prefix ARG, interactively run kotl-mode:remove-cell-attribute; otherwise, run kotl-mode:set-cell-attribute.
+  "Run kotl-mode:remove-cell-attribute or kotl-mode:set-cell-attribute.
+With numeric prefix ARG, interactively run kotl-mode:remove-cell-attribute;
+otherwise, run kotl-mode:set-cell-attribute.
 Prefix ARG selects the cells whose attributes are removed or set:
   If =  0, set one of the attributes of the invisible root cell;
   If <  0, remove one of the attributes of the invisible root cell;
@@ -2734,7 +2756,8 @@ ARG visible cells."
 ;;; ------------------------------------------------------------------------
 
 (defun kotl-mode:copy-region-to-buffer (target-buf start end &optional source-buf invisible-flag)
-  "Copy to TARGET-BUF the region between START and END from the current buffer or optional SOURCE-BUF (a buffer or buffer name).
+  "Copy to TARGET-BUF the region between START and END.
+Copy from the current buffer or optional SOURCE-BUF (a buffer or buffer name).
 Invisible text is expanded and included only if INVISIBLE-FLAG is non-nil."
   (interactive
    (hargs:iform-read
@@ -2786,7 +2809,9 @@ included only if INVISIBLE-FLAG is non-nil."
       (kotl-mode:copy-region-to-buffer target-buf start end nil invisible-flag))))
 
 (defun kotl-mode:copy-tree-or-region-to-buffer ()
-  "If no usable active region, prompt for and copy a Koutline tree to a specified buffer, otherwise, copy the active region.
+  "Copy a Koutline tree to a specified buffer.
+If no usable active region, prompt for and copy a Koutline tree
+to a specified buffer, otherwise, copy the active region.
 
 Use 0 to copy the whole outline buffer.  Prompt for whether or not
 to expand and include any hidden/invisible text within the copied text."
@@ -2850,7 +2875,8 @@ the current view."
      kview all-flag t)))
 
 (defun kotl-mode:toggle-tree-expansion (&optional all-flag)
-  "Collapse or expand each cell of tree rooted at point or all visible cells if optional prefix arg ALL-FLAG is given.
+  "Collapse or expand each cell of tree rooted at point.
+Act on all visible cells if optional prefix arg ALL-FLAG is given.
 If current cell is collapsed, cells will be expanded, otherwise they will be
 collapsed."
   (interactive "P")
@@ -3161,7 +3187,9 @@ on when tabs are used for indenting."
      "(kotl-mode:is-p): Command requires a valid Hyperbole koutline")))
 
 (defun kotl-mode:shrink-region ()
-  "If a region is active and outside the visible bounds of a single cell, shrink it to within those bounds.
+  "Shrink region within visible bounds of a single cell.
+If a region is active and outside the visible bounds of a single
+cell, shrink it to within those bounds.
 The region then falls within the first visible cell that was part of
 the region or that followed it.  This prevents editing actions from
 removing Koutline structure."
@@ -3178,7 +3206,7 @@ removing Koutline structure."
     (when exchange-p (kotl-mode:exchange-point-and-mark))))
 
 (defun kotl-mode:valid-region-p ()
-  "Return t if there is no active region or if the region is within the visible bounds of a single cell, else nil."
+  "Return t if no active region or the region is within visible bounds of a cell."
   (if (region-active-p)
       (and (kview:valid-position-p (point))
 	   (kview:valid-position-p (mark))
@@ -3188,8 +3216,10 @@ removing Koutline structure."
     t))
 
 (defun kotl-mode:maybe-shrink-region-p ()
-  "If `kotl-mode:shrink-region-flag' is non-nil, shrink any active region that includes hidden text or crosses cell boundaries.
-The region then falls within the first visible cell that was part of the region or that followed it
+  "Shrink active region if `kotl-mode:shrink-region-flag' is non-nil.
+Shrink any active region that includes hidden text or crosses
+cell boundaries.  The region then falls within the first visible
+cell that was part of the region or that followed it
 
 Return t unless any region problem is left uncorrected, notably in
 cases where `kotl-mode:shrink-region-flag' is nil."
@@ -3254,9 +3284,9 @@ newlines at end of tree."
 
 ;; Consult this: (kotl-mode:to-visible-position)
 (defun kotl-mode:pre-self-insert-command ()
-  "If within a Koutline, prior to inserting a character, ensure point is in an editable position.
-Mouse may have moved point outside of an editable area. kotl-mode adds
-this function to `pre-command-hook'."
+  "In a Koutline ensure point is in an editable position before insertion.
+Mouse may have moved point outside of an editable area.
+`kotl-mode' adds this function to `pre-command-hook'."
   (when (and (memq this-command '(self-insert-command orgtbl-self-insert-command))
 	     (eq major-mode 'kotl-mode)
 	     (not (kview:valid-position-p))
@@ -3266,9 +3296,9 @@ this function to `pre-command-hook'."
       (kotl-mode:to-valid-position))))
 
 (defun kotl-mode:print-attributes (_kview)
-  "Print to the `standard-output' stream the attributes of the current visible kcell.
-Takes argument _KVIEW (so it can be used with `kview:map-tree') but always operates
-upon the current view."
+  "Print to `standard-output' the attributes of the current visible kcell.
+Takes argument _KVIEW (so it can be used with `kview:map-tree')
+but always operates upon the current view."
   ;; Move to start of visible cell to avoid printing attributes for an
   ;; invisible kcell which point may be over.
   ;; Print first line of cell for reference.
@@ -3340,7 +3370,7 @@ upon the current view."
 	      (current-column)))))
 
 (defun kotl-mode:to-visible-position (&optional backward-p)
-  "Move point to the nearest visible and editable position within the current koutline view.
+  "Move point to nearest visible and editable position within current koutline.
 With optional BACKWARD-P, move backward if possible to get to valid position."
   ;; Empty, visible cell
   (unless (and (kotl-mode:bocp) (kotl-mode:eocp) (not (kcell-view:invisible-p (point))))

--- a/kotl/kotl-orgtbl.el
+++ b/kotl/kotl-orgtbl.el
@@ -57,7 +57,7 @@
 
 ;; Redefine this Org Table function to handle Koutlines as well.
 (defun orgtbl-tab (arg)
-  "Justification and field motion for `orgtbl-mode' with Hyperbole Koutline support."
+  "Justification and field motion for `orgtbl-mode' with Koutline support."
   (interactive "P")
   (cond ((and (derived-mode-p #'kotl-mode) arg)
 	 (kotl-mode:tab-command (if (= (prefix-numeric-value arg) 1) nil arg)))
@@ -83,7 +83,7 @@ If no previous line, exchange current with next line."
   )
 
 (defun orgtbl-meta-return (arg)
-  "Let Action Key handle tables in kotl-mode, otherwise, use standard Org table command."
+  "Let Action Key handle tables in kotl-mode, otherwise, use Org table command."
   (interactive "P")
   (if (derived-mode-p #'kotl-mode)
       (hkey-either arg)

--- a/kotl/kproperty.el
+++ b/kotl/kproperty.el
@@ -37,7 +37,8 @@
 		 plist))
 
 (defun kproperty:all-positions (property value)
-  "Return a list of all non-narrowed buffer positions of kcells with PROPERTY set to VALUE, else nil.
+  "Return a list of all non-narrowed positions of kcells with PROPERTY VALUE.
+If no kcells with PROPERTY VALUE return nil.
 Use (kcell-view:start <position>) on each returned <position> to get
 the start position of each cell's content."
   (kproperty:map (lambda (start _end) start) property value))
@@ -45,9 +46,9 @@ the start position of each cell's content."
 (defalias 'kproperty:get 'get-text-property)
 
 (defun kproperty:map (function property value)
-  "Apply FUNCTION to each character with PROPERTY `eq' to VALUE in the current buffer.
-FUNCTION is called with the start and end points of the text span with the matching PROPERTY
-and with point at the start."
+  "Apply FUNCTION to each character with PROPERTY VALUE in the current buffer.
+FUNCTION is called with the start and end points of the text span
+with the matching PROPERTY and with point at the start."
   (let ((result)
 	(start (point-min))
 	end)
@@ -63,7 +64,8 @@ and with point at the start."
 (defalias 'kproperty:next-single-change 'next-single-property-change)
 
 (defun kproperty:position (property value)
-  "Return the non-narrowed buffer position of the first kcell with PROPERTY set to VALUE, else nil.
+  "Return the non-narrowed buffer position of the first kcell with PROPERTY VALUE.
+If no kcell with PROPERTY VALUE return nil.
 Use (kcell-view:start <position>) on the returned <position> to get
 the start position of the cell's content."
   (text-property-any (point-min) (point-max) property value))

--- a/kotl/kview.el
+++ b/kotl/kview.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:     17-Jul-22 at 16:22:51 by Mats Lidell
+;; Last-Mod:     18-Jul-22 at 22:09:14 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -51,13 +51,13 @@ Labels are padded with spaces on the left.  Default value is 4."
   :group 'hyperbole-koutliner)
 
 (defcustom kview:default-label-separator ". "
-  "*Default string of characters to insert between label and contents of a koutline cell.
+  "*Characters to insert between label and contents of a koutline cell.
 Default value is \". \"."
   :type 'string
   :group 'hyperbole-koutliner)
 
 (defcustom kview:default-label-type 'alpha
-  "*Default label-type to use for new koutlines.  Default value is 'alpha.
+  "*Default label-type to use for new koutlines.  Default value is `alpha'.
 It must be one of the following symbols:
   alpha           for `1b3' full alphanumeric labels
   id              for `027' permanent idstamp labels
@@ -118,7 +118,7 @@ Return t unless no such cell."
   (kproperty:get (kcell-view:plist-point pos) 'kcell))
 
 (defun kcell-view:cell-from-ref (cell-ref)
-  "Return a kcell referenced by CELL-REF, a cell label, id string or integer idstamp.
+  "Return a kcell referenced by CELL-REF, a cell label, id string or idstamp.
 Trigger an error if CELL-REF is not a string or is not found."
   (if (or (stringp cell-ref)
 	  (integerp cell-ref))
@@ -190,7 +190,7 @@ a cell's label and the start of its contents."
   (kcell-view:expand pos lbl-sep-len t))
 
 (defun kcell-view:invisible-p (&optional pos lbl-sep-len)
-  "Return t if cell at optional POS or point is entirely invisible within the current view.
+  "Return t if cell at optional POS or point is entirely invisible in current view.
 Optional LBL-SEP-LEN is the length of the separation between
 a cell's label and the start of its contents.
 
@@ -219,7 +219,8 @@ Any cell that is invisible is also collapsed as indicated by a call to
        "\\1" (buffer-substring start end)))))
 
 (defun kcell-view:create (kview cell contents level idstamp klabel &optional no-fill sibling-p)
-  "Insert into KVIEW at point, CELL with CONTENTS at LEVEL (1 = first level) with IDSTAMP and KLABEL.
+  "Insert into KVIEW at point, CELL with CONTENTS at LEVEL with IDSTAMP and KLABEL.
+First level is 1.
 If the current view displays klabels, then KLABEL should be inserted
 prior to this call, with point following it.
 
@@ -413,7 +414,7 @@ Return t unless no next cell."
     t))
 
 (defun kcell-view:next-invisible-p (&optional _pos lbl-sep-len)
-  "Return t if there is a next cell after optional POS or point and it is invisible."
+  "Return t if next cell is after optional POS or point and it is invisible."
   (save-excursion (and (kcell-view:next nil lbl-sep-len)
 		       (kcell-view:invisible-p (point) lbl-sep-len))))
 
@@ -460,11 +461,13 @@ Return t unless no previous cell."
   (kcell:plist (kcell-view:cell pos)))
 
 (defun kcell-view:plist-point (&optional pos)
-  "Return buffer position of attributes associated with cell at optional POS or point."
+  "Return buffer position of attributes associated with cell.
+Cell is at optional POS or point."
   (save-excursion (1+ (kcell-view:to-label-end pos))))
 
 (defun kcell-view:to-label-end (&optional pos)
-  "Move point from optional POS to the end of the current cell's label (before the label separator) and return point.
+  "Move point from optional POS to end of current cell's label and return point.
+Point is set at end of cell's label but before the label separator.
 If between kcells, move to the previous one.  The current cell may be hidden."
   (when pos (goto-char pos))
   (kview:end-of-actual-line)
@@ -484,7 +487,7 @@ If between kcells, move to the previous one.  The current cell may be hidden."
 	     (error "(kcell-view:to-label-end): Can't find end of current cell's label"))))))
 
 (defun kcell-view:absolute-reference (&optional pos)
-  "Return a klink to the kcell at optional POS or point; return nil if not in a kcell.
+  "Return a klink to kcell at optional POS or point; return nil if not in a kcell.
 The reference is a string of the form, \"<kcell-file, cell-ref>\"
 where cell-ref is as described in the documentation for
 `kcell:ref-to-id'.  Kcell-file is an absolute path to the current
@@ -495,7 +498,7 @@ Koutline file."
 	     (kcell-view:label pos) (kcell-view:idstamp pos)))))
 
 (defun kcell-view:reference (&optional pos relative-dir)
-  "Return a klink to the kcell at optional POS or point; return nil if not in a kcell.
+  "Return a klink to kcell at optional POS or point; return nil if not in a kcell.
 The reference is a string of the form, \"<kcell-file, cell-ref>\"
 where cell-ref is as described in the documentation for
 `kcell:ref-to-id'.  Kcell-file is made relative to optional
@@ -507,7 +510,8 @@ or is nil), before it is returned."
 	     (kcell-view:label pos) (kcell-view:idstamp pos)))))
 
 (defun kcell-view:remove-attr (attribute &optional pos)
-  "Remove ATTRIBUTE, if any, for current cell or cell at optional POS.  Return the modified cell."
+  "Remove ATTRIBUTE, if any, for cell and return the modified cell.
+Cell is current or at optional POS."
   (interactive "*SAttribute to remove: ")
   (unless (eq attribute 'idstamp) ;; Can't remove idstamp
     (let (mod-cell)
@@ -521,7 +525,8 @@ or is nil), before it is returned."
       mod-cell)))
 
 (defun kcell-view:set-attr (attribute value &optional pos)
-  "Set ATTRIBUTE's VALUE for current cell or cell at optional POS and return the modified cell.
+  "Set ATTRIBUTE's VALUE for cell and return the modified cell.
+Cell is current or at optional POS.
 Use 0 for POS to set top cell's attributes."
   (unless (and (eq pos 0) (eq attribute 'idstamp)) ;; top cell idstamp set when Koutline is created
     (save-excursion
@@ -557,7 +562,8 @@ With optional VISIBLE-P, consider only visible siblings."
        (or lbl-sep-len (kview:label-separator-length kview)))))
 
 (defun kcell-view:to-visible-label-end (&optional pos)
-  "Move point to the end of the current visible cell's label (before the label separator).
+  "Move point to end of the visible cell's label.
+Cell is current or at optional POS.  Point is set before the label separator.
 If between kcells, move to the previous one.  Return final point location."
   (when pos
     (goto-char pos))
@@ -629,9 +635,11 @@ level."
 			 label-type level-indent label-separator
 			 label-min-width blank-lines levels-to-show lines-to-show)
   "Return a new kview for BUFFER-NAME.
-Optional ID-COUNTER is the maximum permanent id previously given out in this
-outline.  Optional LABEL-TYPE, LEVEL-INDENT, LABEL-SEPARATOR, LABEL-MIN-WIDTH,
-BLANK-LINES, LEVELS-TO-SHOW, and LINES-TO-SHOW may also be given, otherwise default values are used.
+Optional ID-COUNTER is the maximum permanent id previously given
+out in this outline.  Optional LABEL-TYPE, LEVEL-INDENT,
+LABEL-SEPARATOR, LABEL-MIN-WIDTH, BLANK-LINES, LEVELS-TO-SHOW,
+and LINES-TO-SHOW may also be given, otherwise default values are
+used.
 
   See documentation of:
  `kview:default-label-type' for LABEL-TYPE,
@@ -714,7 +722,9 @@ this function is called."
     (set-marker opoint nil)))
 
 (defun kview:first-invisible-point (&optional pos)
-  "Return the first point following optional POS that is followed by an invisible character, else the end point of the cell contents.
+  "Return the first point that is followed by an invisible character.
+Start from point or optional POS.  If none are found return the
+end point of the cell contents.
 Value may be the character immediately after point."
   (unless pos
     (setq pos (point)))
@@ -728,8 +738,8 @@ Value may be the character immediately after point."
     (or pos end)))
 
 (defun kview:first-visible-point (&optional pos)
-  "Return the first point following optional POS that is followed by a visible character, else (point-max).
-Value may be the character immediately after point."
+  "Return the first point that is followed by a visible character.
+Start from point or optional POS.  If none are found return (point-max)."
   (unless pos
     (setq pos (point)))
   (while (and pos (kview:char-invisible-p pos))
@@ -741,7 +751,9 @@ Value may be the character immediately after point."
   (or pos (point-max)))
 
 (defun kview:get-cells-status (kview start end)
-  "In the current buffer's KVIEW, between START and END, return a coded list of status of each visible cell.
+  "In current buffer's KVIEW, return a coded list of status of each visible cell.
+Return the list between START and END.
+
 Status is returned as: 0 if all the lines of the cell are visible and
 it has no hidden branches; a positive count of the lines displayed in
 the cell if it has no hidden branches; otherwise, a negative count of
@@ -760,7 +772,8 @@ the lines displayed, since it has hidden branches."
    kview t start end))
 
 (defun kview:goto-cell-id (idstamp-or-string)
-  "Move point to start of cell with permanent IDSTAMP-OR-STRING and return t, else nil."
+  "Move point to start of cell with permanent IDSTAMP-OR-STRING.
+On success return t, else nil."
   (let* ((idstamp (if (integerp idstamp-or-string)
 		      idstamp-or-string
 		    (string-to-number idstamp-or-string)))
@@ -787,7 +800,8 @@ the lines displayed, since it has hidden branches."
       (kcell-view:label))))
 
 (defun kview:insert-contents (kcell contents no-fill fill-prefix)
-  "Insert KCELL's CONTENTS into view at point and fill resulting paragraphs, unless NO-FILL is non-nil.
+  "Insert KCELL's CONTENTS into view at point and fill resulting paragraphs.
+Do not fill if NO-FILL is non-nil.
 FILL-PREFIX is the indentation string for the current cell.  If
 CONTENTS is nil, get contents from the cell at point.  Return contents
 inserted (this value may differ from the value passed in) due to
@@ -843,7 +857,8 @@ filling."
     (kview:get-attr kview 'kotl)))
 
 (defun kview:label (klabel-function prev-label child-p)
-  "Return label string to display for current cell computed from KLABEL-FUNCTION, PREV-LABEL and CHILD-P."
+  "Return label string to display for current cell.
+Label is computed from KLABEL-FUNCTION, PREV-LABEL and CHILD-P."
   (funcall klabel-function prev-label child-p))
 
 (defun kview:label-function (kview)
@@ -883,7 +898,8 @@ See documentation for kview:default-level-indent."
     (kview:get-attr kview 'level-indent)))
 
 (defun kview:map-branch (func kview &optional first-p visible-p)
-  "Apply FUNC to the sibling trees from point forward within KVIEW and return results as a list.
+  "Apply FUNC to the sibling trees from point forward within KVIEW.
+Return results as a list.
 With optional FIRST-P non-nil, begins with first sibling in current branch.
 With optional VISIBLE-P, considers only those sibling cells that are visible
 in the view.
@@ -954,7 +970,8 @@ See also `kview:map-tree', `kview:map-branch’, and ‘kview:map-siblings’."
 	      (t (error "(kview:map-region): No region or invalid start and end positions")))))))
 
 (defun kview:map-siblings (func kview &optional first-p visible-p)
-  "Apply FUNC to the sibling cells from point forward within KVIEW and return results as a list.
+  "Apply FUNC to the sibling cells from point forward within KVIEW.
+Return results as a list.
 With optional FIRST-P non-nil, begins with first sibling in current branch.
 With optional VISIBLE-P, considers only those sibling cells that are visible
 in the view.
@@ -987,7 +1004,8 @@ See also `kview:map-branch' and `kview:map-tree'."
 	(nreverse results)))))
 
 (defun kview:map-expanded-tree (func kview &optional top-p)
-  "Temporarily expand the tree at point, apply FUNC to the tree in the KVIEW and return results as a list.
+  "Temporarily expand the tree at point, apply FUNC to the tree in the KVIEW.
+Return results as a list.
 This is for a FUNC that requires all cells in the tree be fully visible and
 expanded before operating upon it.  If this is not the case, use
 `kview:map-tree' instead.  FUNC may not change the number of or the order of
@@ -1044,7 +1062,7 @@ See also `kview:map-region', `kview:map-branch' and `kview:map-siblings'."
 	  (nreverse results)))))
 
 (defun kview:map-tree (func kview &optional top-p visible-p)
-  "Apply FUNC to the tree starting at point within KVIEW and return results as a list.
+  "Apply FUNC to the tree starting at point within KVIEW, return results as a list.
 With optional TOP-P non-nil, maps over all of kview's cells.
 With optional VISIBLE-P, considers only those cells that are visible in the
 view.
@@ -1084,7 +1102,8 @@ See also `kview:map-region', `kview:map-branch' and `kview:map-siblings'."
 
 (defun kview:move (from-start from-end to-start from-indent to-indent
 	           &optional copy-p fill-p)
-  "Move tree between FROM-START and FROM-END to TO-START, changing FROM-INDENT to TO-INDENT.
+  "Move tree between FROM-START and FROM-END to TO-START.
+Changes indentation from FROM-INDENT to TO-INDENT.
 Copy tree if optional COPY-P is non-nil.  Refill cells if optional
 FILL-P is non-nil.  Leave point at TO-START."
   (let ((region (buffer-substring from-start from-end))
@@ -1154,7 +1173,8 @@ FILL-P is non-nil.  Leave point at TO-START."
     (set-marker new-start nil)))
 
 (defun kview:previous-visible-point (&optional pos)
-  "Return the first point preceding optional POS that is followed by a visible character, else (point-min).
+  "Return the first preceding point that is followed by a visible character.
+Start from point or optional POS.  If none are found return (point-min).
 Value may be the character immediately after point."
   (unless pos
     (setq pos (point)))
@@ -1178,7 +1198,8 @@ Value may be the character immediately after point."
     (error "(kview:set-buffer): Invalid kview argument")))
 
 (defun kview:set-cells-status (kview start end cell-status-list)
-  "In the current buffer's KVIEW, between START and END, use CELL-STATUS-LIST to restore each cell's status.
+  "Use CELL-STATUS-LIST to restore each cell's status.
+Set status in the current buffer's KVIEW, between START and END.
 Status is: 0 if all the lines of the cell are visible and it has no
 hidden branches; a positive count of the lines displayed in the cell
 if it has no hidden branches; otherwise, a negative count of the lines
@@ -1237,12 +1258,12 @@ valid values of NEW-TYPE."
       (kvspec:update t))))
 
 (defun kview:top-cell (kview)
-  "Return KVIEW's invisible top cell with idstamp 0 or nil if argument is not a kview."
+  "Return KVIEW's invisible top cell with idstamp 0 or nil if not a kview."
   (when (kview:is-p kview)
     (kview:get-attr kview 'top-cell)))
 
 (defun kview:valid-position-p (&optional pos)
-  "Return non-nil iff point or optional POS is at a position where editing may occur.
+  "Return non-nil iff point or optional POS is where editing may occur.
 The read-only positions between cells and within cell indentations are invalid."
   (when (cond ((null pos)
 	       (>= (current-column) (kcell-view:indent)))
@@ -1271,7 +1292,7 @@ or marker, `%s'" pos))
   (cadr (memq attribute (cadr (memq 'plist obj)))))
 
 (defun kcell-view:next-kcell (&optional visible-p lbl-sep-len)
-  "Move to the point holding the kcell property within the next cell of the current kview.
+  "Move to point holding the kcell property within next cell of the current kview.
 With optional VISIBLE-P, consider only visible cells.  Return t
 unless no next cell."
   (let* ((opoint (point))
@@ -1284,7 +1305,7 @@ unless no next cell."
 	(progn (goto-char pos) t))))
 
 (defun kcell-view:previous-kcell (&optional visible-p lbl-sep-len)
-  "Move to the point holding the kcell property within the previous cell of the current kview.
+  "Move to point holding the kcell property within previous cell of current kview.
 With optional VISIBLE-P, consider only visible cells.  Return t
 unless no previous cell."
   (when (not (kview:valid-position-p))
@@ -1321,7 +1342,8 @@ unless no previous cell."
   (kview:set-attr kview 'label-parent (klabel-type:parent label-type)))
 
 (defun kview:set-label-separator (label-separator &optional set-default-p)
-  "Set the LABEL-SEPARATOR (a string) between labels and cell contents for the current kview.
+  "Set the LABEL-SEPARATOR between labels and cell contents for the current kview.
+The LABEL-SEPARATOR is a string.
 With optional prefix arg SET-DEFAULT-P, the default separator value used for
 new outlines is also set to this new value."
   (interactive

--- a/kotl/kvspec.el
+++ b/kotl/kvspec.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Oct-95 at 15:17:07
-;; Last-Mod:     16-Jul-22 at 22:33:26 by Mats Lidell
+;; Last-Mod:     18-Jul-22 at 21:57:01 by Mats Lidell
 ;;
 ;; Copyright (C) 1995-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -255,8 +255,9 @@ view specs."
       (kview:set-label-type kview type))))
 
 (defun kvspec:show-lines-this-cell (num)
-  "Assume the current cell is fully expanded and collapse to show NUM lines within it.
-If NUM is less than 1 or greater than the number of lines available, the cell remains fully expanded."
+  "Assume current cell is fully expanded and collapse to show NUM lines within it.
+If NUM is less than 1 or greater than the number of lines
+available, the cell remains fully expanded."
   ;; Use free variable kview-label-sep-len bound in kview:map-* for speed.
   (unless (< num 1)
     (let ((_start (goto-char (kcell-view:start (point) kview-label-sep-len)))


### PR DESCRIPTION
## What 

Example of doc changes to be within 80 char limit.

## Why

Looking at how it would be to go down the route to fix the 80 char limit. You suggested that I would do a couple of docs to see what it means. I did slightly more but before doing all I would want to share it for feedback. It is really a lot to do but it triggers some good discussion points, see below.

Some things I noticed while doing this work:
* elisp mode defaults to fill column of 65 chars which is a bit surprising. We should probably have a style guide so that our doc strings look similar. Tried to look for a general style guide for Emacs about that but did not find it but maybe there is. I have for this work kept the default when formatting the comment body. I have tried to do that in as few cases as possible as that creates a bigger diff.
* Some first line comments are really close to 80 chars so simple things like dropping a `the` or similar suffice to fix those.
* Some first line comments mentions Hyperbole, or other facts that should be clear for the context, and can be fixed by removing these.
* Some first line comments tries to capture everything about a function. Both the major functionality but also all alternatives. This might be the ones that would be hardest to change, but to be honest, I find them sometimes hard to read and understand. So forcing us to describe it within 80 chars would have the good side effect of making them more readable since long sentences are harder to read.
* Some functions have slightly misleading names. Example of that are the `-p` (predicate functions) where the comment line has to compensate for that by explain more what the function does. A good function name could make the task of the first comment line smaller and by that possible to capture in the less space.
* Functions with a lot of alternatives, controlled by optional arguments, might benefit from being split into multiple functions making each function both easier to test and to describe?
* Some techniques I have used:
   * Simply write a shorter first comment line and kept the original comment line in the comment body.
   * Cut the comment line in two. Moving the second part of it into the comment body.
   * Cut our part of the doc in the first line and then write a longer part describing the cut out piece in the comment body.
* My flycheck warned about single quotes in some doc strings so I fixed those as well. Not sure that is necessary. It just happened when I was at it. So feel free to ignore those changes. 