### PR TITLE
Remove last mentioning xemacs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,13 @@
 2022-07-17  Mats Lidell  <matsl@gnu.org>
 
+* kotl/kotl-mode.el (kotl-mode:beginning-of-line): Rename from
+    kotl-mode:to-start-of-line since it is the preferred name but was
+    blocked due to XEmacs byte compiler bug.
+    (kotl-mode:to-start-of-line): Mark as obsolete from version 8.0.1.
+
+* hmouse-sh.el (hmouse-get-bindings): Do not mention XEmacs since it is
+    not supported.
+
 * kotl/kview.el:
 * kotl/kotl-mode.el:
 * kotl/klabel.el: Use lbl-sep-len for all defun parameters to avoid name

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 2022-07-17  Mats Lidell  <matsl@gnu.org>
 
+* hypb.el (hypb:replace-match-string): Fix obsolete version to 8.0.1.
+
 * kotl/kotl-mode.el (kotl-mode:beginning-of-line): Rename from
     kotl-mode:to-start-of-line since it is the preferred name but was
     blocked due to XEmacs byte compiler bug.

--- a/hmouse-sh.el
+++ b/hmouse-sh.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     3-Sep-91 at 21:40:58
-;; Last-Mod:     24-Jan-22 at 00:18:46 by Bob Weiner
+;; Last-Mod:      9-Jul-22 at 16:41:14 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -271,8 +271,8 @@ These may be the bindings prior to initializing Hyperbole or the Hyperbole bindi
   (unless noninteractive
     (nconc
      (when hmouse-middle-flag (hmouse-get-unshifted-bindings))
-     ;; Get mouse bindings under Emacs or XEmacs, even if not under a
-     ;; window system since they can have frames on ttys and windowed
+     ;; Get mouse bindings under Emacs, even if not under a window
+     ;; system, since there can be frames on ttys and windowed
      ;; displays at the same time.
      (mapcar (lambda (key) (cons key (key-binding key)))
 	     (if (eq window-system 'dps)

--- a/hypb.el
+++ b/hypb.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     6-Oct-91 at 03:42:38
-;; Last-Mod:     15-Jul-22 at 23:08:28 by Mats Lidell
+;; Last-Mod:     17-Jul-22 at 10:17:21 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -544,7 +544,7 @@ WINDOW pixelwise."
 	((symbolp object)
 	 (get object 'hyperbole))))
 
-(make-obsolete 'hypb:replace-match-string 'replace-regexp-in-string "9.0")
+(make-obsolete 'hypb:replace-match-string 'replace-regexp-in-string "8.0.1")
 
 (defun hypb:replace-match-string (regexp str new &optional literal fixedcase)
   "Replace all matches for REGEXP in STR with NEW string and return the result.

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:     17-Jul-22 at 16:21:35 by Mats Lidell
+;; Last-Mod:     17-Jul-22 at 16:25:03 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -1547,7 +1547,7 @@ See `forward-paragraph' for more information."
   (point))
 
 ;;; This ensures that the key bound to `beginning-of-line' is replaced in kotl-mode.
-(define-obsolete-function-alias 'kotl-mode:to-start-of-line #'kotl-mode:beginning-of-line "9.0")
+(define-obsolete-function-alias 'kotl-mode:to-start-of-line #'kotl-mode:beginning-of-line "8.0.1")
 (defalias 'kotl-mode:beginning-of-visual-line 'kotl-mode:beginning-of-line)
 (defalias 'kotl-mode:move-beginning-of-line 'kotl-mode:beginning-of-line)
 

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:     17-Jul-22 at 11:09:42 by Mats Lidell
+;; Last-Mod:     17-Jul-22 at 16:21:35 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -290,7 +290,7 @@ the end of the text and `fill-column'."
 	(opoint (point-marker))
 	(bocp)
 	start)
-    (setq start (kotl-mode:to-start-of-line))
+    (setq start (kotl-mode:beginning-of-line))
     (when (setq bocp (kotl-mode:bocp))
       ;; Add a temporary fill-prefix since this is the 1st line of the cell
       ;; where label could interfere with centering.
@@ -488,7 +488,7 @@ Do not delete across cell boundaries."
   (save-restriction
     (narrow-to-region
      (save-excursion
-       (kotl-mode:to-start-of-line))
+       (kotl-mode:beginning-of-line))
      (save-excursion
        (kotl-mode:to-end-of-line)))
     (delete-horizontal-space)))
@@ -635,7 +635,7 @@ With optional prefix argument TOP-P non-nil, refill all cells in the outline."
   (save-excursion
     (save-restriction
       (save-excursion
-	(narrow-to-region (kotl-mode:to-start-of-line) (kotl-mode:to-end-of-line)))
+	(narrow-to-region (kotl-mode:beginning-of-line) (kotl-mode:to-end-of-line)))
       (just-one-space))))
 
 (defun kotl-mode:kill-line (&optional arg)
@@ -662,7 +662,7 @@ With optional prefix argument TOP-P non-nil, refill all cells in the outline."
 	(kill-region (point) (setq arg (kotl-mode:to-end-of-line))))
        ((= num-arg 0)
 	;; kill to bol
-	(kill-region (point) (setq arg (kotl-mode:to-start-of-line))))
+	(kill-region (point) (setq arg (kotl-mode:beginning-of-line))))
        (t ;; (/= num-arg 0)
 	;; Find start and end of region to kill
 	(let ((start (point))
@@ -821,7 +821,7 @@ too long."
 	    (insert-char ?\  indent))
 	  (do-auto-fill)
 	  (kfill:forward-line 1)
-	  (kotl-mode:to-start-of-line))
+	  (kotl-mode:beginning-of-line))
       (while (> arg 0)
 	(insert ?\n)
 	(insert-char ?\  indent)
@@ -993,7 +993,7 @@ that contains mark."
       (insert "\n")
       (insert-char ?\  (kcell-view:indent))
       (insert line-to-move)
-      (kotl-mode:to-start-of-line)))))
+      (kotl-mode:beginning-of-line)))))
 
 (defun kotl-mode:transpose-paragraphs (arg)
   "Interchange this (or next) paragraph with previous one."
@@ -1532,17 +1532,14 @@ See `forward-paragraph' for more information."
     (kotl-mode:backward-cell (1- arg)))
   (point))
 
-;;; Avoid XEmacs byte-compiler bug which inserts nil for calls to this
-;;; function if named kotl-mode:beginning-of-line.
-;;;
-(defun kotl-mode:to-start-of-line (&optional arg)
+(defun kotl-mode:beginning-of-line (&optional arg)
   "Move point to beginning of current or ARGth - 1 line and return point."
   (interactive "p")
   (kotl-mode:maintain-region-highlight)
   (unless arg
     (setq arg 1))
   (unless (integer-or-marker-p arg)
-    (error "(kotl-mode:to-start-of-line): Wrong type arg, integer-or-marker, `%s'" arg))
+    (error "(kotl-mode:beginning-of-line): Wrong type arg, integer-or-marker, `%s'" arg))
   (kfill:forward-line (1- arg))
   (unless (eolp)
     (forward-char (prog1 (kcell-view:indent)
@@ -1550,8 +1547,8 @@ See `forward-paragraph' for more information."
   (point))
 
 ;;; This ensures that the key bound to `beginning-of-line' is replaced in kotl-mode.
-(defalias 'kotl-mode:beginning-of-line 'kotl-mode:to-start-of-line)
-(defalias 'kotl-mode:beginning-of-visual-line 'kotl-mode:to-start-of-line)
+(define-obsolete-function-alias 'kotl-mode:to-start-of-line #'kotl-mode:beginning-of-line "9.0")
+(defalias 'kotl-mode:beginning-of-visual-line 'kotl-mode:beginning-of-line)
 (defalias 'kotl-mode:move-beginning-of-line 'kotl-mode:beginning-of-line)
 
 (defun kotl-mode:beginning-of-tree ()
@@ -2066,7 +2063,7 @@ If at tail cell already, do nothing and return nil."
 	    (when (kotl-mode:eolp)
 	      (save-excursion
 		(skip-chars-forward "\n\r")
-		(kotl-mode:to-start-of-line)
+		(kotl-mode:beginning-of-line)
 		(kotl-mode:bocp))))
     (point)))
 
@@ -2291,7 +2288,7 @@ to one level and kotl-mode:refill-flag is treated as true."
 	   start-level start-point prev prev-level)
       ;; Next line ensures point is in the root of the current tree if
       ;; the tree is at all hidden.
-      (kotl-mode:to-start-of-line)
+      (kotl-mode:beginning-of-line)
       (setq start-point (point)
 	    start-level (kcell-view:level start-point lbl-sep-len))
       (when fill-p
@@ -2501,7 +2498,7 @@ to one level and kotl-mode:refill-flag is treated as true."
 	   start-point)
       ;; Next line ensures point is in the root of the current tree if
       ;; the tree is at all hidden.
-      (kotl-mode:to-start-of-line)
+      (kotl-mode:beginning-of-line)
       (setq start-point (point))
       (when fill-p
 	(setq arg 1))
@@ -2922,7 +2919,7 @@ With optional SHOW-FLAG, expand the subtree instead."
   (save-excursion
     ;; Next line ensures point is in the root of the current tree if
     ;; the tree is at all hidden.
-    (kotl-mode:to-start-of-line)
+    (kotl-mode:beginning-of-line)
     (if cell-ref
 	(kotl-mode:goto-cell cell-ref t)
       (kotl-mode:beginning-of-cell))
@@ -2945,7 +2942,7 @@ With optional SHOW-FLAG, expand the tree instead."
   (save-excursion
     ;; Next line ensures point is in the root of the current tree if
     ;; the tree is at all hidden.
-    (kotl-mode:to-start-of-line)
+    (kotl-mode:beginning-of-line)
     (let ((start (if cell-ref
 		     (kotl-mode:goto-cell cell-ref t)
 		   (kotl-mode:beginning-of-cell)))
@@ -3124,7 +3121,7 @@ Do not delete newline at end of line."
     (when pos
       (goto-char pos))
     (if (kview:valid-position-p)
-	(let ((bol (kotl-mode:to-start-of-line))
+	(let ((bol (kotl-mode:beginning-of-line))
 	      (eol (kotl-mode:to-end-of-line)))
 	  (prog1
 	      (buffer-substring bol eol)

--- a/kotl/kview.el
+++ b/kotl/kview.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:     17-Jul-22 at 11:09:42 by Mats Lidell
+;; Last-Mod:     17-Jul-22 at 16:22:51 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -391,7 +391,7 @@ characters of the cell whose level is desired."
     (when pos
       (goto-char pos))
     (if (kview:valid-position-p)
-	(buffer-substring (kotl-mode:to-start-of-line) (kotl-mode:to-end-of-line))
+	(buffer-substring (kotl-mode:beginning-of-line) (kotl-mode:to-end-of-line))
       (error "(kcell-view:line): Invalid position, `%d'" (point)))))
 
 (defun kcell-view:lines-visible ()
@@ -576,7 +576,7 @@ If labels are off, return cell's idstamp as a string."
   (save-excursion
     ;; Next line ensures point is in the root of the current tree if
     ;; the tree is at all hidden.
-    (kotl-mode:to-start-of-line)
+    (kotl-mode:beginning-of-line)
     (kcell-view:label pos)))
 
 ;;;
@@ -976,7 +976,7 @@ See also `kview:map-branch' and `kview:map-tree'."
 	;; Next line ensures point is in the root of the current tree if
 	;; the tree is at all hidden.
 	(when visible-p
-	  (kotl-mode:to-start-of-line))
+	  (kotl-mode:beginning-of-line))
 	(when first-p
 	  ;; Move back to first predecessor at same level.
 	  (while (kcell-view:backward t lbl-sep-len)))
@@ -1009,7 +1009,7 @@ See also `kview:map-region', `kview:map-branch' and `kview:map-siblings'."
 	;; Next line ensures point is in the root of the current tree if
 	;; the tree is at all hidden.
 	(unless top-p
-	  (kotl-mode:to-start-of-line))
+	  (kotl-mode:beginning-of-line))
 	(let* ((results)
 	       (lbl-sep-len (kview:label-separator-length kview))
 	       (start (set-marker (make-marker) (if top-p (point-min) (point))))
@@ -1071,6 +1071,7 @@ See also `kview:map-region', `kview:map-branch' and `kview:map-siblings'."
 				   (kcell-view:next visible-p lbl-sep-len))))
 	    ;; Next line ensures point is in the root of the current tree if
 	    ;; the tree is at all hidden.
+	    (kotl-mode:beginning-of-line)
 	    (kotl-mode:to-start-of-line)
 	    (setq cell-indent (kcell-view:indent nil lbl-sep-len))
 	    ;; Terminate when no further cells or when reach a cell at an equal


### PR DESCRIPTION
## What

Remove last mentioning xemacs.

## Why

Since XEmacs is not supported it is strange to have code and comments that mentions XEmacs.

## Note

This PR has two parts:

1. Remove XEmacs from a comment where it looks like the comment still is valid for Emacs so changed the sentence to work with  that.
2. Second is more controversial. From the existing comment is sounds like the preferred name was not chosen due to a XEmacs byte compile bug. So I got ambitious and renamed it back, removed the comment and added an obsolete definition. An alternative would to keep the function as is and simply remove the comment!? (Learned to use wgrep which was handy and could be useful for future changes like this.)