### PR TITLE
Rename global var to remove shadowing warnings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2022-07-16  Mats Lidell  <matsl@gnu.org>
+
+* kotl/kvspec.el (kvspec:show-lines-this-cell): Use kview-label-sep-len.
+
+* kotl/kotl-mode.el (kotl-mode:collapse-tree, kotl-mode:expand-tree): Use
+    kview-label-sep-len.
+
+* kotl/kview.el (kview-label-sep-len): Rename global variable.
+    (kcell-view:lines-visible, kview:set-cells-status): Use it.
+
 2022-07-15  Mats Lidell  <matsl@gnu.org>
 
 * test/hypb-tests.el: Remove test cases for hypb:replace-match-string.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-2022-07-16  Mats Lidell  <matsl@gnu.org>
+2022-07-17  Mats Lidell  <matsl@gnu.org>
 
 * kotl/kvspec.el (kvspec:show-lines-this-cell): Use kview-label-sep-len.
 
@@ -7,6 +7,7 @@
 
 * kotl/kview.el (kview-label-sep-len): Rename global variable.
     (kcell-view:lines-visible, kview:set-cells-status): Use it.
+    (label-sep-len):  Mark variable as obsolete. Use kview-label-sep-len.
 
 2022-07-15  Mats Lidell  <matsl@gnu.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 2022-07-17  Mats Lidell  <matsl@gnu.org>
 
+* kotl/kview.el:
+* kotl/kotl-mode.el:
+* kotl/klabel.el: Use lbl-sep-len for all defun parameters to avoid name
+    clash with obsolete variable label-sep-len.
+
 * kotl/kvspec.el (kvspec:show-lines-this-cell): Use kview-label-sep-len.
 
 * kotl/kotl-mode.el (kotl-mode:collapse-tree, kotl-mode:expand-tree): Use

--- a/kotl/klabel.el
+++ b/kotl/klabel.el
@@ -3,9 +3,9 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    17-Apr-94
-;; Last-Mod:     12-Feb-22 at 10:42:20 by Mats Lidell
+;; Last-Mod:     17-Jul-22 at 11:13:30 by Mats Lidell
 ;;
-;; Copyright (C) 1994-2021  Free Software Foundation, Inc.
+;; Copyright (C) 1994-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.
@@ -327,11 +327,11 @@ With optional CHILD-P, return label for first child cell of PREV-LABEL cell."
       (let ((klabel-type:changing-flag t))
 	(klabel-type:update-labels-from-point label-type first-label)))))
 
-(defun klabel-type:set-alpha (current-cell-label label-sep-len current-indent
+(defun klabel-type:set-alpha (current-cell-label lbl-sep-len current-indent
 			      per-level-indent &optional current-tree-only)
   "Set the labels of current cell, its following siblings and their subtrees.
 CURRENT-CELL-LABEL is the label to display for the current cell.
-LABEL-SEP-LEN is the length of the separation between a cell's label
+LBL-SEP-LEN is the length of the separation between a cell's label
 and the start of its contents."
   (let (label-prefix label-suffix suffix-val suffix-function opoint)
     (if current-cell-label
@@ -347,20 +347,20 @@ and the start of its contents."
 				'kotl-label:int-to-alpha)))
     (while current-cell-label
       ;; Set current cell's label.
-      (klabel:set current-cell-label label-sep-len)
+      (klabel:set current-cell-label lbl-sep-len)
       ;; Process any subtrees of current cell.
-      (if (kcell-view:child nil label-sep-len)
+      (if (kcell-view:child nil lbl-sep-len)
 	  ;; Recurse over subtree.
 	  (klabel-type:set-alpha
 	   (klabel:child-alpha current-cell-label)
-	   label-sep-len
+	   lbl-sep-len
 	   (+ current-indent per-level-indent)
 	   per-level-indent))
       ;; Process next sibling of current cell if any.
       (setq opoint (point))
       (if (and (not current-tree-only)
-	       (kcell-view:next nil label-sep-len)
-	       (< (abs (- (kcell-view:indent nil label-sep-len) current-indent))
+	       (kcell-view:next nil lbl-sep-len)
+	       (< (abs (- (kcell-view:indent nil lbl-sep-len) current-indent))
 		  (kview:level-indent kview)))
 	  (setq suffix-val (1+ suffix-val)
 		label-suffix (funcall suffix-function suffix-val)
@@ -368,21 +368,21 @@ and the start of its contents."
 	(goto-char opoint)
 	(setq current-cell-label nil)))))
 
-(defun klabel-type:set-id (_current-cell-label label-sep-len &rest _ignore)
+(defun klabel-type:set-id (_current-cell-label lbl-sep-len &rest _ignore)
   "Set the labels of current cell, its following siblings and their subtrees.
 CURRENT-CELL-LABEL is the label to display for the current cell."
   ;; Only need to do this when switching from one label type to another,
   ;; i.e. when every cell label will be updated.  So if not starting with the
   ;; first cell, do nothing.
   (if (kotl-mode:first-cell-p)
-      (while (and (klabel:set (kcell-view:idstamp) label-sep-len)
-		  (kcell-view:next nil label-sep-len)))))
+      (while (and (klabel:set (kcell-view:idstamp) lbl-sep-len)
+		  (kcell-view:next nil lbl-sep-len)))))
 
-(defun klabel-type:set-legal (current-cell-label label-sep-len current-indent
+(defun klabel-type:set-legal (current-cell-label lbl-sep-len current-indent
 			      per-level-indent &optional current-tree-only)
   "Set the labels of current cell, its following siblings and their subtrees.
 CURRENT-CELL-LABEL is the label to display for the current cell.
-LABEL-SEP-LEN is the length of the separation between a cell's label
+LBL-SEP-LEN is the length of the separation between a cell's label
 and the start of its contents."
   (let (label-prefix label-suffix suffix-val opoint)
     (if current-cell-label
@@ -392,20 +392,20 @@ and the start of its contents."
 	      suffix-val (string-to-number label-suffix)))
     (while current-cell-label
       ;; Set current cell's label.
-      (klabel:set current-cell-label label-sep-len)
+      (klabel:set current-cell-label lbl-sep-len)
       ;; Process any subtrees of current cell.
-      (if (kcell-view:child nil label-sep-len)
+      (if (kcell-view:child nil lbl-sep-len)
 	  ;; Recurse over subtree.
 	  (klabel-type:set-legal
 	   (klabel:child-legal current-cell-label)
-	   label-sep-len
+	   lbl-sep-len
 	   (+ current-indent per-level-indent)
 	   per-level-indent))
       ;; Process next sibling of current cell if any.
       (setq opoint (point))
       (if (and (not current-tree-only)
-	       (kcell-view:next nil label-sep-len)
-	       (< (abs (- (kcell-view:indent nil label-sep-len) current-indent))
+	       (kcell-view:next nil lbl-sep-len)
+	       (< (abs (- (kcell-view:indent nil lbl-sep-len) current-indent))
 		  (kview:level-indent kview)))
 	  (setq suffix-val (1+ suffix-val)
 		label-suffix (int-to-string suffix-val)
@@ -413,22 +413,22 @@ and the start of its contents."
 	(goto-char opoint)
 	(setq current-cell-label nil)))))
 
-(defun klabel-type:set-no (_current-cell-label label-sep-len &rest _ignore)
+(defun klabel-type:set-no (_current-cell-label lbl-sep-len &rest _ignore)
   "Set the labels of current cell, its following siblings and their subtrees.
 CURRENT-CELL-LABEL is the label to display for the current cell."
   ;; Only need to do this when switching from one label type to another,
   ;; i.e. when every cell label will be updated.  So if not starting with the
   ;; first cell, do nothing.
   (if (kotl-mode:first-cell-p)
-      (while (and (klabel:set "" label-sep-len)
-		  (kcell-view:next nil label-sep-len)))))
+      (while (and (klabel:set "" lbl-sep-len)
+		  (kcell-view:next nil lbl-sep-len)))))
 
-(defun klabel-type:set-partial-alpha (current-cell-label label-sep-len
+(defun klabel-type:set-partial-alpha (current-cell-label lbl-sep-len
                                       current-indent per-level-indent
 				      &optional current-tree-only)
   "Set the labels of current cell, its following siblings and their subtrees.
 CURRENT-CELL-LABEL is the label to display for the current cell.
-LABEL-SEP-LEN is the length of the separation between a cell's label
+LBL-SEP-LEN is the length of the separation between a cell's label
 and the start of its contents."
   (let (label-suffix suffix-val suffix-function opoint)
     (if current-cell-label
@@ -442,20 +442,20 @@ and the start of its contents."
 				'kotl-label:int-to-alpha)))
     (while current-cell-label
       ;; Set current cell's label.
-      (klabel:set current-cell-label label-sep-len)
+      (klabel:set current-cell-label lbl-sep-len)
       ;; Process any subtrees of current cell.
-      (if (kcell-view:child nil label-sep-len)
+      (if (kcell-view:child nil lbl-sep-len)
 	  ;; Recurse over subtree.
 	  (klabel-type:set-partial-alpha
 	   (klabel:child-partial-alpha current-cell-label)
-	   label-sep-len
+	   lbl-sep-len
 	   (+ current-indent per-level-indent)
 	   per-level-indent))
       ;; Process next sibling of current cell if any.
       (setq opoint (point))
       (if (and (not current-tree-only)
-	       (kcell-view:next nil label-sep-len)
-	       (< (abs (- (kcell-view:indent nil label-sep-len) current-indent))
+	       (kcell-view:next nil lbl-sep-len)
+	       (< (abs (- (kcell-view:indent nil lbl-sep-len) current-indent))
 		  (kview:level-indent kview)))
 	  (setq suffix-val (1+ suffix-val)
 		label-suffix (funcall suffix-function suffix-val)
@@ -463,19 +463,19 @@ and the start of its contents."
 	(goto-char opoint)
 	(setq current-cell-label nil)))))
 
-(defun klabel-type:set-star (_current-cell-label label-sep-len &rest _ignore)
+(defun klabel-type:set-star (_current-cell-label lbl-sep-len &rest _ignore)
   "Set the labels of current cell, its following siblings and their subtrees.
 CURRENT-CELL-LABEL is the label to display for the current cell.
-LABEL-SEP-LEN is the length of the separation between a cell's label
+LBL-SEP-LEN is the length of the separation between a cell's label
 and the start of its contents."
   ;; Only need to do this when switching from one label type to another,
   ;; i.e. when every cell label will be updated.  So if not starting with the
   ;; first cell, do nothing.
   (if (kotl-mode:first-cell-p)
       (while (and (klabel:set (make-string
-			       (kcell-view:level nil label-sep-len) ?*)
-			      label-sep-len)
-		  (kcell-view:next nil label-sep-len)))))
+			       (kcell-view:level nil lbl-sep-len) ?*)
+			      lbl-sep-len)
+		  (kcell-view:next nil lbl-sep-len)))))
 
 (defun klabel-type:update-labels (current-cell-label)
   "Update the labels of current cell, its following siblings and their subtrees if need be.
@@ -495,12 +495,12 @@ If, however, it is \"0\", then all cell labels are updated."
 CURRENT-CELL-LABEL is the label to display for the current cell.
 Use `(klabel-type:update-labels \"0\")' to update all cells in an outline."
   (let ((label-type (kview:label-type kview))
-	(label-sep-len (kview:label-separator-length kview)))
+	(lbl-sep-len (kview:label-separator-length kview)))
     (save-excursion
       (funcall (intern-soft (concat "klabel-type:set-"
 				    (symbol-name label-type)))
-	       first-label label-sep-len
-	       (kcell-view:indent nil label-sep-len)
+	       first-label lbl-sep-len
+	       (kcell-view:indent nil lbl-sep-len)
 	       (kview:level-indent kview)
 	       ;; Update current tree only.
 	       t))))
@@ -614,13 +614,13 @@ N may be an integer or a string containing an integer."
 ;;; Private functions
 ;;; ************************************************************************
 
-(defun klabel:set (new-label &optional label-sep-len)
+(defun klabel:set (new-label &optional lbl-sep-len)
   "Replace label displayed in cell at point with NEW-LABEL, which may be a different label type.
 Return NEW-LABEL string."
   (let ((modified (buffer-modified-p))
 	(buffer-read-only)
-	(thru-label (- (kcell-view:indent nil label-sep-len)
-		       (or label-sep-len
+	(thru-label (- (kcell-view:indent nil lbl-sep-len)
+		       (or lbl-sep-len
 			   (kview:label-separator-length kview)))))
     (save-excursion
       (kcell-view:to-label-end)
@@ -639,12 +639,12 @@ For example, the full label \"1a2\" has kotl-label \"2\", as does \"1.1.2\"."
     (error "(klabel:to-kotl-label): Invalid label, `%s'" label)))
 
 (defun klabel-type:update-labels-from-point (label-type first-label)
-  (let ((label-sep-len (kview:label-separator-length kview)))
+  (let ((lbl-sep-len (kview:label-separator-length kview)))
     (save-excursion
       (funcall (intern-soft (concat "klabel-type:set-"
 				    (symbol-name label-type)))
-	       first-label label-sep-len
-	       (kcell-view:indent nil label-sep-len)
+	       first-label lbl-sep-len
+	       (kcell-view:indent nil lbl-sep-len)
 	       (kview:level-indent kview)))))
 
 (provide 'klabel)

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:     16-Jul-22 at 22:33:04 by Mats Lidell
+;; Last-Mod:     17-Jul-22 at 11:09:42 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -1140,15 +1140,15 @@ Leave point at original location but return the tree's new start point."
       (list current-prefix-arg))))
   (if (and (not copy-p) (equal from-cell-ref to-cell-ref))
       (error "(kotl-mode:move-after): Can't move tree after itself"))
-  (let* ((label-sep-len (kview:label-separator-length kview))
+  (let* ((lbl-sep-len (kview:label-separator-length kview))
 	 (move-to-point (set-marker
 			 (make-marker)
 			 (kotl-mode:goto-cell to-cell-ref t)))
 	 (to-label (kcell-view:label))
-	 (to-indent (kcell-view:indent nil label-sep-len))
+	 (to-indent (kcell-view:indent nil lbl-sep-len))
 	 (from-label (progn (kotl-mode:goto-cell from-cell-ref t)
 			    (kcell-view:label)))
-	 (from-indent (kcell-view:indent nil label-sep-len))
+	 (from-indent (kcell-view:indent nil lbl-sep-len))
 	 (start (kotl-mode:tree-start))
 	 (end   (kotl-mode:tree-end))
 	 (sib-id (when (= 0 (kotl-mode:forward-cell 1))
@@ -1168,7 +1168,7 @@ Leave point at original location but return the tree's new start point."
     ;; to renumber the sibling separately from the tree to move.
     (when sib-id
       ;; Move to middle of label and insert klabel-original temp property.
-      (goto-char (- (point) label-sep-len 3))
+      (goto-char (- (point) lbl-sep-len 3))
       (kproperty:set 'klabel-original t))
     ;;
     ;; Position for insertion before deletion of tree-to-move from old
@@ -1205,7 +1205,7 @@ Leave point at original location but return the tree's new start point."
 	(kotl-mode:goto-cell sib-id t)
 	;; Sibling labels may have already been updated if tree was
 	;; moved somewhere preceding its siblings.
-	(let ((label-middle (- (point) label-sep-len 2)))
+	(let ((label-middle (- (point) lbl-sep-len 2)))
 	  (when (kproperty:get label-middle 'klabel-original)
 	    (klabel-type:update-labels from-label)))))
     ;;
@@ -1237,15 +1237,15 @@ Leave point at original location but return the tree's new start point."
       (list current-prefix-arg))))
   (when (and (not copy-p) (equal from-cell-ref to-cell-ref))
     (error "(kotl-mode:move-before): Can't move tree before itself"))
-  (let* ((label-sep-len (kview:label-separator-length kview))
+  (let* ((lbl-sep-len (kview:label-separator-length kview))
 	 (move-to-point (set-marker
 			 (make-marker)
 			 (kotl-mode:goto-cell to-cell-ref t)))
 	 (to-label (kcell-view:label))
-	 (to-indent (kcell-view:indent nil label-sep-len))
+	 (to-indent (kcell-view:indent nil lbl-sep-len))
 	 (from-label (progn (kotl-mode:goto-cell from-cell-ref t)
 			    (kcell-view:label)))
-	 (from-indent (kcell-view:indent nil label-sep-len))
+	 (from-indent (kcell-view:indent nil lbl-sep-len))
 	 (start (kotl-mode:tree-start))
 	 (end   (kotl-mode:tree-end))
 	 (sib-id (when (= 0 (kotl-mode:forward-cell 1))
@@ -1264,7 +1264,7 @@ Leave point at original location but return the tree's new start point."
     ;; to renumber the sibling separately from the tree to move.
     (when sib-id
       ;; Move to middle of label and insert klabel-original temp property.
-      (goto-char (- (point) label-sep-len 3))
+      (goto-char (- (point) lbl-sep-len 3))
       (kproperty:set 'klabel-original t))
     ;;
     ;; Position for insertion at succeeding-tree, before deletion of
@@ -1272,7 +1272,7 @@ Leave point at original location but return the tree's new start point."
     (goto-char move-to-point)
     (if parent-p
 	;; Move to insert position for first child of to-cell-ref's parent.
-	(if (kcell-view:parent nil label-sep-len)
+	(if (kcell-view:parent nil lbl-sep-len)
 	    (progn (setq to-label (klabel:child (kcell-view:label)))
 		   (goto-char (kcell-view:end)))
 	  (error "(kotl-mode:move-before): to-cell-ref's parent not in current view"))
@@ -1299,7 +1299,7 @@ Leave point at original location but return the tree's new start point."
 	(kotl-mode:goto-cell sib-id t)
 	;; Sibling labels may have already been updated if tree was
 	;; moved somewhere preceding its siblings.
-	(let ((label-middle (- (point) label-sep-len 2)))
+	(let ((label-middle (- (point) lbl-sep-len 2)))
 	  (when (kproperty:get label-middle 'klabel-original)
 	    (klabel-type:update-labels from-label)))))
     ;;
@@ -1410,14 +1410,14 @@ Return number of cells left to move."
   (if (< arg 0)
       (kotl-mode:forward-cell (- arg))
     (let ((prior (= arg 0))
-	  (label-sep-len (kview:label-separator-length kview)))
+	  (lbl-sep-len (kview:label-separator-length kview)))
       (when (not (kview:valid-position-p))
         (progn
           (kotl-mode:to-valid-position t)
           (kotl-mode:beginning-of-cell)
           (setq arg (1- arg))
           (setq prior t)))
-      (while (and (> arg 0) (setq prior (kcell-view:backward t label-sep-len)))
+      (while (and (> arg 0) (setq prior (kcell-view:backward t lbl-sep-len)))
 	(setq arg (1- arg)))
       (if (or prior (not (called-interactively-p 'interactive)))
 	  arg
@@ -1464,27 +1464,27 @@ See `forward-paragraph' for more information."
   "Move point backward ARG (or 1) sentences and return point."
   (interactive "p")
   (kotl-mode:maintain-region-highlight)
-  (let* ((label-sep-len (kview:label-separator-length kview))
+  (let* ((lbl-sep-len (kview:label-separator-length kview))
 	 ;; Setting fill prefix makes sentence commands properly recognize
 	 ;; indented paragraphs.
-	 (fill-prefix (make-string (kcell-view:indent nil label-sep-len) ?\ )))
+	 (fill-prefix (make-string (kcell-view:indent nil lbl-sep-len) ?\ )))
     (if (kotl-mode:bobp)
 	(error "(kotl-mode:backward-sentence): First sentence")
-      (when (and (kotl-mode:bocp) (kcell-view:previous nil label-sep-len))
+      (when (and (kotl-mode:bocp) (kcell-view:previous nil lbl-sep-len))
 	(goto-char (kcell-view:end-contents)))
       (unless arg
 	(setq arg 1))
       (save-restriction
 	(when (= arg 1)
 	  (narrow-to-region
-	   (- (kcell-view:start nil label-sep-len)
-	      (kcell-view:indent nil label-sep-len))
+	   (- (kcell-view:start nil lbl-sep-len)
+	      (kcell-view:indent nil lbl-sep-len))
 	   (kcell-view:end-contents)))
 	(unwind-protect
 	    (let ((opoint (point)))
 	      (backward-sentence arg)
 	      (when (= opoint (point))
-		(kcell-view:previous nil label-sep-len)
+		(kcell-view:previous nil lbl-sep-len)
 		(backward-sentence arg)))
 	  (kotl-mode:to-valid-position t)))))
   (point))
@@ -1559,12 +1559,12 @@ See `forward-paragraph' for more information."
 Leave point at the start of the cell."
   (interactive)
   (kotl-mode:maintain-region-highlight)
-  (let ((label-sep-len (kview:label-separator-length kview)))
-    (when (/= (kcell-view:level nil label-sep-len) 1)
+  (let ((lbl-sep-len (kview:label-separator-length kview)))
+    (when (/= (kcell-view:level nil lbl-sep-len) 1)
       ;; Enable user to return to this previous position if desired.
       (push-mark nil 'no-msg))
-    (while (and (/= (kcell-view:level nil label-sep-len) 1)
-		(kcell-view:parent nil label-sep-len)))
+    (while (and (/= (kcell-view:level nil lbl-sep-len) 1)
+		(kcell-view:parent nil lbl-sep-len)))
     (kotl-mode:beginning-of-cell)))
 
 (defun kotl-mode:down-level (arg)
@@ -1640,18 +1640,18 @@ With optional ARG < 0, move to the ARGth previous visible cell."
   (kotl-mode:maintain-region-highlight)
   ;; Enable user to return to this previous position if desired.
   (push-mark nil 'no-msg)
-  (let ((label-sep-len (kview:label-separator-length kview)))
-    (if (kcell-view:forward nil label-sep-len)
+  (let ((lbl-sep-len (kview:label-separator-length kview)))
+    (if (kcell-view:forward nil lbl-sep-len)
 	;; Move to cell preceding start of next tree.
-	(kcell-view:previous nil label-sep-len)
+	(kcell-view:previous nil lbl-sep-len)
       ;; Otherwise, no next tree, so move until find last cell in tree.
-      (let ((cell-indent (kcell-view:indent nil label-sep-len))
+      (let ((cell-indent (kcell-view:indent nil lbl-sep-len))
 	    (end-point (point)))
 	;; Terminate when no further cells or when reach a cell at an equal
 	;; or higher level in the outline than the first cell that we
 	;; processed.
-	(while (and (kcell-view:next nil label-sep-len)
-		    (>= (- (kcell-view:indent nil label-sep-len) cell-indent)
+	(while (and (kcell-view:next nil lbl-sep-len)
+		    (>= (- (kcell-view:indent nil lbl-sep-len) cell-indent)
 			(kview:level-indent kview)))
 	  (setq end-point (point)))
 	(goto-char end-point)))
@@ -1663,11 +1663,11 @@ Leave point at the start of the cell or at its present position if it is
 already within the first sibling cell."
   (interactive)
   (kotl-mode:maintain-region-highlight)
-  (let ((label-sep-len (kview:label-separator-length kview)))
-    (when (save-excursion (kcell-view:backward nil label-sep-len))
+  (let ((lbl-sep-len (kview:label-separator-length kview)))
+    (when (save-excursion (kcell-view:backward nil lbl-sep-len))
 	;; Enable user to return to this previous position if desired.
       (push-mark nil 'no-msg))
-    (while (kcell-view:backward nil label-sep-len))))
+    (while (kcell-view:backward nil lbl-sep-len))))
 
 (defun kotl-mode:forward-cell (arg)
   "Move to prefix ARGth following cell (same level) within current view.
@@ -1677,8 +1677,8 @@ Return number of cells left to move."
   (if (< arg 0)
       (kotl-mode:backward-cell (- arg))
     (let ((next (= arg 0))
-	  (label-sep-len (kview:label-separator-length kview)))
-      (while (and (> arg 0) (setq next (kcell-view:forward t label-sep-len)))
+	  (lbl-sep-len (kview:label-separator-length kview)))
+      (while (and (> arg 0) (setq next (kcell-view:forward t lbl-sep-len)))
 	(setq arg (1- arg)))
       (if (or next (not (called-interactively-p 'interactive)))
 	  arg
@@ -1733,26 +1733,26 @@ part of the paragraph, or the end of the buffer."
   "Move point forward ARG (or 1) sentences and return point."
   (interactive "P")
   (kotl-mode:maintain-region-highlight)
-  (let* ((label-sep-len (kview:label-separator-length kview))
+  (let* ((lbl-sep-len (kview:label-separator-length kview))
 	 ;; Setting fill prefix makes sentence commands properly recognize
 	 ;; indented paragraphs.
-	 (fill-prefix (make-string (kcell-view:indent nil label-sep-len) ?\ )))
+	 (fill-prefix (make-string (kcell-view:indent nil lbl-sep-len) ?\ )))
     (if (kotl-mode:eobp)
 	(error "(kotl-mode:forward-sentence): Last sentence")
-      (if (kotl-mode:eocp) (kcell-view:next nil label-sep-len))
+      (if (kotl-mode:eocp) (kcell-view:next nil lbl-sep-len))
       (unless arg
 	(setq arg 1))
       (save-restriction
 	(when (= arg 1)
 	  (narrow-to-region
-	   (- (kcell-view:start nil label-sep-len)
-	      (kcell-view:indent nil label-sep-len))
+	   (- (kcell-view:start nil lbl-sep-len)
+	      (kcell-view:indent nil lbl-sep-len))
 	   (kcell-view:end-contents)))
 	(unwind-protect
 	    (let ((opoint (point)))
 	      (forward-sentence arg)
 	      (when (= opoint (point))
-		(kcell-view:next nil label-sep-len)
+		(kcell-view:next nil lbl-sep-len)
 		(forward-sentence arg)))
 	  (kotl-mode:to-valid-position)))))
   (point))
@@ -1838,8 +1838,8 @@ If at head cell already, do nothing and return nil."
   (interactive "p")
   (kotl-mode:maintain-region-highlight)
   (let ((moved)
-	(label-sep-len (kview:label-separator-length kview)))
-    (while (kcell-view:backward t label-sep-len)
+	(lbl-sep-len (kview:label-separator-length kview)))
+    (while (kcell-view:backward t lbl-sep-len)
       (setq moved t))
     moved))
 
@@ -1849,11 +1849,11 @@ Leave point at the start of the cell or at its present position if it is
 already within the last sibling cell."
   (interactive)
   (kotl-mode:maintain-region-highlight)
-  (let ((label-sep-len (kview:label-separator-length kview)))
-    (when (save-excursion (kcell-view:forward nil label-sep-len))
+  (let ((lbl-sep-len (kview:label-separator-length kview)))
+    (when (save-excursion (kcell-view:forward nil lbl-sep-len))
       ;; Enable user to return to this previous position if desired.
       (push-mark nil 'no-msg))
-    (while (kcell-view:forward nil label-sep-len))))
+    (while (kcell-view:forward nil lbl-sep-len))))
 
 (defun kotl-mode:mark-paragraph ()
   "Put point at beginning of this paragraph, mark at end.
@@ -1880,8 +1880,8 @@ The paragraph marked is the one that contains point or follows point."
   (if (< arg 0)
       (kotl-mode:previous-cell (- arg))
     (let ((next (= arg 0))
-	  (label-sep-len (kview:label-separator-length kview)))
-      (while (and (> arg 0) (setq next (kcell-view:next t label-sep-len)))
+	  (lbl-sep-len (kview:label-separator-length kview)))
+      (while (and (> arg 0) (setq next (kcell-view:next t lbl-sep-len)))
 	(setq arg (1- arg)))
       (if next
 	  arg
@@ -1916,10 +1916,10 @@ The paragraph marked is the one that contains point or follows point."
   "Move past current tree to the start of the next tree, or to the start of the last cell in tree if no next tree.
 Return non-nil iff there is a next tree within the koutline."
   (let ((start-indent (kcell-view:indent))
-	(label-sep-len (kview:label-separator-length kview))
+	(lbl-sep-len (kview:label-separator-length kview))
 	(same-tree t))
-      (while (and (kcell-view:next nil label-sep-len)
-		  (setq same-tree (>= (- (kcell-view:indent nil label-sep-len) start-indent)
+      (while (and (kcell-view:next nil lbl-sep-len)
+		  (setq same-tree (>= (- (kcell-view:indent nil lbl-sep-len) start-indent)
 				      (kview:level-indent kview)))))
       (not same-tree)))
 
@@ -1954,7 +1954,7 @@ Return non-nil iff there is a next tree within the koutline."
   (if (< arg 0)
       (kotl-mode:next-cell (- arg))
     (let ((previous (= arg 0))
-	  (label-sep-len (kview:label-separator-length kview)))
+	  (lbl-sep-len (kview:label-separator-length kview)))
       (when (not (kview:valid-position-p))
         (progn
           (kotl-mode:to-valid-position t)
@@ -1962,7 +1962,7 @@ Return non-nil iff there is a next tree within the koutline."
           (setq arg (1- arg))
           (setq previous t)))
       (while (and (> arg 0) (setq previous
-				  (kcell-view:previous t label-sep-len)))
+				  (kcell-view:previous t lbl-sep-len)))
 	(setq arg (1- arg)))
       (if previous
 	  arg
@@ -1992,8 +1992,8 @@ If at tail cell already, do nothing and return nil."
   (interactive "p")
   (kotl-mode:maintain-region-highlight)
   (let ((moved)
-	(label-sep-len (kview:label-separator-length kview)))
-    (while (kcell-view:forward t label-sep-len)
+	(lbl-sep-len (kview:label-separator-length kview)))
+    (while (kcell-view:forward t lbl-sep-len)
       (setq moved t))
     moved))
 
@@ -2006,9 +2006,9 @@ If at tail cell already, do nothing and return nil."
     ;; Enable user to return to this previous position if desired.
     (push-mark nil 'no-msg)
     (let ((parent)
-	  (label-sep-len (kview:label-separator-length kview))
+	  (lbl-sep-len (kview:label-separator-length kview))
 	  result)
-      (while (and (> arg 0) (setq result (kcell-view:parent t label-sep-len)))
+      (while (and (> arg 0) (setq result (kcell-view:parent t lbl-sep-len)))
 	(or parent (setq parent result))
 	(setq arg (if (eq result 0) 0 (1- arg))))
       ;; Signal an error if couldn't move up at least 1 parent level.
@@ -2211,10 +2211,10 @@ Return last newly added cell."
   (interactive "*P")
   (or (stringp contents) (setq contents nil))
   (let ((klabel (kcell-view:label))
-	(label-sep-len (kview:label-separator-length kview))
+	(lbl-sep-len (kview:label-separator-length kview))
 	cell-level new-cell sibling-p child-p start parent
 	cells-to-add)
-    (setq cell-level (kcell-view:level nil label-sep-len)
+    (setq cell-level (kcell-view:level nil lbl-sep-len)
 	  child-p (equal relative-level '(4))
 	  sibling-p (and (not child-p)
 			 (cond ((not relative-level) 1)
@@ -2228,7 +2228,7 @@ Return last newly added cell."
 	;; Move to parent.
 	(setq cell-level (1- cell-level)
 	      start (point)
-	      parent (kcell-view:parent nil label-sep-len))
+	      parent (kcell-view:parent nil lbl-sep-len))
 	(unless (eq parent t)
 	  (goto-char start)
 	  (error
@@ -2237,7 +2237,7 @@ Return last newly added cell."
       (when (kotl-mode:next-tree)
 	;; If found a new tree, then move back to prior cell so can add
 	;; new cell after it.
-	(kcell-view:previous nil label-sep-len)))
+	(kcell-view:previous nil lbl-sep-len)))
     (goto-char (kcell-view:end))
     ;;
     ;; Insert new cells into view.
@@ -2265,7 +2265,7 @@ Return last newly added cell."
     ;; sibling if any.
     (kotl-mode:to-valid-position t)
     (save-excursion
-      (when (kcell-view:forward t label-sep-len)
+      (when (kcell-view:forward t lbl-sep-len)
 	(let ((label-type (kview:label-type kview)))
 	  (when (memq label-type '(alpha legal partial-alpha))
 	    ;; Update the labels of these siblings and their subtrees.
@@ -2283,17 +2283,17 @@ to one level and kotl-mode:refill-flag is treated as true."
   (interactive "*p")
   (if (< arg 0)
       (kotl-mode:promote-tree (- arg))
-    (let* ((label-sep-len (kview:label-separator-length kview))
+    (let* ((lbl-sep-len (kview:label-separator-length kview))
 	   (orig-id (kcell-view:idstamp))
 	   (fill-p (= arg 0))
 	   (orig-pos-in-cell
-	    (- (point) (kcell-view:start (point) label-sep-len)))
+	    (- (point) (kcell-view:start (point) lbl-sep-len)))
 	   start-level start-point prev prev-level)
       ;; Next line ensures point is in the root of the current tree if
       ;; the tree is at all hidden.
       (kotl-mode:to-start-of-line)
       (setq start-point (point)
-	    start-level (kcell-view:level start-point label-sep-len))
+	    start-level (kcell-view:level start-point lbl-sep-len))
       (when fill-p
 	(setq arg 1))
       (unwind-protect
@@ -2301,10 +2301,10 @@ to one level and kotl-mode:refill-flag is treated as true."
 	    (backward-char 1)
 	    (while (and (> arg 0)
 			(setq prev
-			      (kcell-view:previous nil label-sep-len)))
+			      (kcell-view:previous nil lbl-sep-len)))
 	      (when prev
 		(setq prev-level
-		      (kcell-view:level (point) label-sep-len))
+		      (kcell-view:level (point) lbl-sep-len))
 		(cond ((> prev-level (+ start-level arg))
 		       ;; Don't want to demote this far
 		       ;; so keep looking at prior nodes.
@@ -2429,12 +2429,12 @@ If ARG is a non-positive number, nothing is done."
   (interactive "*p")
   (or (integerp arg) (setq arg 1))
   (let ((killed) (label (kcell-view:label))
-	(label-sep-len (kview:label-separator-length kview))
+	(lbl-sep-len (kview:label-separator-length kview))
 	start end sib)
     (while (> arg 0)
       (setq start (kotl-mode:tree-start)
 	    end   (kotl-mode:tree-end)
-	    sib   (kcell-view:sibling-p nil nil label-sep-len)
+	    sib   (kcell-view:sibling-p nil nil lbl-sep-len)
 	    arg (1- arg)
 	    killed t)
       ;; Don't want to delete any prior cells, so if on last cell, ensure
@@ -2493,11 +2493,11 @@ to one level and kotl-mode:refill-flag is treated as true."
   (if (< arg 0)
       (kotl-mode:demote-tree (- arg))
     (let* ((parent) (result)
-	   (label-sep-len (kview:label-separator-length kview))
+	   (lbl-sep-len (kview:label-separator-length kview))
 	   (orig-id (kcell-view:idstamp))
 	   (fill-p (= arg 0))
 	   (orig-pos-in-cell
-	    (- (point) (kcell-view:start nil label-sep-len)))
+	    (- (point) (kcell-view:start nil lbl-sep-len)))
 	   start-point)
       ;; Next line ensures point is in the root of the current tree if
       ;; the tree is at all hidden.
@@ -2509,7 +2509,7 @@ to one level and kotl-mode:refill-flag is treated as true."
 	  (progn
 	    (backward-char 1)
 	    (while (and (> arg 0)
-			(setq result (kcell-view:parent nil label-sep-len))
+			(setq result (kcell-view:parent nil lbl-sep-len))
 			(not (eq result 0)))
 	      (setq parent result
 		    arg (1- arg)))
@@ -2690,10 +2690,10 @@ that contains mark.
 With any other non-nil prefix ARG, take the current tree and move it past
 ARG visible cells."
   (interactive "*p")
-  (let ((label-sep-len (kview:label-separator-length kview)))
+  (let ((lbl-sep-len (kview:label-separator-length kview)))
     (cond
-     ((save-excursion (not (or (kcell-view:next t label-sep-len)
-			       (kcell-view:previous t label-sep-len))))
+     ((save-excursion (not (or (kcell-view:next t lbl-sep-len)
+			       (kcell-view:previous t lbl-sep-len))))
       (error "(kotl-mode:transpose-cells): Only one visible cell in outline"))
      ;;
      ;; Transpose current and previous cells or current and next cells, if no
@@ -2701,13 +2701,13 @@ ARG visible cells."
      ;; visible cell.
      ((= arg 1)
       (let ((label-1 (kcell-view:label))
-	    (prev (kcell-view:previous t label-sep-len))
+	    (prev (kcell-view:previous t lbl-sep-len))
 	    label-2)
-	(unless prev (kcell-view:next t label-sep-len))
+	(unless prev (kcell-view:next t lbl-sep-len))
 	(setq label-2 (kcell-view:label))
 	(kotl-mode:exchange-cells label-1 label-2)
-	(kcell-view:next t label-sep-len)
-	(when prev (kcell-view:next t label-sep-len))))
+	(kcell-view:next t lbl-sep-len)
+	(when prev (kcell-view:next t lbl-sep-len))))
      ;;
      ;; Transpose point and mark cells, moving point to the new location of the
      ;; cell which originally contained point.
@@ -2725,7 +2725,7 @@ ARG visible cells."
 			      (save-excursion (kotl-mode:next-line arg)))))
 	(kotl-mode:move-after
 	 (kcell-view:label)
-	 (progn (while (and (> arg 0) (kcell-view:next t label-sep-len))
+	 (progn (while (and (> arg 0) (kcell-view:next t lbl-sep-len))
 		  (setq arg (1- arg)))
 		(kcell-view:label))
 	 nil)
@@ -2972,10 +2972,10 @@ See also the documentation for `kotl-mode:cell-help'."
   (save-excursion
     (if (not all-flag)
 	(kotl-mode:print-attributes kview)
-      (let ((label-sep-len (kview:label-separator-length kview)))
+      (let ((lbl-sep-len (kview:label-separator-length kview)))
 	(kotl-mode:beginning-of-buffer)
 	(while (progn (kotl-mode:print-attributes kview)
-		      (kcell-view:next t label-sep-len)))))))
+		      (kcell-view:next t lbl-sep-len)))))))
 
 (defun kotl-mode:cell-help (&optional cell-ref cells-flag)
   "Display a temporary buffer with CELL-REF's attributes.
@@ -3217,15 +3217,15 @@ cases where `kotl-mode:shrink-region-flag' is nil."
   "Return end point of current cell's tree within this view.
 If optional OMIT-END-NEWLINES is non-nil, point returned precedes any
 newlines at end of tree."
-  (let* ((label-sep-len (kview:label-separator-length kview))
-	 (start-indent (kcell-view:indent nil label-sep-len))
+  (let* ((lbl-sep-len (kview:label-separator-length kview))
+	 (start-indent (kcell-view:indent nil lbl-sep-len))
 	 (next))
     (save-excursion
-      (while (and (setq next (kcell-view:next nil label-sep-len))
-		  (>= (- (kcell-view:indent nil label-sep-len) start-indent)
+      (while (and (setq next (kcell-view:next nil lbl-sep-len))
+		  (>= (- (kcell-view:indent nil lbl-sep-len) start-indent)
 		      (kview:level-indent kview))))
       (cond (next
-	     (goto-char (progn (kcell-view:previous nil label-sep-len)
+	     (goto-char (progn (kcell-view:previous nil lbl-sep-len)
 			       (kcell-view:end))))
 	    (t (goto-char (kcell-view:end))))
       (when omit-end-newlines
@@ -3359,16 +3359,16 @@ With optional BACKWARD-P, move backward if possible to get to valid position."
   "Move point to the nearest editable position within the current koutline view.
 With optional BACKWARD-P, move backward if possible to get to valid position."
   (unless (kview:valid-position-p)
-    (let ((label-sep-len (kview:label-separator-length kview)))
+    (let ((lbl-sep-len (kview:label-separator-length kview)))
       (cond ((kotl-mode:bobp)
-	     (goto-char (kcell-view:start nil label-sep-len)))
+	     (goto-char (kcell-view:start nil lbl-sep-len)))
 	    ((kotl-mode:eobp)
 	     (skip-chars-backward "\n\r"))
 	    (t (when (bolp)
 		 (if backward-p
 		     (skip-chars-backward "\n\r")
 		   (skip-chars-forward "\n\r")))
-	       (let ((indent (kcell-view:indent nil label-sep-len)))
+	       (let ((indent (kcell-view:indent nil lbl-sep-len)))
 		 (when (< (current-column) indent)
 		   (move-to-column indent))))))))
 

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:     15-Jul-22 at 22:07:35 by Mats Lidell
+;; Last-Mod:     16-Jul-22 at 22:33:04 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -2834,8 +2834,8 @@ within the current view."
   (kotl-mode:is-p)
   (let (buffer-read-only)
     (kview:map-tree (lambda (_kview)
-		      ;; Use free variable label-sep-len bound in kview:map-tree for speed.
-		      (kcell-view:collapse nil label-sep-len))
+		      ;; Use free variable kview-label-sep-len bound in kview:map-tree for speed.
+		      (kcell-view:collapse nil kview-label-sep-len))
 		    kview all-flag t)))
 
 (defun kotl-mode:expand-tree (&optional all-flag)
@@ -2847,8 +2847,8 @@ the current view."
   (let (buffer-read-only)
     (kview:map-tree
      (lambda (_kview)
-       ;; Use free variable label-sep-len bound in kview:map-tree for speed.
-       (goto-char (kcell-view:start (point) label-sep-len))
+       ;; Use free variable kview-label-sep-len bound in kview:map-tree for speed.
+       (goto-char (kcell-view:start (point) kview-label-sep-len))
        (outline-flag-region (point) (kcell-view:end-contents) nil))
      kview all-flag t)))
 

--- a/kotl/kview.el
+++ b/kotl/kview.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:     16-Jul-22 at 22:33:12 by Mats Lidell
+;; Last-Mod:     17-Jul-22 at 10:39:07 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -20,6 +20,7 @@
 (eval-and-compile (mapc #'require '(hact klabel kfill klink hypb)))
 ;; Quiet byte compiler warnings for this free variable.
 
+(define-obsolete-variable-alias 'label-sep-len 'kview-label-sep-len "8.0.1")
 (defvar kview-label-sep-len nil)
 
 ;;; ************************************************************************

--- a/kotl/kview.el
+++ b/kotl/kview.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:     15-Jul-22 at 23:25:24 by Mats Lidell
+;; Last-Mod:     16-Jul-22 at 22:33:12 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -19,8 +19,8 @@
 
 (eval-and-compile (mapc #'require '(hact klabel kfill klink hypb)))
 ;; Quiet byte compiler warnings for this free variable.
-(eval-when-compile
-  (defvar label-sep-len nil))
+
+(defvar kview-label-sep-len nil)
 
 ;;; ************************************************************************
 ;;; Public variables
@@ -394,7 +394,7 @@ characters of the cell whose level is desired."
 
 (defun kcell-view:lines-visible ()
   "Return the number of lines visible within the current cell."
-  ;; Use free variable label-sep-len bound in kview:map-* for speed.
+  ;; Use free variable kview-label-sep-len bound in kview:map-* for speed.
   (if (kcell-view:invisible-p)
       0
     (let* ((start (kcell-view:start nil (kview:label-separator-length kview)))
@@ -748,11 +748,11 @@ the lines displayed, since it has hidden branches."
   ;; subcells, indicating its branches are hidden.
   (kview:map-region
    (lambda ()
-     (cond ((kcell-view:next-invisible-p (point) label-sep-len)
+     (cond ((kcell-view:next-invisible-p (point) kview-label-sep-len)
 	    ;; Skip to end of this subtree
 	    (prog1 (- (kcell-view:lines-visible))
 	      (goto-char (kotl-mode:tree-end t))))
-	   ((kcell-view:collapsed-p (point) label-sep-len)
+	   ((kcell-view:collapsed-p (point) kview-label-sep-len)
 	    (kcell-view:lines-visible))
 	   (t 0)))
    kview t start end))
@@ -1192,7 +1192,7 @@ displayed, since it has hidden branches."
 	      ;; Hide the subtree of this cell and display only
 	      ;; (- status) lines.
 	      (kvspec:show-lines-this-cell (- status))
-	      (if (save-excursion (kcell-view:parent nil label-sep-len))
+	      (if (save-excursion (kcell-view:parent nil kview-label-sep-len))
 		  (kotl-mode:hide-subtree)
 		(error "(kview:set-cells-status): Invisible cell `%s' is missing its parent cell"
 		       (kcell-view:label))))

--- a/kotl/kview.el
+++ b/kotl/kview.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:     17-Jul-22 at 10:39:07 by Mats Lidell
+;; Last-Mod:     17-Jul-22 at 10:54:29 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -21,7 +21,8 @@
 ;; Quiet byte compiler warnings for this free variable.
 
 (define-obsolete-variable-alias 'label-sep-len 'kview-label-sep-len "8.0.1")
-(defvar kview-label-sep-len nil)
+(defvar kview-label-sep-len nil
+  "Length of the separation between cell's label and start of its contents.")
 
 ;;; ************************************************************************
 ;;; Public variables

--- a/kotl/kview.el
+++ b/kotl/kview.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:     17-Jul-22 at 10:54:29 by Mats Lidell
+;; Last-Mod:     17-Jul-22 at 11:09:42 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -85,25 +85,25 @@ Default value is 3."
 ;;; kcell-view - Kcell view-specific functions
 ;;;
 
-(defun kcell-view:backward (&optional visible-p label-sep-len)
+(defun kcell-view:backward (&optional visible-p lbl-sep-len)
   "Move to start of the prior cell at the same level as the current cell.
 With optional VISIBLE-P, consider only visible cells.
 Return t unless no such cell."
-  (or label-sep-len (setq label-sep-len
+  (or lbl-sep-len (setq lbl-sep-len
 			  (kview:label-separator-length kview)))
   (let ((opoint (point))
 	(found) (done)
 	(curr-indent 0)
-	(start-indent (kcell-view:indent nil label-sep-len)))
+	(start-indent (kcell-view:indent nil lbl-sep-len)))
     (while (and (not (or found done))
-		(kcell-view:previous visible-p label-sep-len))
+		(kcell-view:previous visible-p lbl-sep-len))
       (if (bobp)
 	  (progn (setq done t)
 		 (goto-char opoint))
-	(setq curr-indent (kcell-view:indent nil label-sep-len))
+	(setq curr-indent (kcell-view:indent nil lbl-sep-len))
 	(cond ((< (abs (- curr-indent start-indent))
 		  (kview:level-indent kview))
-	       (goto-char (kcell-view:start nil label-sep-len))
+	       (goto-char (kcell-view:start nil lbl-sep-len))
 	       (setq found t))
 	      ((< curr-indent start-indent)
 	       ;; Went past start of this tree without a match.
@@ -131,17 +131,17 @@ Trigger an error if CELL-REF is not a string or is not found."
 	      (t (error "(kcell:get-from-ref): No such Koutline cell: '%s'" cell-ref))))
     (error "(kcell:get-from-ref): cell-ref arg must be a string, not: %s" cell-ref)))
 
-(defun kcell-view:child (&optional visible-p label-sep-len)
+(defun kcell-view:child (&optional visible-p lbl-sep-len)
   "Move to start of current cell's child.
 With optional VISIBLE-P, consider only visible children.
 Return t unless cell has no matching child.
-Optional LABEL-SEP-LEN is the length of the separation between
+Optional LBL-SEP-LEN is the length of the separation between
 a cell's label and the start of its contents."
   (let* ((opoint (point))
-	 (prev-indent (kcell-view:indent nil label-sep-len))
-	 (next (kcell-view:next visible-p label-sep-len)))
-    (unless label-sep-len
-      (setq label-sep-len (kview:label-separator-length kview)))
+	 (prev-indent (kcell-view:indent nil lbl-sep-len))
+	 (next (kcell-view:next visible-p lbl-sep-len)))
+    (unless lbl-sep-len
+      (setq lbl-sep-len (kview:label-separator-length kview)))
     ;; Since kcell-view:next leaves point at the start of a cell, the cell's
     ;; indent is just the current-column of point.
     (if (and next (>= (- (current-column) prev-indent)
@@ -151,52 +151,52 @@ a cell's label and the start of its contents."
       (goto-char opoint)
       nil)))
 
-(defun kcell-view:child-p (&optional pos visible-p label-sep-len)
+(defun kcell-view:child-p (&optional pos visible-p lbl-sep-len)
   "Return t if cell at optional POS or point has a child.
 With optional VISIBLE-P, consider only visible children.
-Optional LABEL-SEP-LEN is the length of the separation between
+Optional LBL-SEP-LEN is the length of the separation between
 a cell's label and the start of its contents."
   (save-excursion
     (when pos
       (goto-char pos))
-    (kcell-view:child visible-p label-sep-len)))
+    (kcell-view:child visible-p lbl-sep-len)))
 
-(defun kcell-view:collapse (&optional pos label-sep-len)
+(defun kcell-view:collapse (&optional pos lbl-sep-len)
   "Collapse cell at optional POS or point to a single line within the current view.
-Optional LABEL-SEP-LEN is the length of the separation between
+Optional LBL-SEP-LEN is the length of the separation between
 a cell's label and the start of its contents."
   (save-excursion
-    (goto-char (kcell-view:start pos label-sep-len))
+    (goto-char (kcell-view:start pos lbl-sep-len))
     (kview:end-of-actual-line)
     (outline-flag-region (point) (kcell-view:end-contents) t)))
 
-(defun kcell-view:collapsed-p (&optional pos label-sep-len)
+(defun kcell-view:collapsed-p (&optional pos lbl-sep-len)
   "Return t if cell at optional POS or point is collapsed within the current view.
-Optional LABEL-SEP-LEN is the length of the separation between
+Optional LBL-SEP-LEN is the length of the separation between
 a cell's label and the start of its contents.
 
 A cell may be collapsed yet still have some of its text visible.  Use
 `kcell-view:invisible-p' to test for invisibility."
   (when (memq 'outline (mapcar (lambda (o) (overlay-get o 'invisible))
 			       ;; Allow for empty cell
-			       (overlays-in (1- (kcell-view:start pos label-sep-len))
+			       (overlays-in (1- (kcell-view:start pos lbl-sep-len))
 					    (kcell-view:end-contents pos))))
     t))
 
-(defun kcell-view:hide (&optional pos label-sep-len)
+(defun kcell-view:hide (&optional pos lbl-sep-len)
   "Make cell at optional POS or point invisible within the current view.
-Optional LABEL-SEP-LEN is the length of the separation between
+Optional LBL-SEP-LEN is the length of the separation between
 a cell's label and the start of its contents."
-  (kcell-view:expand pos label-sep-len t))
+  (kcell-view:expand pos lbl-sep-len t))
 
-(defun kcell-view:invisible-p (&optional pos label-sep-len)
+(defun kcell-view:invisible-p (&optional pos lbl-sep-len)
   "Return t if cell at optional POS or point is entirely invisible within the current view.
-Optional LABEL-SEP-LEN is the length of the separation between
+Optional LBL-SEP-LEN is the length of the separation between
 a cell's label and the start of its contents.
 
 Any cell that is invisible is also collapsed as indicated by a call to
 `kcell-view:collapsed-p'."
-  (let ((start (1- (kcell-view:start pos label-sep-len))) ;; Allow for empty cell
+  (let ((start (1- (kcell-view:start pos lbl-sep-len))) ;; Allow for empty cell
 	(end (kcell-view:end-contents pos)))
     (when (delq nil (mapcar (lambda (o)
 			      (and (eq (overlay-get o 'invisible) 'outline)
@@ -293,28 +293,28 @@ Excludes blank lines following cell contents."
     (skip-chars-backward "\n\r")
     (point)))
 
-(defun kcell-view:expand (&optional pos label-sep-len hide-p)
+(defun kcell-view:expand (&optional pos lbl-sep-len hide-p)
   "Expand cell at optional POS or point within the current view."
   (save-excursion
-    (goto-char (kcell-view:start pos label-sep-len))
+    (goto-char (kcell-view:start pos lbl-sep-len))
     (outline-flag-region (point) (kcell-view:end-contents) hide-p)))
 
-(defun kcell-view:forward (&optional visible-p label-sep-len)
+(defun kcell-view:forward (&optional visible-p lbl-sep-len)
   "Move to start of the following cell at the same level as the current cell.
 With optional VISIBLE-P, consider only visible cells.
 Return t unless no such cell."
-  (unless label-sep-len
-    (setq label-sep-len (kview:label-separator-length kview)))
+  (unless lbl-sep-len
+    (setq lbl-sep-len (kview:label-separator-length kview)))
   (let ((opoint (point))
 	(found) (done)
 	(curr-indent 0)
-	(start-indent (kcell-view:indent nil label-sep-len)))
+	(start-indent (kcell-view:indent nil lbl-sep-len)))
     (while (and (not (or found done))
-		(kcell-view:next visible-p label-sep-len))
-      (setq curr-indent (kcell-view:indent nil label-sep-len))
+		(kcell-view:next visible-p lbl-sep-len))
+      (setq curr-indent (kcell-view:indent nil lbl-sep-len))
       (cond ((< (abs (- curr-indent start-indent))
 		(kview:level-indent kview))
-	     (goto-char (kcell-view:start nil label-sep-len))
+	     (goto-char (kcell-view:start nil lbl-sep-len))
 	     (setq found t))
 	    ((< curr-indent start-indent)
 	     ;; Went past end of this tree without a match.
@@ -352,14 +352,14 @@ Use 0 for POS to retrieve top cell's attributes."
     (goto-char (or pos (kcell-view:plist-point)))
     (format "0%s" (or (kproperty:get (point) 'idstamp) ""))))
 
-(defun kcell-view:indent (&optional pos label-sep-len)
+(defun kcell-view:indent (&optional pos lbl-sep-len)
   "Return indentation of cell at optional POS or point.
-Optional LABEL-SEP-LEN is the view-specific length of the separator between a
+Optional LBL-SEP-LEN is the view-specific length of the separator between a
 cell's label and the start of its contents."
   (+ (save-excursion
        (kcell-view:to-label-end pos)
        (current-column))
-     (or label-sep-len (kview:label-separator-length kview))))
+     (or lbl-sep-len (kview:label-separator-length kview))))
 
 (defun kcell-view:label (&optional pos)
   "Return displayed label string of cell at optional POS or point.
@@ -374,15 +374,15 @@ If labels are off, return cell's idstamp as a string."
 	(buffer-substring-no-properties (point) (progn (skip-chars-backward "^ \t\n\r")
 						       (point)))))))
 
-(defun kcell-view:level (&optional pos label-sep-len indent)
+(defun kcell-view:level (&optional pos lbl-sep-len indent)
   "Return the outline level of the current cell or the one at optional POS.
 0 = top cell level, 1 = 1st level of the outline.  Optional
-LABEL-SEP-LEN is the number of spaces between a cell label and
+LBL-SEP-LEN is the number of spaces between a cell label and
 the start of its body.  Optional INDENT is the indentation in
 characters of the cell whose level is desired."
-  (unless label-sep-len
-    (setq label-sep-len (kview:label-separator-length kview)))
-  (floor (/ (- (or indent (kcell-view:indent pos label-sep-len)) label-sep-len)
+  (unless lbl-sep-len
+    (setq lbl-sep-len (kview:label-separator-length kview)))
+  (floor (/ (- (or indent (kcell-view:indent pos lbl-sep-len)) lbl-sep-len)
 	    (kview:level-indent kview))))
 
 (defun kcell-view:line (&optional pos)
@@ -404,18 +404,18 @@ characters of the cell whose level is desired."
       ;; Prevent bounds error with empty cells that have hidden subtrees.
       (max 1 (count-lines start end)))))
 
-(defun kcell-view:next (&optional visible-p label-sep-len)
+(defun kcell-view:next (&optional visible-p lbl-sep-len)
   "Move to start of next cell within current view.
 With optional VISIBLE-P, consider only visible cells.
 Return t unless no next cell."
-  (when (kcell-view:next-kcell visible-p label-sep-len)
-    (goto-char (kcell-view:start nil label-sep-len))
+  (when (kcell-view:next-kcell visible-p lbl-sep-len)
+    (goto-char (kcell-view:start nil lbl-sep-len))
     t))
 
-(defun kcell-view:next-invisible-p (&optional _pos label-sep-len)
+(defun kcell-view:next-invisible-p (&optional _pos lbl-sep-len)
   "Return t if there is a next cell after optional POS or point and it is invisible."
-  (save-excursion (and (kcell-view:next nil label-sep-len)
-		       (kcell-view:invisible-p (point) label-sep-len))))
+  (save-excursion (and (kcell-view:next nil lbl-sep-len)
+		       (kcell-view:invisible-p (point) lbl-sep-len))))
 
 (defun kcell-view:operate (function &optional start end)
   "Invoke FUNCTION with view restricted to current cell contents.
@@ -425,34 +425,34 @@ Optional START and END are start and endpoints of cell to use."
 		      (or end (kcell-view:end-contents)))
     (funcall function)))
 
-(defun kcell-view:parent (&optional visible-p label-sep-len)
+(defun kcell-view:parent (&optional visible-p lbl-sep-len)
   "Move to start of current cell's parent within current view.
 If parent is top cell, move to first cell within view and return 0.
 Otherwise, return t unless optional VISIBLE-P is non-nil and the parent cell
 is not part of the current view, else nil."
-  (unless label-sep-len
-    (setq label-sep-len (kview:label-separator-length kview)))
+  (unless lbl-sep-len
+    (setq lbl-sep-len (kview:label-separator-length kview)))
   (let ((opoint (point))
-	(parent-level (1- (kcell-view:level nil label-sep-len))))
+	(parent-level (1- (kcell-view:level nil lbl-sep-len))))
     (if (= parent-level 0) ;; top cell
 	(progn (goto-char (point-min))
-	       (goto-char (kcell-view:start nil label-sep-len))
+	       (goto-char (kcell-view:start nil lbl-sep-len))
 	       0)
       ;; Skip from point back past any siblings
-      (while (kcell-view:backward visible-p label-sep-len))
+      (while (kcell-view:backward visible-p lbl-sep-len))
       ;; Move back to parent.
-      (if (kcell-view:previous visible-p label-sep-len)
+      (if (kcell-view:previous visible-p lbl-sep-len)
 	  t
 	;; Move back to previous point and return nil.
 	(goto-char opoint)
 	nil))))
 
-(defun kcell-view:previous (&optional visible-p label-sep-len)
+(defun kcell-view:previous (&optional visible-p lbl-sep-len)
   "Move to start of previous cell within current view.
 With optional VISIBLE-P, consider only visible cells.
 Return t unless no previous cell."
-  (when (kcell-view:previous-kcell visible-p label-sep-len)
-    (goto-char (kcell-view:start nil label-sep-len))
+  (when (kcell-view:previous-kcell visible-p lbl-sep-len)
+    (goto-char (kcell-view:start nil lbl-sep-len))
     t))
 
 (defun kcell-view:plist (&optional pos)
@@ -542,19 +542,19 @@ Use 0 for POS to set top cell's attributes."
     (kproperty:add-properties
      (list 'idstamp idstamp 'kcell kcell))))
 
-(defun kcell-view:sibling-p (&optional pos visible-p label-sep-len)
+(defun kcell-view:sibling-p (&optional pos visible-p lbl-sep-len)
   "Return t if cell at optional POS or point has a successor.
 With optional VISIBLE-P, consider only visible siblings."
   (save-excursion
     (when pos
       (goto-char pos))
-    (kcell-view:forward visible-p label-sep-len)))
+    (kcell-view:forward visible-p lbl-sep-len)))
 
-(defun kcell-view:start (&optional pos label-sep-len)
+(defun kcell-view:start (&optional pos lbl-sep-len)
   "Return start position of visible cell contents from optional POS or point."
   (save-excursion
     (+ (kcell-view:to-label-end pos)
-       (or label-sep-len (kview:label-separator-length kview)))))
+       (or lbl-sep-len (kview:label-separator-length kview)))))
 
 (defun kcell-view:to-visible-label-end (&optional pos)
   "Move point to the end of the current visible cell's label (before the label separator).
@@ -695,13 +695,13 @@ With optional JUSTIFY, justify region as well.
 Fill-prefix must be a string of spaces the length of this cell's indent, when
 this function is called."
   (let ((opoint (set-marker (make-marker) (point)))
-	(label-sep-len (kview:label-separator-length kview))
+	(lbl-sep-len (kview:label-separator-length kview))
 	(continue t)
 	prev-point)
     (goto-char start)
     (while continue
       (if (kcell:get-attr (or kcell (kcell-view:cell)) 'no-fill)
-	  (setq continue (kcell-view:next nil label-sep-len))
+	  (setq continue (kcell-view:next nil lbl-sep-len))
 	(fill-paragraph justify t)
 	(setq prev-point (point))
 	(forward-paragraph)
@@ -892,24 +892,24 @@ FUNC should take one argument, the kview local variable of the current
 buffer or some other kview, and should operate upon the cell at point.
 
 `Cell-indent' contains the indentation value of the first cell mapped when
-FUNC is called so that it may test against this value.  `Label-sep-len'
+FUNC is called so that it may test against this value.  `lbl-sep-len'
 contains the label separator length.
 
 See also `kview:map-region', `kview:map-siblings' and `kview:map-tree'."
   (with-current-buffer (kview:buffer kview)
     (save-excursion
       (let ((results)
-	    (label-sep-len (kview:label-separator-length kview))
+	    (lbl-sep-len (kview:label-separator-length kview))
 	    cell-indent)
 	(when first-p
 	  ;; Move back to first predecessor at same level.
-	  (while (kcell-view:backward t label-sep-len)))
-	(setq cell-indent (kcell-view:indent nil label-sep-len))
+	  (while (kcell-view:backward t lbl-sep-len)))
+	(setq cell-indent (kcell-view:indent nil lbl-sep-len))
 	;; Terminate when no further cells or when reach a cell at an equal
 	;; or higher level in the kotl than the first cell that we processed.
 	(while (and (setq results (cons (funcall func kview) results))
-		    (kcell-view:next visible-p label-sep-len)
-		    (>= (- (kcell-view:indent nil label-sep-len) cell-indent)
+		    (kcell-view:next visible-p lbl-sep-len)
+		    (>= (- (kcell-view:indent nil lbl-sep-len) cell-indent)
 			(kview:level-indent kview))))
 	(nreverse results)))))
 
@@ -921,13 +921,13 @@ than the bounds of the active region.
 
 FUNC should take no arguments and should operate upon the cell at point.
 
-`Label-sep-len’ contains the label separator length.
+`lbl-sep-len’ contains the label separator length.
 
 See also `kview:map-tree', `kview:map-branch’, and ‘kview:map-siblings’."
   (with-current-buffer (kview:buffer kview)
     (save-excursion
       (let* ((results)
-	     (label-sep-len (kview:label-separator-length kview))
+	     (lbl-sep-len (kview:label-separator-length kview))
 	     (bounds-given (and (or (integerp start) (markerp start))
 				(or (integerp end) (markerp end))
 				(<= start end)))
@@ -948,7 +948,7 @@ See also `kview:map-tree', `kview:map-branch’, and ‘kview:map-siblings’."
 		 (kotl-mode:to-valid-position))
 	       ;; Terminate when no further cells within the region.
 	       (while (and (setq results (cons (funcall func) results))
-			   (kcell-view:next visible-p label-sep-len)
+			   (kcell-view:next visible-p lbl-sep-len)
 			   (<= (point) end)))
 	       (nreverse results))
 	      (t (error "(kview:map-region): No region or invalid start and end positions")))))))
@@ -964,13 +964,13 @@ buffer or some other kview, and should operate upon the cell at point.
 
 The variable `cell-indent' contains the indentation value of the
 first cell mapped when FUNC is called so that it may be tested
-against this value.  The variable `label-sep-len' contains the label
+against this value.  The variable `lbl-sep-len' contains the label
 separator length.
 
 See also `kview:map-branch' and `kview:map-tree'."
   (with-current-buffer (kview:buffer kview)
     (save-excursion
-      (let ((label-sep-len (kview:label-separator-length kview))
+      (let ((lbl-sep-len (kview:label-separator-length kview))
 	    cell-indent
 	    results)
 	;; Next line ensures point is in the root of the current tree if
@@ -979,11 +979,11 @@ See also `kview:map-branch' and `kview:map-tree'."
 	  (kotl-mode:to-start-of-line))
 	(when first-p
 	  ;; Move back to first predecessor at same level.
-	  (while (kcell-view:backward t label-sep-len)))
-	(setq cell-indent (kcell-view:indent nil label-sep-len))
+	  (while (kcell-view:backward t lbl-sep-len)))
+	(setq cell-indent (kcell-view:indent nil lbl-sep-len))
 	;; Terminate when no further cells at same level.
 	(while (progn (setq results (cons (funcall func kview) results))
-		      (kcell-view:forward visible-p label-sep-len)))
+		      (kcell-view:forward visible-p lbl-sep-len)))
 	(nreverse results)))))
 
 (defun kview:map-expanded-tree (func kview &optional top-p)
@@ -1000,7 +1000,7 @@ operate upon the cell at point.
 
 The variable `cell-indent' contains the indentation value of the
 first cell mapped when FUNC is called so that it may be tested
-against this value.  The variable `label-sep-len' contains the label
+against this value.  The variable `lbl-sep-len' contains the label
 separator length.
 
 See also `kview:map-region', `kview:map-branch' and `kview:map-siblings'."
@@ -1011,7 +1011,7 @@ See also `kview:map-region', `kview:map-branch' and `kview:map-siblings'."
 	(unless top-p
 	  (kotl-mode:to-start-of-line))
 	(let* ((results)
-	       (label-sep-len (kview:label-separator-length kview))
+	       (lbl-sep-len (kview:label-separator-length kview))
 	       (start (set-marker (make-marker) (if top-p (point-min) (point))))
 	       (end (set-marker (make-marker) (if top-p (point-max) (save-excursion (kotl-mode:tree-end)))))
 	       (collapsed-cells (kview:get-cells-status kview start end))
@@ -1025,13 +1025,13 @@ See also `kview:map-region', `kview:map-branch' and `kview:map-siblings'."
 		     (kview:end-of-actual-line)
 		     ;; Terminate when no further cells to process.
 		     (while (progn (setq results (cons (funcall func kview) results))
-				   (kcell-view:next nil label-sep-len))))
-	    (setq cell-indent (kcell-view:indent nil label-sep-len))
+				   (kcell-view:next nil lbl-sep-len))))
+	    (setq cell-indent (kcell-view:indent nil lbl-sep-len))
 	    ;; Terminate when no further cells or when reach a cell at an equal
 	    ;; or higher level in the kotl than the first cell that we processed.
 	    (while (and (setq results (cons (funcall func kview) results))
-			(kcell-view:next nil label-sep-len)
-			(>= (- (kcell-view:indent nil label-sep-len) cell-indent)
+			(kcell-view:next nil lbl-sep-len)
+			(>= (- (kcell-view:indent nil lbl-sep-len) cell-indent)
 			    (kview:level-indent kview)))))
 	  ;;
 	  ;; Restore status of temporarily expanded cells.
@@ -1054,30 +1054,30 @@ should operate upon the cell at point.
 
 The variable `cell-indent' contains the indentation value of the
 first cell mapped when FUNC is called so that it may be tested
-against this value.  The variable `label-sep-len' contains the label
+against this value.  The variable `lbl-sep-len' contains the label
 separator length.
 
 See also `kview:map-region', `kview:map-branch' and `kview:map-siblings'."
     (with-current-buffer (kview:buffer kview)
       (save-excursion
 	(let ((results)
-	      (label-sep-len (kview:label-separator-length kview))
+	      (lbl-sep-len (kview:label-separator-length kview))
 	      cell-indent)
 	  (if top-p
 	      (progn (goto-char (point-min))
 		     (kview:end-of-actual-line)
 		     ;; Terminate when no further cells to process.
 		     (while (progn (setq results (cons (funcall func kview) results))
-				   (kcell-view:next visible-p label-sep-len))))
+				   (kcell-view:next visible-p lbl-sep-len))))
 	    ;; Next line ensures point is in the root of the current tree if
 	    ;; the tree is at all hidden.
 	    (kotl-mode:to-start-of-line)
-	    (setq cell-indent (kcell-view:indent nil label-sep-len))
+	    (setq cell-indent (kcell-view:indent nil lbl-sep-len))
 	    ;; Terminate when no further cells or when reach a cell at an equal
 	    ;; or higher level in the kotl than the first cell that we processed.
 	    (while (and (setq results (cons (funcall func kview) results))
-			(kcell-view:next visible-p label-sep-len)
-			(>= (- (kcell-view:indent nil label-sep-len) cell-indent)
+			(kcell-view:next visible-p lbl-sep-len)
+			(>= (- (kcell-view:indent nil lbl-sep-len) cell-indent)
 			    (kview:level-indent kview)))))
 	  (nreverse results)))))
 
@@ -1269,7 +1269,7 @@ or marker, `%s'" pos))
   "Return the value of OBJ's ATTRIBUTE."
   (cadr (memq attribute (cadr (memq 'plist obj)))))
 
-(defun kcell-view:next-kcell (&optional visible-p label-sep-len)
+(defun kcell-view:next-kcell (&optional visible-p lbl-sep-len)
   "Move to the point holding the kcell property within the next cell of the current kview.
 With optional VISIBLE-P, consider only visible cells.  Return t
 unless no next cell."
@@ -1277,12 +1277,12 @@ unless no next cell."
 	 (pos opoint))
     (while (and (setq pos (kproperty:next-single-change pos 'kcell))
 		(or (not (kproperty:get pos 'kcell))
-		    (and visible-p (kcell-view:invisible-p pos label-sep-len)))))
+		    (and visible-p (kcell-view:invisible-p pos lbl-sep-len)))))
     (if (and pos (/= pos opoint) (kproperty:get pos 'kcell)
-	     (if visible-p (not (kcell-view:invisible-p pos label-sep-len)) t))
+	     (if visible-p (not (kcell-view:invisible-p pos lbl-sep-len)) t))
 	(progn (goto-char pos) t))))
 
-(defun kcell-view:previous-kcell (&optional visible-p label-sep-len)
+(defun kcell-view:previous-kcell (&optional visible-p lbl-sep-len)
   "Move to the point holding the kcell property within the previous cell of the current kview.
 With optional VISIBLE-P, consider only visible cells.  Return t
 unless no previous cell."
@@ -1296,9 +1296,9 @@ unless no previous cell."
 	    pos (kproperty:previous-single-change pos 'kcell)))
     (while (and pos (setq pos (kproperty:previous-single-change pos 'kcell))
 		(or (not (kproperty:get pos 'kcell))
-		    (and visible-p (kcell-view:invisible-p pos label-sep-len)))))
+		    (and visible-p (kcell-view:invisible-p pos lbl-sep-len)))))
     (if (and pos (/= pos opoint) (kproperty:get pos 'kcell)
-	     (if visible-p (not (kcell-view:invisible-p pos label-sep-len)) t))
+	     (if visible-p (not (kcell-view:invisible-p pos lbl-sep-len)) t))
 	(progn (goto-char pos) t))))
 
 (defun kview:set-attr (obj attribute value)

--- a/kotl/kvspec.el
+++ b/kotl/kvspec.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Oct-95 at 15:17:07
-;; Last-Mod:     15-Jul-22 at 23:25:45 by Mats Lidell
+;; Last-Mod:     16-Jul-22 at 22:33:26 by Mats Lidell
 ;;
 ;; Copyright (C) 1995-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -55,11 +55,6 @@
 
 (require 'hact) ;; Ensure symtable:add is defined.
 (require 'kview)
-
-;; Quiet byte compiler warnings for these free variables.
-(eval-when-compile
-  (defvar label-sep-len nil)
-  (defvar modeline-format nil))
 
 ;;; ************************************************************************
 ;;; Public variables
@@ -262,9 +257,9 @@ view specs."
 (defun kvspec:show-lines-this-cell (num)
   "Assume the current cell is fully expanded and collapse to show NUM lines within it.
 If NUM is less than 1 or greater than the number of lines available, the cell remains fully expanded."
-  ;; Use free variable label-sep-len bound in kview:map-* for speed.
+  ;; Use free variable kview-label-sep-len bound in kview:map-* for speed.
   (unless (< num 1)
-    (let ((_start (goto-char (kcell-view:start (point) label-sep-len)))
+    (let ((_start (goto-char (kcell-view:start (point) kview-label-sep-len)))
 	  (end (kcell-view:end-contents)))
       ;; Hide all but num lines of the cell.
       (and (search-forward "\n" end t num)


### PR DESCRIPTION
## What

Rename global var to remove shadowing warnings.

## Why

By renaming the global variable to `kview-label-sep-len` the functionality is kept intact. The shadowing warnings are by this removed. It remains to analyze if there is any code that relies on dynamic binding. 

Note that this PR should not make the situation worse or even change. It just makes it clear where the global variable is used. With lexical scoping the value passed in to functions will not affect functions using the global variable.