### PR TITLE
Adjust to new tramp regexp in emacs 29

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2022-09-12  Mats Lidell  <matsl@gnu.org>
+
+* hpath.el (hpath:tramp-file-name-regexp): Handle tramp regexp from
+    different Emacs versions.
+
+* test/hpath-tests.el (hpath:remote-at-p): Add test case for
+    hpath:remote-at-p.
+
 2022-08-29  Bob Weiner  <rsw@gnu.org>
 
 * hbut.el (ebut:key-src): Rename to 'ebut:to-key-src'.

--- a/hpath.el
+++ b/hpath.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Nov-91 at 00:44:23
-;; Last-Mod:     24-Jul-22 at 01:02:25 by Bob Weiner
+;; Last-Mod:     12-Sep-22 at 23:57:39 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -724,7 +724,11 @@ Removes bol anchor and removes match to empty string if present."
 	 (tramp-regexp (car (if (fboundp 'tramp-file-name-structure)
 				(tramp-file-name-structure)
 			      tramp-file-name-structure))))
-    (substring-no-properties (replace-regexp-in-string "\\\\'" "" tramp-regexp) 1)))
+    (replace-regexp-in-string
+     "\\\\'" ""
+     (cond ((string-match-p "\\\\(\\?:^/\\\\)" tramp-regexp)
+            (replace-regexp-in-string  "\\\\(\\?:\\^/\\\\)" "\\(?:/\\)" tramp-regexp nil t))
+           (t (substring tramp-regexp 1))))))
 
 (defun hpath:remote-at-p ()
   "Return a remote pathname that point is within or nil.

--- a/test/hpath-tests.el
+++ b/test/hpath-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    28-Feb-21 at 23:26:00
-;; Last-Mod:     24-Jul-22 at 10:31:32 by Bob Weiner
+;; Last-Mod:     12-Sep-22 at 22:11:14 by Mats Lidell
 ;;
 ;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -247,6 +247,14 @@
               (goto-char 4)
               (hy-test-helpers:action-key-should-call-hpath:find (expand-file-name py-file hyperb:dir)))))
       (setenv "PYTHONPATH" old-python-path))))
+
+(ert-deftest hpath:remote-at-p ()
+  "Verify hpath:remote-at-p match a tramp remote file name."
+  (let ((tramp-file "/ssh:user@host.org:/home/username/file"))
+    (with-temp-buffer
+      (insert (concat "\"" tramp-file "\""))
+      (goto-char 5)
+      (should (string= (hpath:remote-at-p) tramp-file)))))
 
 (provide 'hpath-tests)
 ;;; hpath-tests.el ends here


### PR DESCRIPTION
## What 

Adjust to new tramp regexp in emacs 29

## Why

The value of tramp regexp has changed so we need to adjust the modification of it based on how the origin regexp looks.  Defaults to old behavior of just cutting of the first char, the anchor, in the regexp.

Adds a text case to verify that it works for different Emacs versions.