### PR TITLE
Simplify test case by only testing unquoted file name

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2022-07-12  Mats Lidell  <matsl@gnu.org>
+
+* test/hpath-tests.el (hpath:auto-variable-alist-load-path-test): Simplify
+    test case to only test with unquoted file name.
+
 2022-07-11  Mats Lidell  <matsl@gnu.org>
 
 * test/hy-test-helpers.el (hy-test-helpers:should-last-message): Use

--- a/test/hpath-tests.el
+++ b/test/hpath-tests.el
@@ -3,9 +3,9 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    28-Feb-21 at 23:26:00
-;; Last-Mod:      6-Feb-22 at 00:56:13 by Bob Weiner
+;; Last-Mod:     12-Jul-22 at 23:09:14 by Mats Lidell
 ;;
-;; Copyright (C) 2021  Free Software Foundation, Inc.
+;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.
@@ -210,19 +210,18 @@
             (hy-test-helpers:action-key-should-call-hpath:find (expand-file-name file hyperb:dir))))
       (kill-buffer shell-buffer))))
 
-(defun hpath-tests--insert (str &optional with-quotes)
-  "Insert STR with quotes if WITH-QUOTES is not nil."
-  (concat (when with-quotes "\"") str (when with-quotes "\"")))
-
 (ert-deftest hpath:auto-variable-alist-load-path-test ()
  "An elisp file, even without double quotes, should be looked up in the load path."
   (let ((load-path (list (expand-file-name "kotl" hyperb:dir)))
         (el-file "kview.el"))
-    (dolist (with-quotes '(nil t))
-      (with-temp-buffer
-        (insert (hpath-tests--insert el-file))
-        (goto-char 4)
-        (hy-test-helpers:action-key-should-call-hpath:find (expand-file-name el-file (car load-path)))))))
+    (with-temp-buffer
+      (insert el-file)
+      (goto-char 4)
+      (hy-test-helpers:action-key-should-call-hpath:find (expand-file-name el-file (car load-path))))))
+
+(defun hpath-tests--insert (str &optional with-quotes)
+  "Insert STR with quotes if WITH-QUOTES is not nil."
+  (concat (when with-quotes "\"") str (when with-quotes "\"")))
 
 (ert-deftest hpath:auto-variable-alist-org-folder-test ()
   "An org file should be looked up in the org directory."


### PR DESCRIPTION
## What

Simplify test case by only testing unquoted file name.

## Why

Testcase was running the same test twice since the `with-quotes` var was not used. Only testing with unquoted file name is needed so removed the unused code to only test that once.