### PR TITLE
Doc strings within 80 char limit for hmouse-tag.el

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2022-07-20  Mats Lidell  <matsl@gnu.org>
+
+* hmouse-tag.el: Shorten docs strings to be within 80 char limit.
+
 2022-07-19  Mats Lidell  <matsl@gnu.org>
 
 * test/demo-tests.el (fast-demo-key-series-shell-apropos): Add optional

--- a/hmouse-tag.el
+++ b/hmouse-tag.el
@@ -1446,7 +1446,8 @@ to look.  If no tags file is found, an error is signaled."
 ;;; ************************************************************************
 
 (defun smart-tags-noselect-function ()
-  "Return the best available function for finding a tag definition without selecting it."
+  "Return the best available function for finding a tag definition.
+The function does not select the tag definition."
   (car (delq nil (mapcar (lambda (func) (if (fboundp func) func))
 			 #'(xref-definition find-tag-noselect find-tag-internal)))))
 


### PR DESCRIPTION
## What

Doc strings within 80 char limit for hmouse-tag.el

## Why

Extracted from longer PR for easier review.