### PR TITLE
Add 28.1 in again

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [27.2, 28.2, master]
+        version: [27.2, 28.1, 28.2, master]
     container: silex/emacs:${{ matrix.version }}-ci
 
     # Steps represent a sequence of tasks that will be executed as part of the job


### PR DESCRIPTION
## What

Add 28.1 in again.

## Why

The 28.1 requirement is sticky and we need to figure out how to remove that.  Adding back the 28.1 so that the CI build works again.