### PR TITLE
Use messages-buffer, run test case only interactively

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2022-07-11  Mats Lidell  <matsl@gnu.org>
+
+* test/hy-test-helpers.el (hy-test-helpers:should-last-message): Use
+    function messages-buffer for getting the *Messages* buffer.
+
+* test/hui-select-tests.el (hui-select--thing): Limit test case to run in
+    interactive mode, i.e. make test-all.
+
 2022-06-19  Bob Weiner  <rsw@gnu.org>
 
 * test/demo-tests.el (fast-demo-key-series-shell-apropos): Allow optional space

--- a/test/hui-select-tests.el
+++ b/test/hui-select-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    14-Apr-22 at 23:45:52
-;; Last-Mod:     15-Apr-22 at 23:53:52 by Mats Lidell
+;; Last-Mod:     11-Jul-22 at 23:29:45 by Mats Lidell
 ;;
 ;; Copyright (C) 2021  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -80,6 +80,7 @@
 
 (ert-deftest hui-select--thing ()
   "`hui-select-thing' selects bigger sections of text when called repeatedly."
+  (skip-unless (not noninteractive))
   (hui-select-reset)
   (with-temp-buffer
     (insert "Buffer\n\nParagraph\nline.  One word.\n")

--- a/test/hy-test-helpers.el
+++ b/test/hy-test-helpers.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     24-Jan-22 at 00:40:54 by Bob Weiner
+;; Last-Mod:     11-Jul-22 at 23:23:08 by Mats Lidell
 ;;
 ;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -27,7 +27,7 @@
 
 (defun hy-test-helpers:should-last-message (msg)
   "Verify last message is MSG."
-  (with-current-buffer "*Messages*"
+  (with-current-buffer (messages-buffer)
     (should (save-excursion
               (goto-char (point-max))
               (search-backward msg (- (point-max) 350))))))


### PR DESCRIPTION
## What

Use messages-buffer for getting the `*Messages*` buffer and run test case `hui-select--thing` only interactively.

## Why

* Elisp manual suggest not using the string `*Messages*` but instead use the function `messages-buffer`.
* Output in batch mode goes to stdout and not `*Messages*` so test cases reading `*Messages*` should not be run non interactively (But oddly it seems to work anyway under some circumstances. Anyway test-all is the preferred method to run test cases so this will just ensure that when `make test` is used it will not fail. This happens when run in a docker container and is useful for quick tests.)