### PR TITLE
Doc strings within 80 char limit for hmoccur.el

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2022-09-14  Mats Lidell  <matsl@gnu.org>
+
+* hmoccur.el: Shorten docs strings to be within 80 char limit.
+
 2022-09-13  Mats Lidell  <matsl@gnu.org>
 
 * hmouse-info.el: Shorten docs strings to be within 80 char limit.

--- a/hmoccur.el
+++ b/hmoccur.el
@@ -3,7 +3,7 @@
 ;; Author:       Markus Freericks <Mfx@cs.tu-berlin.de> / Bob Weiner
 ;;
 ;; Orig-Date:     1-Aug-91
-;; Last-Mod:     18-Apr-22 at 00:19:03 by Mats Lidell
+;; Last-Mod:     25-Jul-22 at 20:00:01 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -181,8 +181,10 @@ serves as a menu to find any of the occurrences in this buffer.
   (setq mode-name "Moccur"))
 
 (defun moccur-noselect ()
-  "Return (destination-buffer line-number occur-match-text) for the current moccur buffer line.
-Signal an error if not on a valid occurrence line."
+  "Return match data for the current moccur buffer line.
+Match data is returned as a list (destination-buffer line-number
+occur-match-text).  Signal an error if not on a valid occurrence
+line."
   (if (not (eq major-mode 'moccur-mode))
       (error "'moccur-to' must be called within a moccur buffer")
     (let (beg file-path lineno dstbuf occur-match)


### PR DESCRIPTION
## What

Doc strings within 80 char limit for hmoccur.el.

## Why

Long doc strings produces warnings when byte compiling.