### PR TITLE
Use replace regexp in string

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2022-07-15  Mats Lidell  <matsl@gnu.org>
+
+* test/hypb-tests.el: Remove test cases for hypb:replace-match-string.
+
+* hypb.el (hypb:replace-match-string): Mark as obsolete. Replace all
+    calls, in numerous places, to use replace-regexp-in-string.
+
 2022-07-13  Stefan Monnier  <monnier@iro.umontreal.ca>
 
 * hrmail.el (rmail-cease-edit, rmail-forward, rmail-get-new-mail)

--- a/hargs.el
+++ b/hargs.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    31-Oct-91 at 23:17:35
-;; Last-Mod:     15-Jul-22 at 21:21:12 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 22:07:35 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -150,7 +150,7 @@ With optional EXCLUDE-REGEXP, any matched string is ignored if it matches this r
 	     (>= end opoint)
 	     (let ((string (hargs:buffer-substring start end)))
 	       (unless (and (stringp exclude-regexp) (string-match exclude-regexp string) )
-		 (setq string (hypb:replace-match-string "[\n\r\f]\\s-*" " " string nil t))
+		 (setq string (replace-regexp-in-string "[\n\r\f]\\s-*" " " string nil t))
 		 (unless hyperb:microsoft-os-p
 		   (setq string (hpath:mswindows-to-posix string)))
 		 (if list-positions-flag

--- a/hargs.el
+++ b/hargs.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    31-Oct-91 at 23:17:35
-;; Last-Mod:     15-Jul-22 at 20:00:09 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 21:21:12 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -150,7 +150,7 @@ With optional EXCLUDE-REGEXP, any matched string is ignored if it matches this r
 	     (>= end opoint)
 	     (let ((string (hargs:buffer-substring start end)))
 	       (unless (and (stringp exclude-regexp) (string-match exclude-regexp string) )
-		 (setq string (hypb:replace-match-string "[\n\r\f]\\s-*" " " string t))
+		 (setq string (hypb:replace-match-string "[\n\r\f]\\s-*" " " string nil t))
 		 (unless hyperb:microsoft-os-p
 		   (setq string (hpath:mswindows-to-posix string)))
 		 (if list-positions-flag

--- a/hargs.el
+++ b/hargs.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    31-Oct-91 at 23:17:35
-;; Last-Mod:     20-Feb-22 at 22:15:24 by Bob Weiner
+;; Last-Mod:     15-Jul-22 at 20:00:09 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -150,7 +150,7 @@ With optional EXCLUDE-REGEXP, any matched string is ignored if it matches this r
 	     (>= end opoint)
 	     (let ((string (hargs:buffer-substring start end)))
 	       (unless (and (stringp exclude-regexp) (string-match exclude-regexp string) )
-		 (setq string (hypb:replace-match-string "[\n\r\f]\\s-*" string " " t))
+		 (setq string (hypb:replace-match-string "[\n\r\f]\\s-*" " " string t))
 		 (unless hyperb:microsoft-os-p
 		   (setq string (hpath:mswindows-to-posix string)))
 		 (if list-positions-flag

--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:     15-May-22 at 23:07:36 by Bob Weiner
+;; Last-Mod:     15-Jul-22 at 20:00:09 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -1032,7 +1032,7 @@ Ignore email-related buffers."
   (when (string-match "\n" label)
     (mapc (lambda (prefix)
 	    (when (string-match "\n" label)
-	      (setq label (hypb:replace-match-string prefix label " " t))))
+	      (setq label (hypb:replace-match-string prefix " " label t))))
 	  hbut:fill-prefix-regexps))
   label)
 
@@ -1261,9 +1261,9 @@ whitespace sequences with `_'."
     (setq label (hbut:fill-prefix-remove label)
 	  ;; Remove leading and trailing space.
 	  label (hypb:replace-match-string "\\`[ \t\n\r]+\\|[ \t\n\r]+\\'"
-					   label "" t)
-	  label (hypb:replace-match-string "_" label "__" t))
-    (hypb:replace-match-string "[ \t\n\r]+" label "_" t)))
+					   "" label t)
+	  label (hypb:replace-match-string "_" "__" label t))
+    (hypb:replace-match-string "[ \t\n\r]+" "_" label t)))
 
 (defun    hbut:map (but-func &optional start-delim end-delim
 			     regexp-match include-delims)

--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:     15-Jul-22 at 20:00:09 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 21:06:06 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -1032,7 +1032,7 @@ Ignore email-related buffers."
   (when (string-match "\n" label)
     (mapc (lambda (prefix)
 	    (when (string-match "\n" label)
-	      (setq label (hypb:replace-match-string prefix " " label t))))
+	      (setq label (hypb:replace-match-string prefix " " label nil t))))
 	  hbut:fill-prefix-regexps))
   label)
 
@@ -1261,9 +1261,9 @@ whitespace sequences with `_'."
     (setq label (hbut:fill-prefix-remove label)
 	  ;; Remove leading and trailing space.
 	  label (hypb:replace-match-string "\\`[ \t\n\r]+\\|[ \t\n\r]+\\'"
-					   "" label t)
-	  label (hypb:replace-match-string "_" "__" label t))
-    (hypb:replace-match-string "[ \t\n\r]+" "_" label t)))
+					   "" label nil t)
+	  label (hypb:replace-match-string "_" "__" label nil t))
+    (hypb:replace-match-string "[ \t\n\r]+" "_" label nil t)))
 
 (defun    hbut:map (but-func &optional start-delim end-delim
 			     regexp-match include-delims)

--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:     15-Jul-22 at 21:06:06 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 22:07:35 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -1032,7 +1032,7 @@ Ignore email-related buffers."
   (when (string-match "\n" label)
     (mapc (lambda (prefix)
 	    (when (string-match "\n" label)
-	      (setq label (hypb:replace-match-string prefix " " label nil t))))
+	      (setq label (replace-regexp-in-string prefix " " label nil t))))
 	  hbut:fill-prefix-regexps))
   label)
 
@@ -1260,10 +1260,10 @@ whitespace sequences with `_'."
   (when label
     (setq label (hbut:fill-prefix-remove label)
 	  ;; Remove leading and trailing space.
-	  label (hypb:replace-match-string "\\`[ \t\n\r]+\\|[ \t\n\r]+\\'"
+	  label (replace-regexp-in-string "\\`[ \t\n\r]+\\|[ \t\n\r]+\\'"
 					   "" label nil t)
-	  label (hypb:replace-match-string "_" "__" label nil t))
-    (hypb:replace-match-string "[ \t\n\r]+" "_" label nil t)))
+	  label (replace-regexp-in-string "_" "__" label nil t))
+    (replace-regexp-in-string "[ \t\n\r]+" "_" label nil t)))
 
 (defun    hbut:map (but-func &optional start-delim end-delim
 			     regexp-match include-delims)

--- a/hib-kbd.el
+++ b/hib-kbd.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    22-Nov-91 at 01:37:57
-;; Last-Mod:     12-Jun-22 at 15:57:09 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 20:00:09 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -289,33 +289,33 @@ keyboad input queue, as if they had been typed by the user."
 		   norm-key-series (kbd-key:mark-spaces-to-keep norm-key-series "<" ">")
 		   norm-key-series (kbd-key:mark-spaces-to-keep norm-key-series "\"" "\"")
 		   norm-key-series (hypb:replace-match-string
-				    "<DEL>\\|<DELETE>\\|@key{DEL}\\|\\<DEL\\>" norm-key-series " DEL " t)
+				    "<DEL>\\|<DELETE>\\|@key{DEL}\\|\\<DEL\\>" " DEL " norm-key-series t)
 		   norm-key-series (hypb:replace-match-string
-				    "<BS>\\|<BACKSPACE>\\|@key{BS}\\|\\<BS\\>" norm-key-series " BS " t)
+				    "<BS>\\|<BACKSPACE>\\|@key{BS}\\|\\<BS\\>" " BS " norm-key-series t)
 		   norm-key-series (hypb:replace-match-string
 				    "<RET>\\|<RTN>\\|<RETURN>\\|@key{RET}\\|@key{RTN}\\|\\<RETURN\\>\\|\\<RET\\>\\|\\<RTN\\>"
-				    norm-key-series " RET " t)
+				    " RET " norm-key-series t)
 		   norm-key-series (hypb:replace-match-string
-				    "<TAB>\\|@key{TAB}\\|\\<TAB\\>" norm-key-series " TAB " t)
+				    "<TAB>\\|@key{TAB}\\|\\<TAB\\>" " TAB " norm-key-series t)
 		   ;; Includes conversion of spaces-to-keep markup to
 		   ;; SPC; otherwise, later calls to `kbd' will remove
 		   ;; these spaces.
 		   norm-key-series (hypb:replace-match-string
-				    "\\\\ \\|\0\0\0\\|<SPC>\\|@key{SPC}\\|\\<SPC\\>" norm-key-series " SPC " t)
+				    "\\\\ \\|\0\0\0\\|<SPC>\\|@key{SPC}\\|\\<SPC\\>" " SPC " norm-key-series t)
 		   norm-key-series (hypb:replace-match-string
-				    "<ESC>\\|<ESCAPE>\\|@key{ESC}\\|\\<ESC\\(APE\\)?\\>" norm-key-series " M-" t)
+				    "<ESC>\\|<ESCAPE>\\|@key{ESC}\\|\\<ESC\\(APE\\)?\\>" " M-" norm-key-series t)
 		   ;; ESC ESC
 		   norm-key-series (hypb:replace-match-string
-				    "M-[ \t\n\r\f]*M-" norm-key-series " ESC M-" t)
+				    "M-[ \t\n\r\f]*M-" " ESC M-" norm-key-series t)
 		   ;; Separate with a space any keys with a modifier
 		   norm-key-series (hypb:replace-match-string kbd-key:modified-key-regexp
-							      norm-key-series " \\1\\3 ")
+							      " \\1\\3 " norm-key-series)
 		   ;; Normalize regular whitespace to single spaces
-		   norm-key-series (hypb:replace-match-string "[ \t\n\r\f]+" norm-key-series " " t)
+		   norm-key-series (hypb:replace-match-string "[ \t\n\r\f]+" " " norm-key-series t)
 
 		   ;; Unqote special {} chars.
 		   norm-key-series (hypb:replace-match-string "\\\\\\([{}]\\)"
-							      norm-key-series "\\1")
+							      "\\1" norm-key-series)
 		   norm-key-series (hpath:trim norm-key-series))
 	     ;; (while (string-match "\\`\\(C-u\\|M-\\)\\(-?[0-9]+\\)" norm-key-series)
 	     ;;   (setq arg (string-to-number (match-string 2 norm-key-series))
@@ -493,7 +493,7 @@ Also, initialize `kbd-key:mini-menu-key' to the key sequence that invokes the Hy
 	    end (match-end 0)
 	    substring (match-string 0 string)
 	    string (concat (substring string 0 start)
-			   (hypb:replace-match-string "[ \t\n\r\f]" substring "\0\0\0" t)
+			   (hypb:replace-match-string "[ \t\n\r\f]" "\0\0\0" substring t)
 			   (if (< end (length string))
 			       (substring string end)
 			     ""))

--- a/hib-kbd.el
+++ b/hib-kbd.el
@@ -3,9 +3,9 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    22-Nov-91 at 01:37:57
-;; Last-Mod:     15-Jul-22 at 22:07:35 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 23:21:33 by Mats Lidell
 ;;
-;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
+;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.

--- a/hib-kbd.el
+++ b/hib-kbd.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    22-Nov-91 at 01:37:57
-;; Last-Mod:     15-Jul-22 at 20:00:09 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 21:10:19 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -289,29 +289,29 @@ keyboad input queue, as if they had been typed by the user."
 		   norm-key-series (kbd-key:mark-spaces-to-keep norm-key-series "<" ">")
 		   norm-key-series (kbd-key:mark-spaces-to-keep norm-key-series "\"" "\"")
 		   norm-key-series (hypb:replace-match-string
-				    "<DEL>\\|<DELETE>\\|@key{DEL}\\|\\<DEL\\>" " DEL " norm-key-series t)
+				    "<DEL>\\|<DELETE>\\|@key{DEL}\\|\\<DEL\\>" " DEL " norm-key-series nil t)
 		   norm-key-series (hypb:replace-match-string
-				    "<BS>\\|<BACKSPACE>\\|@key{BS}\\|\\<BS\\>" " BS " norm-key-series t)
+				    "<BS>\\|<BACKSPACE>\\|@key{BS}\\|\\<BS\\>" " BS " norm-key-series nil t)
 		   norm-key-series (hypb:replace-match-string
 				    "<RET>\\|<RTN>\\|<RETURN>\\|@key{RET}\\|@key{RTN}\\|\\<RETURN\\>\\|\\<RET\\>\\|\\<RTN\\>"
-				    " RET " norm-key-series t)
+				    " RET " norm-key-series nil t)
 		   norm-key-series (hypb:replace-match-string
-				    "<TAB>\\|@key{TAB}\\|\\<TAB\\>" " TAB " norm-key-series t)
+				    "<TAB>\\|@key{TAB}\\|\\<TAB\\>" " TAB " norm-key-series nil t)
 		   ;; Includes conversion of spaces-to-keep markup to
 		   ;; SPC; otherwise, later calls to `kbd' will remove
 		   ;; these spaces.
 		   norm-key-series (hypb:replace-match-string
-				    "\\\\ \\|\0\0\0\\|<SPC>\\|@key{SPC}\\|\\<SPC\\>" " SPC " norm-key-series t)
+				    "\\\\ \\|\0\0\0\\|<SPC>\\|@key{SPC}\\|\\<SPC\\>" " SPC " norm-key-series nil t)
 		   norm-key-series (hypb:replace-match-string
-				    "<ESC>\\|<ESCAPE>\\|@key{ESC}\\|\\<ESC\\(APE\\)?\\>" " M-" norm-key-series t)
+				    "<ESC>\\|<ESCAPE>\\|@key{ESC}\\|\\<ESC\\(APE\\)?\\>" " M-" norm-key-series nil t)
 		   ;; ESC ESC
 		   norm-key-series (hypb:replace-match-string
-				    "M-[ \t\n\r\f]*M-" " ESC M-" norm-key-series t)
+				    "M-[ \t\n\r\f]*M-" " ESC M-" norm-key-series nil t)
 		   ;; Separate with a space any keys with a modifier
 		   norm-key-series (hypb:replace-match-string kbd-key:modified-key-regexp
 							      " \\1\\3 " norm-key-series)
 		   ;; Normalize regular whitespace to single spaces
-		   norm-key-series (hypb:replace-match-string "[ \t\n\r\f]+" " " norm-key-series t)
+		   norm-key-series (hypb:replace-match-string "[ \t\n\r\f]+" " " norm-key-series nil t)
 
 		   ;; Unqote special {} chars.
 		   norm-key-series (hypb:replace-match-string "\\\\\\([{}]\\)"
@@ -493,7 +493,7 @@ Also, initialize `kbd-key:mini-menu-key' to the key sequence that invokes the Hy
 	    end (match-end 0)
 	    substring (match-string 0 string)
 	    string (concat (substring string 0 start)
-			   (hypb:replace-match-string "[ \t\n\r\f]" "\0\0\0" substring t)
+			   (hypb:replace-match-string "[ \t\n\r\f]" "\0\0\0" substring nil t)
 			   (if (< end (length string))
 			       (substring string end)
 			     ""))

--- a/hib-kbd.el
+++ b/hib-kbd.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    22-Nov-91 at 01:37:57
-;; Last-Mod:     15-Jul-22 at 21:10:19 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 22:07:35 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -288,33 +288,33 @@ keyboad input queue, as if they had been typed by the user."
 		   norm-key-series (kbd-key:mark-spaces-to-keep norm-key-series "\\[" "\\]")
 		   norm-key-series (kbd-key:mark-spaces-to-keep norm-key-series "<" ">")
 		   norm-key-series (kbd-key:mark-spaces-to-keep norm-key-series "\"" "\"")
-		   norm-key-series (hypb:replace-match-string
+		   norm-key-series (replace-regexp-in-string
 				    "<DEL>\\|<DELETE>\\|@key{DEL}\\|\\<DEL\\>" " DEL " norm-key-series nil t)
-		   norm-key-series (hypb:replace-match-string
+		   norm-key-series (replace-regexp-in-string
 				    "<BS>\\|<BACKSPACE>\\|@key{BS}\\|\\<BS\\>" " BS " norm-key-series nil t)
-		   norm-key-series (hypb:replace-match-string
+		   norm-key-series (replace-regexp-in-string
 				    "<RET>\\|<RTN>\\|<RETURN>\\|@key{RET}\\|@key{RTN}\\|\\<RETURN\\>\\|\\<RET\\>\\|\\<RTN\\>"
 				    " RET " norm-key-series nil t)
-		   norm-key-series (hypb:replace-match-string
+		   norm-key-series (replace-regexp-in-string
 				    "<TAB>\\|@key{TAB}\\|\\<TAB\\>" " TAB " norm-key-series nil t)
 		   ;; Includes conversion of spaces-to-keep markup to
 		   ;; SPC; otherwise, later calls to `kbd' will remove
 		   ;; these spaces.
-		   norm-key-series (hypb:replace-match-string
+		   norm-key-series (replace-regexp-in-string
 				    "\\\\ \\|\0\0\0\\|<SPC>\\|@key{SPC}\\|\\<SPC\\>" " SPC " norm-key-series nil t)
-		   norm-key-series (hypb:replace-match-string
+		   norm-key-series (replace-regexp-in-string
 				    "<ESC>\\|<ESCAPE>\\|@key{ESC}\\|\\<ESC\\(APE\\)?\\>" " M-" norm-key-series nil t)
 		   ;; ESC ESC
-		   norm-key-series (hypb:replace-match-string
+		   norm-key-series (replace-regexp-in-string
 				    "M-[ \t\n\r\f]*M-" " ESC M-" norm-key-series nil t)
 		   ;; Separate with a space any keys with a modifier
-		   norm-key-series (hypb:replace-match-string kbd-key:modified-key-regexp
+		   norm-key-series (replace-regexp-in-string kbd-key:modified-key-regexp
 							      " \\1\\3 " norm-key-series)
 		   ;; Normalize regular whitespace to single spaces
-		   norm-key-series (hypb:replace-match-string "[ \t\n\r\f]+" " " norm-key-series nil t)
+		   norm-key-series (replace-regexp-in-string "[ \t\n\r\f]+" " " norm-key-series nil t)
 
 		   ;; Unqote special {} chars.
-		   norm-key-series (hypb:replace-match-string "\\\\\\([{}]\\)"
+		   norm-key-series (replace-regexp-in-string "\\\\\\([{}]\\)"
 							      "\\1" norm-key-series)
 		   norm-key-series (hpath:trim norm-key-series))
 	     ;; (while (string-match "\\`\\(C-u\\|M-\\)\\(-?[0-9]+\\)" norm-key-series)
@@ -493,7 +493,7 @@ Also, initialize `kbd-key:mini-menu-key' to the key sequence that invokes the Hy
 	    end (match-end 0)
 	    substring (match-string 0 string)
 	    string (concat (substring string 0 start)
-			   (hypb:replace-match-string "[ \t\n\r\f]" "\0\0\0" substring nil t)
+			   (replace-regexp-in-string "[ \t\n\r\f]" "\0\0\0" substring nil t)
 			   (if (< end (length string))
 			       (substring string end)
 			     ""))

--- a/hmail.el
+++ b/hmail.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     9-Oct-91 at 18:38:05
-;; Last-Mod:      6-Mar-22 at 22:29:00 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 20:08:47 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
 ;; See the HY-COPY (Hyperbole) or BR-COPY (OO-Browser) file for license
@@ -148,7 +148,7 @@ Optional SUBJECT and HELP message may also be given."
 	   hmail-func)
       (mapcar (lambda (func-suffix)
 		(setq hmail-func (hypb:replace-match-string
-				  "Summ-" func-suffix "" t))
+				  "Summ-" "" func-suffix t))
 		(defalias (intern (concat class-prefix hmail-func))
 		  (intern (concat reader-prefix "-" func-suffix))))
 	      func-suffix-list))))

--- a/hmail.el
+++ b/hmail.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     9-Oct-91 at 18:38:05
-;; Last-Mod:     15-Jul-22 at 20:08:47 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 21:21:12 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
 ;; See the HY-COPY (Hyperbole) or BR-COPY (OO-Browser) file for license
@@ -148,7 +148,7 @@ Optional SUBJECT and HELP message may also be given."
 	   hmail-func)
       (mapcar (lambda (func-suffix)
 		(setq hmail-func (hypb:replace-match-string
-				  "Summ-" "" func-suffix t))
+				  "Summ-" "" func-suffix nil t))
 		(defalias (intern (concat class-prefix hmail-func))
 		  (intern (concat reader-prefix "-" func-suffix))))
 	      func-suffix-list))))

--- a/hmail.el
+++ b/hmail.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     9-Oct-91 at 18:38:05
-;; Last-Mod:     15-Jul-22 at 21:21:12 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 22:07:35 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
 ;; See the HY-COPY (Hyperbole) or BR-COPY (OO-Browser) file for license
@@ -147,7 +147,7 @@ Optional SUBJECT and HELP message may also be given."
 				      0 (string-match "-" reader-name))))
 	   hmail-func)
       (mapcar (lambda (func-suffix)
-		(setq hmail-func (hypb:replace-match-string
+		(setq hmail-func (replace-regexp-in-string
 				  "Summ-" "" func-suffix nil t))
 		(defalias (intern (concat class-prefix hmail-func))
 		  (intern (concat reader-prefix "-" func-suffix))))

--- a/hmail.el
+++ b/hmail.el
@@ -3,9 +3,9 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     9-Oct-91 at 18:38:05
-;; Last-Mod:     15-Jul-22 at 22:07:35 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 23:22:06 by Mats Lidell
 ;;
-;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
+;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the HY-COPY (Hyperbole) or BR-COPY (OO-Browser) file for license
 ;; information.
 ;;

--- a/hmouse-info.el
+++ b/hmouse-info.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Apr-89
-;; Last-Mod:     17-Apr-22 at 11:16:29 by Bob Weiner
+;; Last-Mod:     15-Jul-22 at 20:00:09 by Mats Lidell
 ;;
 ;; Copyright (C) 1989-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -352,8 +352,8 @@ This works regardless of the current buffer."
 	       (<= (match-beginning 0) opoint)
 	       (> (match-end 0) opoint))
 	  ;; Remove newline and extra spaces from `note-name'
-	  (hypb:replace-match-string "[ \t\n\r]+" (match-string-no-properties 2)
-				     " " t)))))
+	  (hypb:replace-match-string "[ \t\n\r]+" " "
+				     (match-string-no-properties 2) t)))))
 
 (defun Info-read-index-item-name-1 (string predicate code)
   "Internal function used by `Info-read-index-item-name' to generate completions.

--- a/hmouse-info.el
+++ b/hmouse-info.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Apr-89
-;; Last-Mod:     15-Jul-22 at 21:21:12 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 22:07:35 by Mats Lidell
 ;;
 ;; Copyright (C) 1989-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -352,7 +352,7 @@ This works regardless of the current buffer."
 	       (<= (match-beginning 0) opoint)
 	       (> (match-end 0) opoint))
 	  ;; Remove newline and extra spaces from `note-name'
-	  (hypb:replace-match-string "[ \t\n\r]+" " "
+	  (replace-regexp-in-string "[ \t\n\r]+" " "
 				     (match-string-no-properties 2) nil t)))))
 
 (defun Info-read-index-item-name-1 (string predicate code)

--- a/hmouse-info.el
+++ b/hmouse-info.el
@@ -3,9 +3,9 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Apr-89
-;; Last-Mod:     15-Jul-22 at 22:07:35 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 23:22:20 by Mats Lidell
 ;;
-;; Copyright (C) 1989-2021  Free Software Foundation, Inc.
+;; Copyright (C) 1989-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.

--- a/hmouse-info.el
+++ b/hmouse-info.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Apr-89
-;; Last-Mod:     15-Jul-22 at 20:00:09 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 21:21:12 by Mats Lidell
 ;;
 ;; Copyright (C) 1989-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -353,7 +353,7 @@ This works regardless of the current buffer."
 	       (> (match-end 0) opoint))
 	  ;; Remove newline and extra spaces from `note-name'
 	  (hypb:replace-match-string "[ \t\n\r]+" " "
-				     (match-string-no-properties 2) t)))))
+				     (match-string-no-properties 2) nil t)))))
 
 (defun Info-read-index-item-name-1 (string predicate code)
   "Internal function used by `Info-read-index-item-name' to generate completions.

--- a/hmouse-tag.el
+++ b/hmouse-tag.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    24-Aug-91
-;; Last-Mod:     17-Apr-22 at 23:15:45 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 20:00:09 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -1285,7 +1285,7 @@ Look for packages in `smart-java-package-path'."
 		(if library-path
 		    (hpath:find (expand-file-name
 				 (hypb:replace-match-string
-				  "\\." referent (file-name-as-directory "") t)
+				  "\\." (file-name-as-directory "") referent t)
 				 library-path))
 		  ;; Show the current directory, which should contain this package.
 		  (hpath:find default-directory)))
@@ -1295,9 +1295,9 @@ Look for packages in `smart-java-package-path'."
 	    (if (string-match "\\.\\*" referent)
 		(setq subfile (substring referent 0 (match-beginning 0))
 		      subfile (hypb:replace-match-string
-			       "\\." subfile (file-name-as-directory "") t))
+			       "\\." (file-name-as-directory "") subfile t))
 	      (setq subpath (hypb:replace-match-string
-			     "\\." referent (file-name-as-directory "") t)
+			     "\\." (file-name-as-directory "") referent t)
 		    subfile (concat subpath ".java")))
 	    ;;
 	    ;; Try to find the path containing referent.

--- a/hmouse-tag.el
+++ b/hmouse-tag.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    24-Aug-91
-;; Last-Mod:     15-Jul-22 at 20:00:09 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 21:21:12 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -1285,7 +1285,7 @@ Look for packages in `smart-java-package-path'."
 		(if library-path
 		    (hpath:find (expand-file-name
 				 (hypb:replace-match-string
-				  "\\." (file-name-as-directory "") referent t)
+				  "\\." (file-name-as-directory "") referent nil t)
 				 library-path))
 		  ;; Show the current directory, which should contain this package.
 		  (hpath:find default-directory)))
@@ -1295,9 +1295,9 @@ Look for packages in `smart-java-package-path'."
 	    (if (string-match "\\.\\*" referent)
 		(setq subfile (substring referent 0 (match-beginning 0))
 		      subfile (hypb:replace-match-string
-			       "\\." (file-name-as-directory "") subfile t))
+			       "\\." (file-name-as-directory "") subfile nil t))
 	      (setq subpath (hypb:replace-match-string
-			     "\\." (file-name-as-directory "") referent t)
+			     "\\." (file-name-as-directory "") referent nil t)
 		    subfile (concat subpath ".java")))
 	    ;;
 	    ;; Try to find the path containing referent.

--- a/hmouse-tag.el
+++ b/hmouse-tag.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    24-Aug-91
-;; Last-Mod:     15-Jul-22 at 21:21:12 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 22:07:35 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -1284,7 +1284,7 @@ Look for packages in `smart-java-package-path'."
 	      (let ((library-path (smart-java-library-path referent)))
 		(if library-path
 		    (hpath:find (expand-file-name
-				 (hypb:replace-match-string
+				 (replace-regexp-in-string
 				  "\\." (file-name-as-directory "") referent nil t)
 				 library-path))
 		  ;; Show the current directory, which should contain this package.
@@ -1294,9 +1294,9 @@ Look for packages in `smart-java-package-path'."
 	    ;; package.
 	    (if (string-match "\\.\\*" referent)
 		(setq subfile (substring referent 0 (match-beginning 0))
-		      subfile (hypb:replace-match-string
+		      subfile (replace-regexp-in-string
 			       "\\." (file-name-as-directory "") subfile nil t))
-	      (setq subpath (hypb:replace-match-string
+	      (setq subpath (replace-regexp-in-string
 			     "\\." (file-name-as-directory "") referent nil t)
 		    subfile (concat subpath ".java")))
 	    ;;

--- a/hpath.el
+++ b/hpath.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Nov-91 at 00:44:23
-;; Last-Mod:     15-Jul-22 at 21:21:12 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 22:07:35 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -1631,8 +1631,8 @@ form is what is returned for PATH."
 				      ;; Quote any % except for one %s at the end of the
 				      ;; path part of rtn-path (immediately preceding a #
 				      ;; or , character or the end of string).
-				      (setq rtn-path (hypb:replace-match-string "%" "%%" rtn-path t nil)
-					    rtn-path (hypb:replace-match-string "%%s\\([#,]\\|\\'\\)" "%s\\1" rtn-path t nil))
+				      (setq rtn-path (replace-regexp-in-string "%" "%%" rtn-path t nil)
+					    rtn-path (replace-regexp-in-string "%%s\\([#,]\\|\\'\\)" "%s\\1" rtn-path t nil))
 				      ;; Return path if non-nil return value.
 				      (if (stringp suffix) ;; suffix could = t, which we ignore
 					  (if (string-match (concat (regexp-quote suffix) "%s") rtn-path)
@@ -2375,7 +2375,7 @@ that returns a replacement string."
 	     rtn-str
 	     (substring str prev-start match)
 	     (cond ((functionp new)
-		    (hypb:replace-match-string
+		    (replace-regexp-in-string
 		     regexp (funcall new str)
 		     (substring str match start) fixedcase literal))
 		   (literal new)
@@ -2407,7 +2407,7 @@ that returns a replacement string."
 Replacement is done iff VAR-DIR-VAL is an absolute path.
 If PATH is modified, return PATH, otherwise return nil."
   (when (and (stringp var-dir-val) (file-name-absolute-p var-dir-val))
-    (let ((new-path (hypb:replace-match-string
+    (let ((new-path (replace-regexp-in-string
 		     (regexp-quote (file-name-as-directory
 				    (or var-dir-val default-directory)))
 		     (concat "$\{" (symbol-name var-symbol) "\}/") path

--- a/hpath.el
+++ b/hpath.el
@@ -3,9 +3,9 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Nov-91 at 00:44:23
-;; Last-Mod:     15-Jul-22 at 22:07:35 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 23:23:25 by Mats Lidell
 ;;
-;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
+;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.

--- a/hpath.el
+++ b/hpath.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Nov-91 at 00:44:23
-;; Last-Mod:     15-Jul-22 at 20:30:24 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 21:21:12 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -1631,8 +1631,8 @@ form is what is returned for PATH."
 				      ;; Quote any % except for one %s at the end of the
 				      ;; path part of rtn-path (immediately preceding a #
 				      ;; or , character or the end of string).
-				      (setq rtn-path (hypb:replace-match-string "%" "%%" rtn-path nil t)
-					    rtn-path (hypb:replace-match-string "%%s\\([#,]\\|\\'\\)" "%s\\1" rtn-path nil t))
+				      (setq rtn-path (hypb:replace-match-string "%" "%%" rtn-path t nil)
+					    rtn-path (hypb:replace-match-string "%%s\\([#,]\\|\\'\\)" "%s\\1" rtn-path t nil))
 				      ;; Return path if non-nil return value.
 				      (if (stringp suffix) ;; suffix could = t, which we ignore
 					  (if (string-match (concat (regexp-quote suffix) "%s") rtn-path)
@@ -2377,7 +2377,7 @@ that returns a replacement string."
 	     (cond ((functionp new)
 		    (hypb:replace-match-string
 		     regexp (funcall new str)
-		     (substring str match start) literal fixedcase))
+		     (substring str match start) fixedcase literal))
 		   (literal new)
 		   (t (mapconcat
 		       (lambda (c)

--- a/hpath.el
+++ b/hpath.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Nov-91 at 00:44:23
-;; Last-Mod:     22-May-22 at 13:34:43 by Bob Weiner
+;; Last-Mod:     15-Jul-22 at 20:30:24 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -1631,8 +1631,8 @@ form is what is returned for PATH."
 				      ;; Quote any % except for one %s at the end of the
 				      ;; path part of rtn-path (immediately preceding a #
 				      ;; or , character or the end of string).
-				      (setq rtn-path (hypb:replace-match-string "%" rtn-path "%%" nil t)
-					    rtn-path (hypb:replace-match-string "%%s\\([#,]\\|\\'\\)" rtn-path "%s\\1" nil t))
+				      (setq rtn-path (hypb:replace-match-string "%" "%%" rtn-path nil t)
+					    rtn-path (hypb:replace-match-string "%%s\\([#,]\\|\\'\\)" "%s\\1" rtn-path nil t))
 				      ;; Return path if non-nil return value.
 				      (if (stringp suffix) ;; suffix could = t, which we ignore
 					  (if (string-match (concat (regexp-quote suffix) "%s") rtn-path)
@@ -2376,8 +2376,8 @@ that returns a replacement string."
 	     (substring str prev-start match)
 	     (cond ((functionp new)
 		    (hypb:replace-match-string
-		     regexp (substring str match start)
-		     (funcall new str) literal fixedcase))
+		     regexp (funcall new str)
+		     (substring str match start) literal fixedcase))
 		   (literal new)
 		   (t (mapconcat
 		       (lambda (c)
@@ -2410,7 +2410,7 @@ If PATH is modified, return PATH, otherwise return nil."
     (let ((new-path (hypb:replace-match-string
 		     (regexp-quote (file-name-as-directory
 				    (or var-dir-val default-directory)))
-		     path (concat "$\{" (symbol-name var-symbol) "\}/")
+		     (concat "$\{" (symbol-name var-symbol) "\}/") path
 		     t t)))
       (if (equal new-path path) nil new-path))))
 

--- a/hypb.el
+++ b/hypb.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     6-Oct-91 at 03:42:38
-;; Last-Mod:     19-Jun-22 at 14:50:52 by Bob Weiner
+;; Last-Mod:     15-Jul-22 at 19:38:59 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -544,7 +544,7 @@ WINDOW pixelwise."
 	((symbolp object)
 	 (get object 'hyperbole))))
 
-(defun hypb:replace-match-string (regexp str new &optional literal fixedcase)
+(defun hypb:replace-match-string (regexp new str &optional literal fixedcase)
   "Replace all matches for REGEXP in STR with NEW string and return the result.
 If NEW is nil, return STR unchanged.
 

--- a/hypb.el
+++ b/hypb.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     6-Oct-91 at 03:42:38
-;; Last-Mod:     15-Jul-22 at 21:33:00 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 22:07:35 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.

--- a/hypb.el
+++ b/hypb.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     6-Oct-91 at 03:42:38
-;; Last-Mod:     15-Jul-22 at 19:38:59 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 20:56:15 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -544,7 +544,7 @@ WINDOW pixelwise."
 	((symbolp object)
 	 (get object 'hyperbole))))
 
-(defun hypb:replace-match-string (regexp new str &optional literal fixedcase)
+(defun hypb:replace-match-string (regexp new str &optional fixedcase literal)
   "Replace all matches for REGEXP in STR with NEW string and return the result.
 If NEW is nil, return STR unchanged.
 

--- a/hypb.el
+++ b/hypb.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     6-Oct-91 at 03:42:38
-;; Last-Mod:     15-Jul-22 at 22:07:35 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 23:08:28 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -544,7 +544,9 @@ WINDOW pixelwise."
 	((symbolp object)
 	 (get object 'hyperbole))))
 
-(defun hypb:replace-match-string (regexp new str &optional fixedcase literal)
+(make-obsolete 'hypb:replace-match-string 'replace-regexp-in-string "9.0")
+
+(defun hypb:replace-match-string (regexp str new &optional literal fixedcase)
   "Replace all matches for REGEXP in STR with NEW string and return the result.
 If NEW is nil, return STR unchanged.
 
@@ -563,7 +565,14 @@ in the replaced text, capitalize each word in NEW.
 
 NEW may instead be a function of one argument (the string to replace in)
 that returns a replacement string."
-  (replace-regexp-in-string regexp new str fixedcase literal))
+  (if (null new)
+      str
+    (unless (stringp str)
+      (error "(hypb:replace-match-string): 2nd arg must be a string: %s" str))
+    (unless (or (stringp new) (functionp new))
+      (error "(hypb:replace-match-string): 3rd arg must be a string or function: %s"
+	     new))
+    (replace-regexp-in-string regexp new str fixedcase literal)))
 
 (defun hypb:return-process-output (program &optional infile &rest args)
   "Return as a string the output from external PROGRAM with INFILE for input.

--- a/hypb.el
+++ b/hypb.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     6-Oct-91 at 03:42:38
-;; Last-Mod:     15-Jul-22 at 20:56:15 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 21:33:00 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -563,14 +563,7 @@ in the replaced text, capitalize each word in NEW.
 
 NEW may instead be a function of one argument (the string to replace in)
 that returns a replacement string."
-  (if (null new)
-      str
-    (unless (stringp str)
-      (error "(hypb:replace-match-string): 2nd arg must be a string: %s" str))
-    (unless (or (stringp new) (functionp new))
-      (error "(hypb:replace-match-string): 3rd arg must be a string or function: %s"
-	     new))
-    (replace-regexp-in-string regexp new str fixedcase literal)))
+  (replace-regexp-in-string regexp new str fixedcase literal))
 
 (defun hypb:return-process-output (program &optional infile &rest args)
   "Return as a string the output from external PROGRAM with INFILE for input.

--- a/hyrolo-logic.el
+++ b/hyrolo-logic.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    13-Jun-89 at 22:57:33
-;; Last-Mod:     10-Apr-22 at 09:53:39 by Bob Weiner
+;; Last-Mod:     15-Jul-22 at 20:00:09 by Mats Lidell
 ;;
 ;; Copyright (C) 1989-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -101,28 +101,28 @@ single argument."
 	;; Search string does not contain embedded logic
 	;; operators; do a string search instead.
 	(setq total-matches (hyrolo-fgrep expr))
-      (setq expr (hypb:replace-match-string "\(or " expr "\(| " t))
-      (setq expr (hypb:replace-match-string "\(xor " expr "\(@ " t))
-      (setq expr (hypb:replace-match-string "\(not " expr "\(! " t))
-      (setq expr (hypb:replace-match-string "\(and " expr "\(& " t))
+      (setq expr (hypb:replace-match-string "\(or " "\(| " expr t))
+      (setq expr (hypb:replace-match-string "\(xor " "\(@ " expr t))
+      (setq expr (hypb:replace-match-string "\(not " "\(! " expr t))
+      (setq expr (hypb:replace-match-string "\(and " "\(& " expr t))
       (setq expr (hypb:replace-match-string
-		  "\"\\([^\"]*\\)\"" expr "{\\1}" nil))
+		  "\"\\([^\"]*\\)\"" "{\\1}" expr nil))
       (setq expr (hypb:replace-match-string
-		  "\(\\([^@|!&()][^()\"]*\\)\)" expr "{\\1}" nil))
+		  "\(\\([^@|!&()][^()\"]*\\)\)" "{\\1}" expr nil))
       (let ((saved-expr expr))
 	(while
 	    (not (equal
 		  saved-expr
 		  (setq expr (hypb:replace-match-string
 			      "\\(\\s-\\)\\([^{}()\" \t\n\r]+\\)\\([^{}()]*[()]\\)"
-			      expr "\\1\"\\2\"\\3" nil))))
+			      "\\1\"\\2\"\\3" expr nil))))
 	  (setq saved-expr expr)))
       (setq expr (hypb:replace-match-string
-		  "{\\([^{}]+\\)}" expr "\"\\1\"" nil))
-      (setq expr (hypb:replace-match-string "\(| " expr "\(hyrolo-or start end  " t))
-      (setq expr (hypb:replace-match-string "\(@ " expr "\(hyrolo-xor start end " t))
-      (setq expr (hypb:replace-match-string "\(! " expr "\(hyrolo-not start end " t))
-      (setq expr (hypb:replace-match-string "\(& " expr "\(hyrolo-and start end " t))
+		  "{\\([^{}]+\\)}" "\"\\1\"" expr nil))
+      (setq expr (hypb:replace-match-string "\(| " "\(hyrolo-or start end  " expr t))
+      (setq expr (hypb:replace-match-string "\(@ " "\(hyrolo-xor start end " expr t))
+      (setq expr (hypb:replace-match-string "\(! " "\(hyrolo-not start end " expr t))
+      (setq expr (hypb:replace-match-string "\(& " "\(hyrolo-and start end " expr t))
       (setq expr (format "(hyrolo-logic (quote %s) nil %s %s %s)"
 			 expr count-only include-sub-entries no-sub-entries-out))
       (setq total-matches (eval (read expr))))

--- a/hyrolo-logic.el
+++ b/hyrolo-logic.el
@@ -3,9 +3,9 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    13-Jun-89 at 22:57:33
-;; Last-Mod:     15-Jul-22 at 22:07:35 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 23:23:52 by Mats Lidell
 ;;
-;; Copyright (C) 1989-2021  Free Software Foundation, Inc.
+;; Copyright (C) 1989-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.

--- a/hyrolo-logic.el
+++ b/hyrolo-logic.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    13-Jun-89 at 22:57:33
-;; Last-Mod:     15-Jul-22 at 20:00:09 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 21:21:12 by Mats Lidell
 ;;
 ;; Copyright (C) 1989-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -101,28 +101,28 @@ single argument."
 	;; Search string does not contain embedded logic
 	;; operators; do a string search instead.
 	(setq total-matches (hyrolo-fgrep expr))
-      (setq expr (hypb:replace-match-string "\(or " "\(| " expr t))
-      (setq expr (hypb:replace-match-string "\(xor " "\(@ " expr t))
-      (setq expr (hypb:replace-match-string "\(not " "\(! " expr t))
-      (setq expr (hypb:replace-match-string "\(and " "\(& " expr t))
+      (setq expr (hypb:replace-match-string "\(or " "\(| " expr nil t))
+      (setq expr (hypb:replace-match-string "\(xor " "\(@ " expr nil t))
+      (setq expr (hypb:replace-match-string "\(not " "\(! " expr nil t))
+      (setq expr (hypb:replace-match-string "\(and " "\(& " expr nil t))
       (setq expr (hypb:replace-match-string
-		  "\"\\([^\"]*\\)\"" "{\\1}" expr nil))
+		  "\"\\([^\"]*\\)\"" "{\\1}" expr nil nil))
       (setq expr (hypb:replace-match-string
-		  "\(\\([^@|!&()][^()\"]*\\)\)" "{\\1}" expr nil))
+		  "\(\\([^@|!&()][^()\"]*\\)\)" "{\\1}" expr nil nil))
       (let ((saved-expr expr))
 	(while
 	    (not (equal
 		  saved-expr
 		  (setq expr (hypb:replace-match-string
 			      "\\(\\s-\\)\\([^{}()\" \t\n\r]+\\)\\([^{}()]*[()]\\)"
-			      "\\1\"\\2\"\\3" expr nil))))
+			      "\\1\"\\2\"\\3" expr nil nil))))
 	  (setq saved-expr expr)))
       (setq expr (hypb:replace-match-string
-		  "{\\([^{}]+\\)}" "\"\\1\"" expr nil))
-      (setq expr (hypb:replace-match-string "\(| " "\(hyrolo-or start end  " expr t))
-      (setq expr (hypb:replace-match-string "\(@ " "\(hyrolo-xor start end " expr t))
-      (setq expr (hypb:replace-match-string "\(! " "\(hyrolo-not start end " expr t))
-      (setq expr (hypb:replace-match-string "\(& " "\(hyrolo-and start end " expr t))
+		  "{\\([^{}]+\\)}" "\"\\1\"" expr nil nil))
+      (setq expr (hypb:replace-match-string "\(| " "\(hyrolo-or start end  " expr nil t))
+      (setq expr (hypb:replace-match-string "\(@ " "\(hyrolo-xor start end " expr nil t))
+      (setq expr (hypb:replace-match-string "\(! " "\(hyrolo-not start end " expr nil t))
+      (setq expr (hypb:replace-match-string "\(& " "\(hyrolo-and start end " expr nil t))
       (setq expr (format "(hyrolo-logic (quote %s) nil %s %s %s)"
 			 expr count-only include-sub-entries no-sub-entries-out))
       (setq total-matches (eval (read expr))))

--- a/hyrolo-logic.el
+++ b/hyrolo-logic.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    13-Jun-89 at 22:57:33
-;; Last-Mod:     15-Jul-22 at 21:21:12 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 22:07:35 by Mats Lidell
 ;;
 ;; Copyright (C) 1989-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -101,28 +101,28 @@ single argument."
 	;; Search string does not contain embedded logic
 	;; operators; do a string search instead.
 	(setq total-matches (hyrolo-fgrep expr))
-      (setq expr (hypb:replace-match-string "\(or " "\(| " expr nil t))
-      (setq expr (hypb:replace-match-string "\(xor " "\(@ " expr nil t))
-      (setq expr (hypb:replace-match-string "\(not " "\(! " expr nil t))
-      (setq expr (hypb:replace-match-string "\(and " "\(& " expr nil t))
-      (setq expr (hypb:replace-match-string
+      (setq expr (replace-regexp-in-string "\(or " "\(| " expr nil t))
+      (setq expr (replace-regexp-in-string "\(xor " "\(@ " expr nil t))
+      (setq expr (replace-regexp-in-string "\(not " "\(! " expr nil t))
+      (setq expr (replace-regexp-in-string "\(and " "\(& " expr nil t))
+      (setq expr (replace-regexp-in-string
 		  "\"\\([^\"]*\\)\"" "{\\1}" expr nil nil))
-      (setq expr (hypb:replace-match-string
+      (setq expr (replace-regexp-in-string
 		  "\(\\([^@|!&()][^()\"]*\\)\)" "{\\1}" expr nil nil))
       (let ((saved-expr expr))
 	(while
 	    (not (equal
 		  saved-expr
-		  (setq expr (hypb:replace-match-string
+		  (setq expr (replace-regexp-in-string
 			      "\\(\\s-\\)\\([^{}()\" \t\n\r]+\\)\\([^{}()]*[()]\\)"
 			      "\\1\"\\2\"\\3" expr nil nil))))
 	  (setq saved-expr expr)))
-      (setq expr (hypb:replace-match-string
+      (setq expr (replace-regexp-in-string
 		  "{\\([^{}]+\\)}" "\"\\1\"" expr nil nil))
-      (setq expr (hypb:replace-match-string "\(| " "\(hyrolo-or start end  " expr nil t))
-      (setq expr (hypb:replace-match-string "\(@ " "\(hyrolo-xor start end " expr nil t))
-      (setq expr (hypb:replace-match-string "\(! " "\(hyrolo-not start end " expr nil t))
-      (setq expr (hypb:replace-match-string "\(& " "\(hyrolo-and start end " expr nil t))
+      (setq expr (replace-regexp-in-string "\(| " "\(hyrolo-or start end  " expr nil t))
+      (setq expr (replace-regexp-in-string "\(@ " "\(hyrolo-xor start end " expr nil t))
+      (setq expr (replace-regexp-in-string "\(! " "\(hyrolo-not start end " expr nil t))
+      (setq expr (replace-regexp-in-string "\(& " "\(hyrolo-and start end " expr nil t))
       (setq expr (format "(hyrolo-logic (quote %s) nil %s %s %s)"
 			 expr count-only include-sub-entries no-sub-entries-out))
       (setq total-matches (eval (read expr))))

--- a/kotl/kcell.el
+++ b/kotl/kcell.el
@@ -3,9 +3,9 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-May-93
-;; Last-Mod:     15-Jul-22 at 22:07:35 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 23:24:10 by Mats Lidell
 ;;
-;; Copyright (C) 1993-2021  Free Software Foundation, Inc.
+;; Copyright (C) 1993-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.

--- a/kotl/kcell.el
+++ b/kotl/kcell.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-May-93
-;; Last-Mod:     15-Jul-22 at 20:00:09 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 21:21:12 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2021  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -109,7 +109,7 @@ Augment capabilities not yet implemented and ignored for now:
 	  ((stringp cell-ref)
 	   (let (kviewspec
 		 idstamp-string)
-	     (setq cell-ref (hypb:replace-match-string "\\s-+" "" cell-ref t))
+	     (setq cell-ref (hypb:replace-match-string "\\s-+" "" cell-ref nil t))
 	     (if (string-equal cell-ref "0")
 		 "0"
 	       ;; Ignore Augment :viewspec.

--- a/kotl/kcell.el
+++ b/kotl/kcell.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-May-93
-;; Last-Mod:     15-Jul-22 at 21:21:12 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 22:07:35 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2021  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -109,7 +109,7 @@ Augment capabilities not yet implemented and ignored for now:
 	  ((stringp cell-ref)
 	   (let (kviewspec
 		 idstamp-string)
-	     (setq cell-ref (hypb:replace-match-string "\\s-+" "" cell-ref nil t))
+	     (setq cell-ref (replace-regexp-in-string "\\s-+" "" cell-ref nil t))
 	     (if (string-equal cell-ref "0")
 		 "0"
 	       ;; Ignore Augment :viewspec.

--- a/kotl/kcell.el
+++ b/kotl/kcell.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-May-93
-;; Last-Mod:     22-May-22 at 10:22:02 by Bob Weiner
+;; Last-Mod:     15-Jul-22 at 20:00:09 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2021  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -109,7 +109,7 @@ Augment capabilities not yet implemented and ignored for now:
 	  ((stringp cell-ref)
 	   (let (kviewspec
 		 idstamp-string)
-	     (setq cell-ref (hypb:replace-match-string "\\s-+" cell-ref "" t))
+	     (setq cell-ref (hypb:replace-match-string "\\s-+" "" cell-ref t))
 	     (if (string-equal cell-ref "0")
 		 "0"
 	       ;; Ignore Augment :viewspec.

--- a/kotl/kexport.el
+++ b/kotl/kexport.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    26-Feb-98
-;; Last-Mod:     12-Feb-22 at 10:42:20 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 20:46:06 by Mats Lidell
 ;;
 ;; Copyright (C) 1998-2021  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -456,9 +456,9 @@ hard newlines are not used.  Also converts Urls and Klinks into Html hyperlinks.
    	;;     </nav>\n")
 	(let* ((separator
 		(hypb:replace-match-string
-		 ">" (hypb:replace-match-string
-		      "<" (kview:label-separator kview) "&lt;")
-		 "&gt;"))
+		 ">" "&gt;"
+		 (hypb:replace-match-string
+		      "<" "&lt;" (kview:label-separator kview))))
 	       i is-parent is-last-sibling no-sibling-stack level label contents)
 	  (kview:map-tree
 	   (lambda (_kview)
@@ -549,7 +549,7 @@ Works exclusively within a call to `hypb:replace-match-string'."
   "Perform replacements on STRING specified by `kexport:html-replacement-alist'."
   (mapc
    (lambda (elt)
-     (setq string (hypb:replace-match-string (car elt) string (cdr elt))))
+     (setq string (hypb:replace-match-string (car elt) (cdr elt) string)))
    kexport:html-replacement-alist)
   string)
 

--- a/kotl/kexport.el
+++ b/kotl/kexport.el
@@ -3,9 +3,9 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    26-Feb-98
-;; Last-Mod:     15-Jul-22 at 22:07:35 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 23:24:27 by Mats Lidell
 ;;
-;; Copyright (C) 1998-2021  Free Software Foundation, Inc.
+;; Copyright (C) 1998-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.

--- a/kotl/kexport.el
+++ b/kotl/kexport.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    26-Feb-98
-;; Last-Mod:     15-Jul-22 at 20:46:06 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 22:07:35 by Mats Lidell
 ;;
 ;; Copyright (C) 1998-2021  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -455,9 +455,9 @@ hard newlines are not used.  Also converts Urls and Klinks into Html hyperlinks.
 	;; 	</menu>
    	;;     </nav>\n")
 	(let* ((separator
-		(hypb:replace-match-string
+		(replace-regexp-in-string
 		 ">" "&gt;"
-		 (hypb:replace-match-string
+		 (replace-regexp-in-string
 		      "<" "&lt;" (kview:label-separator kview))))
 	       i is-parent is-last-sibling no-sibling-stack level label contents)
 	  (kview:map-tree
@@ -533,7 +533,7 @@ hard newlines are not used.  Also converts Urls and Klinks into Html hyperlinks.
 
 (defun kexport:html-file-klink (string)
   "Convert STRING containing a klink with a file reference to Html format.
-Works exclusively within a call to `hypb:replace-match-string'."
+Works exclusively within a call to `replace-regexp-in-string'."
   (let ((filename (substring string (match-beginning 1)
 			     (match-end 1))))
     (if (equal filename (file-name-nondirectory
@@ -549,13 +549,13 @@ Works exclusively within a call to `hypb:replace-match-string'."
   "Perform replacements on STRING specified by `kexport:html-replacement-alist'."
   (mapc
    (lambda (elt)
-     (setq string (hypb:replace-match-string (car elt) (cdr elt) string)))
+     (setq string (replace-regexp-in-string (car elt) (cdr elt) string)))
    kexport:html-replacement-alist)
   string)
 
 (defun kexport:html-url (string)
   "Convert STRING containing a Url to Html format.
-Works exclusively within a call to `hypb:replace-match-string'."
+Works exclusively within a call to `replace-regexp-in-string'."
   (let* ((url (substring string (match-beginning hpath:url-grpn)
 			 (match-end hpath:url-grpn)))
 	 (last-str-char (length string))

--- a/kotl/kimport.el
+++ b/kotl/kimport.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Nov-93 at 11:57:05
-;; Last-Mod:     15-Jul-22 at 20:00:09 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 21:21:12 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2021  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -717,7 +717,7 @@ Remove the indent and return the remaining region as a string."
 		(concat "^" (make-string (current-column) ?\ ))))
       (if indent-regexp
 	  (hypb:replace-match-string
-			  indent-regexp "" (buffer-substring start end) t)
+			  indent-regexp "" (buffer-substring start end) nil t)
 	(buffer-substring start end)))))
 
 ;; Do this at the end so kotl-mode can utilize kimport definitions.

--- a/kotl/kimport.el
+++ b/kotl/kimport.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Nov-93 at 11:57:05
-;; Last-Mod:     11-Apr-22 at 23:51:03 by Bob Weiner
+;; Last-Mod:     15-Jul-22 at 20:00:09 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2021  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -717,7 +717,7 @@ Remove the indent and return the remaining region as a string."
 		(concat "^" (make-string (current-column) ?\ ))))
       (if indent-regexp
 	  (hypb:replace-match-string
-			  indent-regexp (buffer-substring start end) "" t)
+			  indent-regexp "" (buffer-substring start end) t)
 	(buffer-substring start end)))))
 
 ;; Do this at the end so kotl-mode can utilize kimport definitions.

--- a/kotl/kimport.el
+++ b/kotl/kimport.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Nov-93 at 11:57:05
-;; Last-Mod:     15-Jul-22 at 21:21:12 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 22:07:35 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2021  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -716,7 +716,7 @@ Remove the indent and return the remaining region as a string."
 	    (if (re-search-forward "[\n\r][ \t]+" end t)
 		(concat "^" (make-string (current-column) ?\ ))))
       (if indent-regexp
-	  (hypb:replace-match-string
+	  (replace-regexp-in-string
 			  indent-regexp "" (buffer-substring start end) nil t)
 	(buffer-substring start end)))))
 

--- a/kotl/kimport.el
+++ b/kotl/kimport.el
@@ -3,9 +3,9 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Nov-93 at 11:57:05
-;; Last-Mod:     15-Jul-22 at 22:07:35 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 23:24:41 by Mats Lidell
 ;;
-;; Copyright (C) 1993-2021  Free Software Foundation, Inc.
+;; Copyright (C) 1993-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.

--- a/kotl/klink.el
+++ b/kotl/klink.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Nov-93 at 12:15:16
-;; Last-Mod:     15-Jul-22 at 20:00:09 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 21:21:12 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2021  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -114,7 +114,7 @@ See documentation for `kcell:ref-to-id' for valid cell-ref formats."
   ;; double quotes and then parse it with pattern matching.
   (and (stringp reference) (> (length reference) 0)
        (eq (aref reference 0) ?\()
-       (setq reference (hypb:replace-match-string "\\\"" "" reference t)))
+       (setq reference (hypb:replace-match-string "\\\"" "" reference nil t)))
   (let ((default-dir default-directory)
 	file-ref cell-ref)
     (setq reference (klink:parse reference)

--- a/kotl/klink.el
+++ b/kotl/klink.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Nov-93 at 12:15:16
-;; Last-Mod:     22-May-22 at 12:52:17 by Bob Weiner
+;; Last-Mod:     15-Jul-22 at 20:00:09 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2021  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -114,7 +114,7 @@ See documentation for `kcell:ref-to-id' for valid cell-ref formats."
   ;; double quotes and then parse it with pattern matching.
   (and (stringp reference) (> (length reference) 0)
        (eq (aref reference 0) ?\()
-       (setq reference (hypb:replace-match-string "\\\"" reference "" t)))
+       (setq reference (hypb:replace-match-string "\\\"" "" reference t)))
   (let ((default-dir default-directory)
 	file-ref cell-ref)
     (setq reference (klink:parse reference)

--- a/kotl/klink.el
+++ b/kotl/klink.el
@@ -3,9 +3,9 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Nov-93 at 12:15:16
-;; Last-Mod:     15-Jul-22 at 22:07:35 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 23:24:53 by Mats Lidell
 ;;
-;; Copyright (C) 1993-2021  Free Software Foundation, Inc.
+;; Copyright (C) 1993-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.

--- a/kotl/klink.el
+++ b/kotl/klink.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Nov-93 at 12:15:16
-;; Last-Mod:     15-Jul-22 at 21:21:12 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 22:07:35 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2021  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -114,7 +114,7 @@ See documentation for `kcell:ref-to-id' for valid cell-ref formats."
   ;; double quotes and then parse it with pattern matching.
   (and (stringp reference) (> (length reference) 0)
        (eq (aref reference 0) ?\()
-       (setq reference (hypb:replace-match-string "\\\"" "" reference nil t)))
+       (setq reference (replace-regexp-in-string "\\\"" "" reference nil t)))
   (let ((default-dir default-directory)
 	file-ref cell-ref)
     (setq reference (klink:parse reference)

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:     15-Jul-22 at 20:00:09 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 21:21:12 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -377,7 +377,7 @@ With optional prefix arg DELETE-FLAG, delete region."
 		  (hypb:replace-match-string
 		   (concat "^" (make-string indent ?\ ))
 		   ""
-		   (buffer-substring start end) t)))
+		   (buffer-substring start end) nil t)))
   (when delete-flag
     (delete-region start end)))
 

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:     15-Jul-22 at 21:21:12 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 22:07:35 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -374,7 +374,7 @@ With optional prefix arg DELETE-FLAG, delete region."
   (interactive "cCopy to register: \nr\nP")
   (let ((indent (kcell-view:indent)))
     (set-register register
-		  (hypb:replace-match-string
+		  (replace-regexp-in-string
 		   (concat "^" (make-string indent ?\ ))
 		   ""
 		   (buffer-substring start end) nil t)))
@@ -745,7 +745,7 @@ If a completion is active, this aborts the completion only."
       ;; Then save to kill ring.
       (setq subst-str (concat "\\([\n\r]\\)" (make-string indent ?\ ))
 	    kill-str
-	    (hypb:replace-match-string
+	    (replace-regexp-in-string
 	     subst-str "\\1" (buffer-substring start end)))
       (unless copy-p
 	;; If last char of region is a newline, then delete indent in
@@ -1339,7 +1339,7 @@ See also the command `yank-pop' (\\[yank-pop])."
 	 (indent-str (make-string indent ?\ )))
     ;; Convert all occurrences of newline to newline + cell indent.
     ;; Then insert into buffer.
-    (insert-for-yank (hypb:replace-match-string
+    (insert-for-yank (replace-regexp-in-string
 		      "[\n\r]" (lambda (match) (concat match indent-str)) yank-text)))
   (when (consp arg) (kotl-mode:exchange-point-and-mark))
   ;; If we do get all the way thru, make this-command indicate that.
@@ -1380,7 +1380,7 @@ doc string for `insert-for-yank-1', which see."
 	   (indent-str (make-string indent ?\ )))
       ;; Convert all occurrences of newline to newline + cell indent.
       ;; Then insert into buffer.
-      (insert-for-yank (hypb:replace-match-string
+      (insert-for-yank (replace-regexp-in-string
 			"[\n\r]" (concat "\\0" indent-str) yank-text)))
     ;; Set the window start back where it was in the yank command,
     ;; if possible.
@@ -2377,7 +2377,7 @@ to one level and kotl-mode:refill-flag is treated as true."
       ;; Substitute cell-1 contents into cell-2 location.
       (delete-region (kcell-view:start) (kcell-view:end-contents))
       (insert
-       (hypb:replace-match-string
+       (replace-regexp-in-string
 	"\\([\n\r]\\)"
 	(concat "\\1" (make-string (kcell-view:indent) ?\ )) contents-1))
       (when kotl-mode:refill-flag
@@ -2389,7 +2389,7 @@ to one level and kotl-mode:refill-flag is treated as true."
       (delete-region (kcell-view:start) (kcell-view:end-contents))
       ;; Add indentation to all but first line.
       (insert
-       (hypb:replace-match-string
+       (replace-regexp-in-string
 	"\\([\n\r]\\)"
 	(concat "\\1" (make-string (kcell-view:indent) ?\ )) contents-2))
       (when kotl-mode:refill-flag

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:     18-Jun-22 at 21:56:13 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 20:00:09 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -376,8 +376,8 @@ With optional prefix arg DELETE-FLAG, delete region."
     (set-register register
 		  (hypb:replace-match-string
 		   (concat "^" (make-string indent ?\ ))
-		   (buffer-substring start end)
-		   "" t)))
+		   ""
+		   (buffer-substring start end) t)))
   (when delete-flag
     (delete-region start end)))
 
@@ -746,7 +746,7 @@ If a completion is active, this aborts the completion only."
       (setq subst-str (concat "\\([\n\r]\\)" (make-string indent ?\ ))
 	    kill-str
 	    (hypb:replace-match-string
-	     subst-str (buffer-substring start end) "\\1"))
+	     subst-str "\\1" (buffer-substring start end)))
       (unless copy-p
 	;; If last char of region is a newline, then delete indent in
 	;; following line.
@@ -1340,7 +1340,7 @@ See also the command `yank-pop' (\\[yank-pop])."
     ;; Convert all occurrences of newline to newline + cell indent.
     ;; Then insert into buffer.
     (insert-for-yank (hypb:replace-match-string
-		      "[\n\r]" yank-text (lambda (match) (concat match indent-str)))))
+		      "[\n\r]" (lambda (match) (concat match indent-str)) yank-text)))
   (when (consp arg) (kotl-mode:exchange-point-and-mark))
   ;; If we do get all the way thru, make this-command indicate that.
   (when (eq this-command t) (setq this-command 'kotl-mode:yank))
@@ -1381,7 +1381,7 @@ doc string for `insert-for-yank-1', which see."
       ;; Convert all occurrences of newline to newline + cell indent.
       ;; Then insert into buffer.
       (insert-for-yank (hypb:replace-match-string
-			"[\n\r]" yank-text (concat "\\0" indent-str))))
+			"[\n\r]" (concat "\\0" indent-str) yank-text)))
     ;; Set the window start back where it was in the yank command,
     ;; if possible.
     (set-window-start (selected-window) yank-window-start t)
@@ -2379,7 +2379,7 @@ to one level and kotl-mode:refill-flag is treated as true."
       (insert
        (hypb:replace-match-string
 	"\\([\n\r]\\)"
-	contents-1 (concat "\\1" (make-string (kcell-view:indent) ?\ ))))
+	(concat "\\1" (make-string (kcell-view:indent) ?\ )) contents-1))
       (when kotl-mode:refill-flag
 	(kotl-mode:fill-cell))
 
@@ -2391,7 +2391,7 @@ to one level and kotl-mode:refill-flag is treated as true."
       (insert
        (hypb:replace-match-string
 	"\\([\n\r]\\)"
-	contents-2 (concat "\\1" (make-string (kcell-view:indent) ?\ ))))
+	(concat "\\1" (make-string (kcell-view:indent) ?\ )) contents-2))
       (when kotl-mode:refill-flag
 	(kotl-mode:fill-cell))
 

--- a/kotl/kview.el
+++ b/kotl/kview.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:     11-May-22 at 00:54:33 by Bob Weiner
+;; Last-Mod:     15-Jul-22 at 20:02:20 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2021  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -214,7 +214,7 @@ Any cell that is invisible is also collapsed as indicated by a call to
       ;; Remove indentation from all but first line.
       (hypb:replace-match-string
        (concat "\\([\n\r]\\)" (make-string indent ?\ ))
-       (buffer-substring start end) "\\1"))))
+       "\\1" (buffer-substring start end)))))
 
 (defun kcell-view:create (kview cell contents level idstamp klabel &optional no-fill sibling-p)
   "Insert into KVIEW at point, CELL with CONTENTS at LEVEL (1 = first level) with IDSTAMP and KLABEL.

--- a/kotl/kview.el
+++ b/kotl/kview.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:     15-Jul-22 at 20:02:20 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 22:07:35 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2021  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -212,7 +212,7 @@ Any cell that is invisible is also collapsed as indicated by a call to
 	  (start (kcell-view:start))
 	  (end (kcell-view:end-contents)))
       ;; Remove indentation from all but first line.
-      (hypb:replace-match-string
+      (replace-regexp-in-string
        (concat "\\([\n\r]\\)" (make-string indent ?\ ))
        "\\1" (buffer-substring start end)))))
 

--- a/kotl/kview.el
+++ b/kotl/kview.el
@@ -3,9 +3,9 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:     15-Jul-22 at 22:07:35 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 23:25:24 by Mats Lidell
 ;;
-;; Copyright (C) 1993-2021  Free Software Foundation, Inc.
+;; Copyright (C) 1993-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.

--- a/kotl/kvspec.el
+++ b/kotl/kvspec.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Oct-95 at 15:17:07
-;; Last-Mod:     15-Jul-22 at 20:00:09 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 21:21:12 by Mats Lidell
 ;;
 ;; Copyright (C) 1995-2021  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -131,7 +131,7 @@ display all levels of cells."
   (interactive)
   (setq kvspec:current
 	(if (string-match "b" kvspec:current)
-	    (hypb:replace-match-string "b" "" kvspec:current t)
+	    (hypb:replace-match-string "b" "" kvspec:current nil t)
 	  (concat "b" kvspec:current)))
   (kvspec:blank-lines)
   (kvspec:update-modeline))
@@ -147,7 +147,7 @@ view specs."
 	 ;; Use given view-spec after removing extraneous characters.
 	 (setq view-spec
 	       (hypb:replace-match-string
-		"[^.*~0-9abcdefgilnrsv]+" "" view-spec t))
+		"[^.*~0-9abcdefgilnrsv]+" "" view-spec nil t))
 	 (unless (string-match "e" view-spec)
 	   ;; Force 'e' elide view spec if not there.
 	   (setq view-spec

--- a/kotl/kvspec.el
+++ b/kotl/kvspec.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Oct-95 at 15:17:07
-;; Last-Mod:     11-May-22 at 00:51:57 by Bob Weiner
+;; Last-Mod:     15-Jul-22 at 20:00:09 by Mats Lidell
 ;;
 ;; Copyright (C) 1995-2021  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -131,7 +131,7 @@ display all levels of cells."
   (interactive)
   (setq kvspec:current
 	(if (string-match "b" kvspec:current)
-	    (hypb:replace-match-string "b" kvspec:current "" t)
+	    (hypb:replace-match-string "b" "" kvspec:current t)
 	  (concat "b" kvspec:current)))
   (kvspec:blank-lines)
   (kvspec:update-modeline))
@@ -147,7 +147,7 @@ view specs."
 	 ;; Use given view-spec after removing extraneous characters.
 	 (setq view-spec
 	       (hypb:replace-match-string
-		"[^.*~0-9abcdefgilnrsv]+" view-spec "" t))
+		"[^.*~0-9abcdefgilnrsv]+" "" view-spec t))
 	 (unless (string-match "e" view-spec)
 	   ;; Force 'e' elide view spec if not there.
 	   (setq view-spec

--- a/kotl/kvspec.el
+++ b/kotl/kvspec.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Oct-95 at 15:17:07
-;; Last-Mod:     15-Jul-22 at 21:21:12 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 22:07:35 by Mats Lidell
 ;;
 ;; Copyright (C) 1995-2021  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -131,7 +131,7 @@ display all levels of cells."
   (interactive)
   (setq kvspec:current
 	(if (string-match "b" kvspec:current)
-	    (hypb:replace-match-string "b" "" kvspec:current nil t)
+	    (replace-regexp-in-string "b" "" kvspec:current nil t)
 	  (concat "b" kvspec:current)))
   (kvspec:blank-lines)
   (kvspec:update-modeline))
@@ -146,7 +146,7 @@ view specs."
   (cond ((stringp view-spec)
 	 ;; Use given view-spec after removing extraneous characters.
 	 (setq view-spec
-	       (hypb:replace-match-string
+	       (replace-regexp-in-string
 		"[^.*~0-9abcdefgilnrsv]+" "" view-spec nil t))
 	 (unless (string-match "e" view-spec)
 	   ;; Force 'e' elide view spec if not there.

--- a/kotl/kvspec.el
+++ b/kotl/kvspec.el
@@ -3,9 +3,9 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Oct-95 at 15:17:07
-;; Last-Mod:     15-Jul-22 at 22:07:35 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 23:25:45 by Mats Lidell
 ;;
-;; Copyright (C) 1995-2021  Free Software Foundation, Inc.
+;; Copyright (C) 1995-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.

--- a/test/hypb-tests.el
+++ b/test/hypb-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:     5-Apr-21 at 18:53:10
-;; Last-Mod:     15-Jul-22 at 20:58:43 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 21:40:52 by Mats Lidell
 ;;
 ;; Copyright (C) 2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -24,7 +24,8 @@
 ;; Test for replace-regexp-in-string copied from emacs src
 (ert-deftest hypb:replace-match-string-test ()
   ;; Test cases added before refactoring to check new = nil case
-  (should (equal (hypb:replace-match-string ".*" nil "abc") "abc"))
+  ;; Disabled due to nil not being a valid third arg in replace-regexp-in-string.
+  ;; (should (equal (hypb:replace-match-string ".*" nil "abc") "abc"))
   (should (equal (hypb:replace-match-string ".*" "x" "abc") "x"))
 
   (should (equal (hypb:replace-match-string "a+" "xy" "abaabbabaaba")

--- a/test/hypb-tests.el
+++ b/test/hypb-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:     5-Apr-21 at 18:53:10
-;; Last-Mod:     15-Jul-22 at 22:07:35 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 23:09:21 by Mats Lidell
 ;;
 ;; Copyright (C) 2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -20,82 +20,6 @@
 (require 'hbut)
 (require 'ert)
 (require 'el-mock)
-
-;; Test for replace-regexp-in-string copied from emacs src
-(ert-deftest replace-regexp-in-string-test ()
-  ;; Test cases added before refactoring to check new = nil case
-  ;; Disabled due to nil not being a valid third arg in replace-regexp-in-string.
-  ;; (should (equal (replace-regexp-in-string ".*" nil "abc") "abc"))
-  (should (equal (replace-regexp-in-string ".*" "x" "abc") "x"))
-
-  (should (equal (replace-regexp-in-string "a+" "xy" "abaabbabaaba")
-                 "xybxybbxybxybxy"))
-  ;; FIXEDCASE
-  (let ((case-fold-search t))
-    (should (equal (replace-regexp-in-string "a+" "xy" "ABAABBABAABA")
-                   "XYBXYBBXYBXYBXY"))
-    (should (equal (replace-regexp-in-string "a+" "xy" "ABAABBABAABA" t nil)
-                   "xyBxyBBxyBxyBxy"))
-    (should (equal (replace-regexp-in-string
-                    "a[bc]*" "xyz" "a A ab AB Ab aB abc ABC Abc AbC aBc")
-                   "xyz XYZ xyz XYZ Xyz xyz xyz XYZ Xyz Xyz xyz"))
-    (should (equal (replace-regexp-in-string
-                    "a[bc]*" "xyz" "a A ab AB Ab aB abc ABC Abc AbC aBc" t nil)
-                   "xyz xyz xyz xyz xyz xyz xyz xyz xyz xyz xyz")))
-  (let ((case-fold-search nil))
-    (should (equal (replace-regexp-in-string "a+" "xy" "ABAABBABAABA")
-                   "ABAABBABAABA")))
-  ;; group substitution
-  (should (equal (replace-regexp-in-string
-                  "a\\(b*\\)" "<\\1,\\&>" "babbcaabacbab")
-                 "b<bb,abb>c<,a><b,ab><,a>cb<b,ab>"))
-  (should (equal (replace-regexp-in-string
-                  "x\\(?2:..\\)\\(?1:..\\)\\(..\\)\\(..\\)\\(..\\)"
-                  "<\\3,\\5,\\4,\\1,\\2>" "yxabcdefghijkl")
-                 "y<ef,ij,gh,cd,ab>kl"))
-  ;; LITERAL
-  (should (equal (replace-regexp-in-string
-                  "a\\(b*\\)" "<\\1,\\&>" "babbcaabacbab" nil t)
-                 "b<\\1,\\&>c<\\1,\\&><\\1,\\&><\\1,\\&>cb<\\1,\\&>"))
-  (should (equal (replace-regexp-in-string
-                  "a" "\\\\,\\?" "aba")
-                 "\\,\\?b\\,\\?"))
-  (should (equal (replace-regexp-in-string
-                  "a" "\\\\,\\?" "aba" nil t)
-                 "\\\\,\\?b\\\\,\\?"))
-  ;; SUBEXP
-  ; Available in subr-replace-regexp-in-string. Not supported here
-  ; (should (equal (replace-regexp-in-string
-  ;                 "\\(a\\)\\(b*\\)c" "xy" "babbcdacd" nil nil 2)
-  ;                "baxycdaxycd"))
-  ;; START
-  ; Available in subr-replace-regexp-in-string. Not supported here
-  ; (should (equal (replace-regexp-in-string
-  ;                 "ab" "x" "abcabdabeabf" nil nil nil 4)
-  ;                "bdxexf"))
-  ;; An empty pattern matches once before every character.
-  (should (equal (replace-regexp-in-string "" "x" "abc")
-                 "xaxbxc"))
-  (should (equal (replace-regexp-in-string "y*" "x" "abc")
-                 "xaxbxc"))
-  ;; replacement function
-  (should (equal (replace-regexp-in-string
-                  "a\\(b*\\)c"
-                  (lambda (s)
-                    (format "<%s,%s,%s,%s,%s>"
-                            s
-                            (match-beginning 0) (match-end 0)
-                            (match-beginning 1) (match-end 1)))
-                  "babbcaacabc")
-                 "b<abbc,0,4,1,3>a<ac,0,2,1,1><abc,0,3,1,2>")))
-
-(ert-deftest replace-regexp-in-string-after-27.1-test ()
-  ;; anchors (bug#15107, bug#44861)
-  (when (version< "27.1" emacs-version)
-    (should (equal (replace-regexp-in-string "a\\B" "b" "a aaaa")
-                   "a bbba"))
-    (should (equal (replace-regexp-in-string "\\`\\|x" "z" "--xx--")
-                   "z--zz--"))))
 
 (ert-deftest hypb:installation-type-test ()
   "Verify installation type alternatives."

--- a/test/hypb-tests.el
+++ b/test/hypb-tests.el
@@ -3,9 +3,9 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:     5-Apr-21 at 18:53:10
-;; Last-Mod:     15-Jul-22 at 23:09:21 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 23:26:35 by Mats Lidell
 ;;
-;; Copyright (C) 2022  Free Software Foundation, Inc.
+;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.

--- a/test/hypb-tests.el
+++ b/test/hypb-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:     5-Apr-21 at 18:53:10
-;; Last-Mod:      5-Feb-22 at 21:21:59 by Bob Weiner
+;; Last-Mod:     15-Jul-22 at 18:48:03 by Mats Lidell
 ;;
 ;; Copyright (C) 2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -23,6 +23,10 @@
 
 ;; Test for replace-regexp-in-string copied from emacs src
 (ert-deftest hypb:replace-match-string-test ()
+  ;; Test cases added before refactoring to check new = nil case
+  (should (equal (hypb:replace-match-string ".*" "abc" nil) "abc"))
+  (should (equal (hypb:replace-match-string ".*" "abc" "x") "x"))
+
   (should (equal (hypb:replace-match-string "a+" "abaabbabaaba" "xy")
                  "xybxybbxybxybxy"))
   ;; FIXEDCASE

--- a/test/hypb-tests.el
+++ b/test/hypb-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:     5-Apr-21 at 18:53:10
-;; Last-Mod:     15-Jul-22 at 18:48:03 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 20:32:47 by Mats Lidell
 ;;
 ;; Copyright (C) 2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -24,43 +24,43 @@
 ;; Test for replace-regexp-in-string copied from emacs src
 (ert-deftest hypb:replace-match-string-test ()
   ;; Test cases added before refactoring to check new = nil case
-  (should (equal (hypb:replace-match-string ".*" "abc" nil) "abc"))
-  (should (equal (hypb:replace-match-string ".*" "abc" "x") "x"))
+  (should (equal (hypb:replace-match-string ".*" nil "abc") "abc"))
+  (should (equal (hypb:replace-match-string ".*" "x" "abc") "x"))
 
-  (should (equal (hypb:replace-match-string "a+" "abaabbabaaba" "xy")
+  (should (equal (hypb:replace-match-string "a+" "xy" "abaabbabaaba")
                  "xybxybbxybxybxy"))
   ;; FIXEDCASE
   (let ((case-fold-search t))
-    (should (equal (hypb:replace-match-string "a+" "ABAABBABAABA" "xy")
+    (should (equal (hypb:replace-match-string "a+" "xy" "ABAABBABAABA")
                    "XYBXYBBXYBXYBXY"))
-    (should (equal (hypb:replace-match-string "a+" "ABAABBABAABA" "xy" nil t)
+    (should (equal (hypb:replace-match-string "a+" "xy" "ABAABBABAABA" nil t)
                    "xyBxyBBxyBxyBxy"))
     (should (equal (hypb:replace-match-string
-                    "a[bc]*" "a A ab AB Ab aB abc ABC Abc AbC aBc" "xyz")
+                    "a[bc]*" "xyz" "a A ab AB Ab aB abc ABC Abc AbC aBc")
                    "xyz XYZ xyz XYZ Xyz xyz xyz XYZ Xyz Xyz xyz"))
     (should (equal (hypb:replace-match-string
-                    "a[bc]*" "a A ab AB Ab aB abc ABC Abc AbC aBc" "xyz" nil t)
+                    "a[bc]*" "xyz" "a A ab AB Ab aB abc ABC Abc AbC aBc" nil t)
                    "xyz xyz xyz xyz xyz xyz xyz xyz xyz xyz xyz")))
   (let ((case-fold-search nil))
-    (should (equal (hypb:replace-match-string "a+" "ABAABBABAABA" "xy")
+    (should (equal (hypb:replace-match-string "a+" "xy" "ABAABBABAABA")
                    "ABAABBABAABA")))
   ;; group substitution
   (should (equal (hypb:replace-match-string
-                  "a\\(b*\\)" "babbcaabacbab" "<\\1,\\&>")
+                  "a\\(b*\\)" "<\\1,\\&>" "babbcaabacbab")
                  "b<bb,abb>c<,a><b,ab><,a>cb<b,ab>"))
   (should (equal (hypb:replace-match-string
                   "x\\(?2:..\\)\\(?1:..\\)\\(..\\)\\(..\\)\\(..\\)"
-                  "yxabcdefghijkl" "<\\3,\\5,\\4,\\1,\\2>")
+                  "<\\3,\\5,\\4,\\1,\\2>" "yxabcdefghijkl")
                  "y<ef,ij,gh,cd,ab>kl"))
   ;; LITERAL
   (should (equal (hypb:replace-match-string
-                  "a\\(b*\\)" "babbcaabacbab" "<\\1,\\&>" t nil)
+                  "a\\(b*\\)" "<\\1,\\&>" "babbcaabacbab" t nil)
                  "b<\\1,\\&>c<\\1,\\&><\\1,\\&><\\1,\\&>cb<\\1,\\&>"))
   (should (equal (hypb:replace-match-string
-                  "a" "aba" "\\\\,\\?")
+                  "a" "\\\\,\\?" "aba")
                  "\\,\\?b\\,\\?"))
   (should (equal (hypb:replace-match-string
-                  "a" "aba" "\\\\,\\?" t nil)
+                  "a" "\\\\,\\?" "aba" t nil)
                  "\\\\,\\?b\\\\,\\?"))
   ;; SUBEXP
   ; Available in subr-replace-regexp-in-string. Not supported here
@@ -73,27 +73,27 @@
   ;                 "ab" "x" "abcabdabeabf" nil nil nil 4)
   ;                "bdxexf"))
   ;; An empty pattern matches once before every character.
-  (should (equal (hypb:replace-match-string "" "abc" "x")
+  (should (equal (hypb:replace-match-string "" "x" "abc")
                  "xaxbxc"))
-  (should (equal (hypb:replace-match-string "y*" "abc" "x")
+  (should (equal (hypb:replace-match-string "y*" "x" "abc")
                  "xaxbxc"))
   ;; replacement function
   (should (equal (hypb:replace-match-string
                   "a\\(b*\\)c"
-                  "babbcaacabc"
                   (lambda (s)
                     (format "<%s,%s,%s,%s,%s>"
                             s
                             (match-beginning 0) (match-end 0)
-                            (match-beginning 1) (match-end 1))))
+                            (match-beginning 1) (match-end 1)))
+                  "babbcaacabc")
                  "b<abbc,0,4,1,3>a<ac,0,2,1,1><abc,0,3,1,2>")))
 
 (ert-deftest hypb:replace-match-string-after-27.1-test ()
   ;; anchors (bug#15107, bug#44861)
   (when (version< "27.1" emacs-version)
-    (should (equal (hypb:replace-match-string "a\\B" "a aaaa" "b")
+    (should (equal (hypb:replace-match-string "a\\B" "b" "a aaaa")
                    "a bbba"))
-    (should (equal (hypb:replace-match-string "\\`\\|x" "--xx--" "z")
+    (should (equal (hypb:replace-match-string "\\`\\|x" "z" "--xx--")
                    "z--zz--"))))
 
 (ert-deftest hypb:installation-type-test ()

--- a/test/hypb-tests.el
+++ b/test/hypb-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:     5-Apr-21 at 18:53:10
-;; Last-Mod:     15-Jul-22 at 21:40:52 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 22:07:35 by Mats Lidell
 ;;
 ;; Copyright (C) 2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -22,64 +22,64 @@
 (require 'el-mock)
 
 ;; Test for replace-regexp-in-string copied from emacs src
-(ert-deftest hypb:replace-match-string-test ()
+(ert-deftest replace-regexp-in-string-test ()
   ;; Test cases added before refactoring to check new = nil case
   ;; Disabled due to nil not being a valid third arg in replace-regexp-in-string.
-  ;; (should (equal (hypb:replace-match-string ".*" nil "abc") "abc"))
-  (should (equal (hypb:replace-match-string ".*" "x" "abc") "x"))
+  ;; (should (equal (replace-regexp-in-string ".*" nil "abc") "abc"))
+  (should (equal (replace-regexp-in-string ".*" "x" "abc") "x"))
 
-  (should (equal (hypb:replace-match-string "a+" "xy" "abaabbabaaba")
+  (should (equal (replace-regexp-in-string "a+" "xy" "abaabbabaaba")
                  "xybxybbxybxybxy"))
   ;; FIXEDCASE
   (let ((case-fold-search t))
-    (should (equal (hypb:replace-match-string "a+" "xy" "ABAABBABAABA")
+    (should (equal (replace-regexp-in-string "a+" "xy" "ABAABBABAABA")
                    "XYBXYBBXYBXYBXY"))
-    (should (equal (hypb:replace-match-string "a+" "xy" "ABAABBABAABA" t nil)
+    (should (equal (replace-regexp-in-string "a+" "xy" "ABAABBABAABA" t nil)
                    "xyBxyBBxyBxyBxy"))
-    (should (equal (hypb:replace-match-string
+    (should (equal (replace-regexp-in-string
                     "a[bc]*" "xyz" "a A ab AB Ab aB abc ABC Abc AbC aBc")
                    "xyz XYZ xyz XYZ Xyz xyz xyz XYZ Xyz Xyz xyz"))
-    (should (equal (hypb:replace-match-string
+    (should (equal (replace-regexp-in-string
                     "a[bc]*" "xyz" "a A ab AB Ab aB abc ABC Abc AbC aBc" t nil)
                    "xyz xyz xyz xyz xyz xyz xyz xyz xyz xyz xyz")))
   (let ((case-fold-search nil))
-    (should (equal (hypb:replace-match-string "a+" "xy" "ABAABBABAABA")
+    (should (equal (replace-regexp-in-string "a+" "xy" "ABAABBABAABA")
                    "ABAABBABAABA")))
   ;; group substitution
-  (should (equal (hypb:replace-match-string
+  (should (equal (replace-regexp-in-string
                   "a\\(b*\\)" "<\\1,\\&>" "babbcaabacbab")
                  "b<bb,abb>c<,a><b,ab><,a>cb<b,ab>"))
-  (should (equal (hypb:replace-match-string
+  (should (equal (replace-regexp-in-string
                   "x\\(?2:..\\)\\(?1:..\\)\\(..\\)\\(..\\)\\(..\\)"
                   "<\\3,\\5,\\4,\\1,\\2>" "yxabcdefghijkl")
                  "y<ef,ij,gh,cd,ab>kl"))
   ;; LITERAL
-  (should (equal (hypb:replace-match-string
+  (should (equal (replace-regexp-in-string
                   "a\\(b*\\)" "<\\1,\\&>" "babbcaabacbab" nil t)
                  "b<\\1,\\&>c<\\1,\\&><\\1,\\&><\\1,\\&>cb<\\1,\\&>"))
-  (should (equal (hypb:replace-match-string
+  (should (equal (replace-regexp-in-string
                   "a" "\\\\,\\?" "aba")
                  "\\,\\?b\\,\\?"))
-  (should (equal (hypb:replace-match-string
+  (should (equal (replace-regexp-in-string
                   "a" "\\\\,\\?" "aba" nil t)
                  "\\\\,\\?b\\\\,\\?"))
   ;; SUBEXP
   ; Available in subr-replace-regexp-in-string. Not supported here
-  ; (should (equal (hypb:replace-match-string
+  ; (should (equal (replace-regexp-in-string
   ;                 "\\(a\\)\\(b*\\)c" "xy" "babbcdacd" nil nil 2)
   ;                "baxycdaxycd"))
   ;; START
   ; Available in subr-replace-regexp-in-string. Not supported here
-  ; (should (equal (hypb:replace-match-string
+  ; (should (equal (replace-regexp-in-string
   ;                 "ab" "x" "abcabdabeabf" nil nil nil 4)
   ;                "bdxexf"))
   ;; An empty pattern matches once before every character.
-  (should (equal (hypb:replace-match-string "" "x" "abc")
+  (should (equal (replace-regexp-in-string "" "x" "abc")
                  "xaxbxc"))
-  (should (equal (hypb:replace-match-string "y*" "x" "abc")
+  (should (equal (replace-regexp-in-string "y*" "x" "abc")
                  "xaxbxc"))
   ;; replacement function
-  (should (equal (hypb:replace-match-string
+  (should (equal (replace-regexp-in-string
                   "a\\(b*\\)c"
                   (lambda (s)
                     (format "<%s,%s,%s,%s,%s>"
@@ -89,12 +89,12 @@
                   "babbcaacabc")
                  "b<abbc,0,4,1,3>a<ac,0,2,1,1><abc,0,3,1,2>")))
 
-(ert-deftest hypb:replace-match-string-after-27.1-test ()
+(ert-deftest replace-regexp-in-string-after-27.1-test ()
   ;; anchors (bug#15107, bug#44861)
   (when (version< "27.1" emacs-version)
-    (should (equal (hypb:replace-match-string "a\\B" "b" "a aaaa")
+    (should (equal (replace-regexp-in-string "a\\B" "b" "a aaaa")
                    "a bbba"))
-    (should (equal (hypb:replace-match-string "\\`\\|x" "z" "--xx--")
+    (should (equal (replace-regexp-in-string "\\`\\|x" "z" "--xx--")
                    "z--zz--"))))
 
 (ert-deftest hypb:installation-type-test ()

--- a/test/hypb-tests.el
+++ b/test/hypb-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:     5-Apr-21 at 18:53:10
-;; Last-Mod:     15-Jul-22 at 20:32:47 by Mats Lidell
+;; Last-Mod:     15-Jul-22 at 20:58:43 by Mats Lidell
 ;;
 ;; Copyright (C) 2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -33,13 +33,13 @@
   (let ((case-fold-search t))
     (should (equal (hypb:replace-match-string "a+" "xy" "ABAABBABAABA")
                    "XYBXYBBXYBXYBXY"))
-    (should (equal (hypb:replace-match-string "a+" "xy" "ABAABBABAABA" nil t)
+    (should (equal (hypb:replace-match-string "a+" "xy" "ABAABBABAABA" t nil)
                    "xyBxyBBxyBxyBxy"))
     (should (equal (hypb:replace-match-string
                     "a[bc]*" "xyz" "a A ab AB Ab aB abc ABC Abc AbC aBc")
                    "xyz XYZ xyz XYZ Xyz xyz xyz XYZ Xyz Xyz xyz"))
     (should (equal (hypb:replace-match-string
-                    "a[bc]*" "xyz" "a A ab AB Ab aB abc ABC Abc AbC aBc" nil t)
+                    "a[bc]*" "xyz" "a A ab AB Ab aB abc ABC Abc AbC aBc" t nil)
                    "xyz xyz xyz xyz xyz xyz xyz xyz xyz xyz xyz")))
   (let ((case-fold-search nil))
     (should (equal (hypb:replace-match-string "a+" "xy" "ABAABBABAABA")
@@ -54,13 +54,13 @@
                  "y<ef,ij,gh,cd,ab>kl"))
   ;; LITERAL
   (should (equal (hypb:replace-match-string
-                  "a\\(b*\\)" "<\\1,\\&>" "babbcaabacbab" t nil)
+                  "a\\(b*\\)" "<\\1,\\&>" "babbcaabacbab" nil t)
                  "b<\\1,\\&>c<\\1,\\&><\\1,\\&><\\1,\\&>cb<\\1,\\&>"))
   (should (equal (hypb:replace-match-string
                   "a" "\\\\,\\?" "aba")
                  "\\,\\?b\\,\\?"))
   (should (equal (hypb:replace-match-string
-                  "a" "\\\\,\\?" "aba" t nil)
+                  "a" "\\\\,\\?" "aba" nil t)
                  "\\\\,\\?b\\\\,\\?"))
   ;; SUBEXP
   ; Available in subr-replace-regexp-in-string. Not supported here


### PR DESCRIPTION
## What

`hypb:replace-match-string` with Emacs `replace-regexp-in-string`.

## Why

The internal hypb function is almost a perfect  match with the standard function but with the order of the arguments slightly different which is a bit confusing. The functionality is further more based on `replace-regexp-in-string` with a few checks performed before dispatching. These small checks does not seem to matter!? (Our unit tests does not complain anyway.)

## Note

Since we don't have 100% test coverage this type of change could be a bit dangerous. It is for that reason performed in steps with each commit providing some logic change. The test suite has been run during there commit steps to ensure that error cases are identified and fixed by later steps.

@rswgnu Maybe not a priority but I thought this would be a way to remove the test case that fails for 27.2 related to this functionality. I think you at some occasions been talking about doing this change and I wanted to see how difficult it would be,