### PR TITLE
Update README

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,5 @@
+Adding a line to trigger a build to see if the 28.1 requirement is still enforced although the workflow was changed.
+
 # README --- Information GNU Hyperbole users and maintainers should read
 #
 # Author:       Bob Weiner


### PR DESCRIPTION
Adding a line to trigger a build to see if the 28.1 requirement is still enforced although the workflow was changed.