### PR TITLE
Show docstring warnings again

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2022-10-11  Mats Lidell  <matsl@gnu.org>
+
+* Makefile (bin, eln): Show docstring warnings again.
+
 2022-10-10  Mats Lidell  <matsl@gnu.org>
 
 * kotl/kview.el (kview:create): Shorten docs strings to be within 80 char

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:     14-Sep-22 at 22:16:31 by Mats Lidell
+# Last-Mod:      7-Oct-22 at 22:17:00 by Mats Lidell
 #
 # Copyright (C) 1994-2022  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -306,8 +306,7 @@ src: autoloads tags
 # which do not yet exist, plus build TAGS file.
 bin: src
 	$(RM) *.elc kotl/*.elc
-	$(EMACS_BATCH) --eval="(setq-default byte-compile-warnings '(not docstrings))" \
-		-f batch-byte-compile $(EL_KOTL) $(EL_COMPILE)
+	$(EMACS_BATCH) -f batch-byte-compile $(EL_KOTL) $(EL_COMPILE)
 
 # Create -l "file.el" load-file command-line args for each Hyperbole .el file for use in
 # eln native compile target below.
@@ -320,7 +319,6 @@ load-hyperbole:
 eln: src
 	$(EMACS_BATCH) \
           $(LOAD_EL) \
-	  --eval="(setq-default byte-compile-warnings '(not docstrings))" \
 	  -f batch-native-compile $(EL_KOTL) $(EL_COMPILE)
 
 # Byte compile files but apply a filter for either including or

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:      7-Oct-22 at 22:17:00 by Mats Lidell
+# Last-Mod:     11-Oct-22 at 22:22:16 by Mats Lidell
 #
 # Copyright (C) 1994-2022  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -304,6 +304,10 @@ src: autoloads tags
 
 # Remove and then rebuild all byte-compiled .elc files, even those .elc files
 # which do not yet exist, plus build TAGS file.
+#
+# Use this to suppress docstring warnings.
+#	$(EMACS_BATCH) --eval="(setq-default byte-compile-warnings '(not docstrings))" \
+#		-f batch-byte-compile $(EL_KOTL) $(EL_COMPILE)
 bin: src
 	$(RM) *.elc kotl/*.elc
 	$(EMACS_BATCH) -f batch-byte-compile $(EL_KOTL) $(EL_COMPILE)
@@ -316,6 +320,11 @@ load-hyperbole:
 	$(EMACS_BATCH) \
           $(LOAD_EL)
 
+# Use this to suppress docstring warnings.
+# 	$(EMACS_BATCH) \
+#           $(LOAD_EL) \
+#           --eval="(setq-default byte-compile-warnings '(not docstrings))" \
+# 	    -f batch-native-compile $(EL_KOTL) $(EL_COMPILE)
 eln: src
 	$(EMACS_BATCH) \
           $(LOAD_EL) \


### PR DESCRIPTION
## What

Show docstring warnings again.

## Why

When docstring warnings are gone we need to keep them under control and echoing them when byte compiling is our best option. This PR makes the build show docstring warnings for the `bin` and `eln` targets.

There is a flag that turns all warnings to errors but we have many more warnings still remaining so we are not ready for that yet I think. It can not be set to turn specific warnings to errors.

We could consider to implement our own checker that would parse (or grep) compilation output for specific warnings we want to fail the build on. For now that feels like over engineering. wdyt?