### PR TITLE
Clean up after test case

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,9 @@
 * test/hpath-tests.el (hpath:auto-variable-alist-load-path-test): Simplify
     test case to only test with unquoted file name.
 
+* test/hui-tests.el (hui-gbut-edit-link-to-file-button): Remove test file
+    after test case is completed.
+
 2022-07-11  Mats Lidell  <matsl@gnu.org>
 
 * test/hy-test-helpers.el (hy-test-helpers:should-last-message): Use

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     27-Apr-22 at 23:24:09 by Mats Lidell
+;; Last-Mod:     12-Jul-22 at 23:25:15 by Mats Lidell
 ;;
 ;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -72,6 +72,7 @@
       (save-excursion
 	(set-buffer gbut-file-buffer)
 	(save-buffer))
+      (delete-file linked-file)
       (when (file-writable-p hbmap:dir-user)
 	(delete-directory hbmap:dir-user t)))))
 


### PR DESCRIPTION
## What

Clean up after test case

## Why

A test file was not deleted after the test case was over so created garbage in the `/tmp` folder.