### PR TITLE
Use maintenance release 28.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [27.2, 28.1, master]
+        version: [27.2, 28.2, master]
     container: silex/emacs:${{ matrix.version }}-ci
 
     # Steps represent a sequence of tasks that will be executed as part of the job


### PR DESCRIPTION
## What

Use maintenance release 28.2.

## Why

Bugfix release 28.2 is here so we should change the PR build to use that image instead of 28.1. Not sure how to go about that the build still says it requires 28.1 but after approval I hope it will me possible to merge this and change this requirement to 28.2.