### PR TITLE
Use loaddefs-generate when available

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2022-08-14  Mats Lidell  <matsl@gnu.org>
+
+* hload-path.el (hload-path--make-directory-autoloads): Use
+    loaddefs-generate if available.
+
 2022-08-07  Mats Lidell  <matsl@gnu.org>
 
 * kotl/kvspec.el: Shorten docs strings to be within 80 char limit.

--- a/hload-path.el
+++ b/hload-path.el
@@ -111,9 +111,12 @@ the symbol list.  For `suspicious', only `set-buffer' can be used."
 ;; New autoload generation function defined only in Emacs 28
 
 (defalias 'hload-path--make-directory-autoloads
-  (if (fboundp #'make-directory-autoloads)
-      #'make-directory-autoloads
-    #'hload-path--internal-make-directory-autoloads))
+  (cond ((fboundp 'loaddefs-generate)
+         #'loaddefs-generate)
+        ((fboundp #'make-directory-autoloads)
+         #'make-directory-autoloads)
+        (t
+         #'hload-path--internal-make-directory-autoloads)))
 
 (defun hload-path--internal-make-directory-autoloads (dir output-file)
   "Update autoload definitions for Lisp files in the directories DIRS.


### PR DESCRIPTION
## What

Use loaddefs-generate when available.

## Why

Autoload.el is obsolete since 29.1.