### PR TITLE
Update docstrings to not use single quotes, removes warning

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 2022-10-09  Mats Lidell  <matsl@gnu.org>
 
+* Update docstrings to not use unescaped quotes.
+
 * hyrolo.el:
 * hyrolo-demo.el:
 * hui-mini.el:

--- a/hact.el
+++ b/hact.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:     18-Sep-22 at 22:23:21 by Mats Lidell
+;; Last-Mod:      7-Oct-22 at 23:01:56 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -38,7 +38,7 @@ e.g. to inhibit actions.")
 
 (defvar symtable:category-plist nil
   "Property list mapping Hyperbole type category symbols to symtables.
-The type categories are either 'actypes or 'ibtypes.")
+The type categories are either `actypes' or `ibtypes'.")
 
 (defsubst symtable:hash-table (symtable)
   "Return the hash-table containing symbol names and values from SYMTABLE."
@@ -193,7 +193,7 @@ Assume PROPERTY is a valid set.  Use `eq' for comparison."
 (defun    htype:category (type-category)
   "Return list of symbols in Hyperbole TYPE-CATEGORY in priority order.
 Symbols contain category component.
-TYPE-CATEGORY should be 'actypes, 'ibtypes or nil for all."
+TYPE-CATEGORY should be `actypes', `ibtypes' or nil for all."
   (let ((def-symbols (symset:get type-category 'symbols))
 	(symtable (symtable:select type-category)))
     ;; Expand def-symbols to Elisp symbols by adding prefix

--- a/hargs.el
+++ b/hargs.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    31-Oct-91 at 23:17:35
-;; Last-Mod:     29-Aug-22 at 00:21:40 by Bob Weiner
+;; Last-Mod:      7-Oct-22 at 22:40:26 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -168,7 +168,7 @@ indicates that the following character is a Hyperbole interactive
 extension command character.
 
 May return a single value or a list of values, in which case the first
-element of the list is always the symbol 'args."
+element of the list is always the symbol \\='args."
   (let (func cmd prompt)
     (cond ((or (null interactive-entry) (equal interactive-entry ""))
 	   (error "(hargs:get): Empty interactive-entry arg"))

--- a/hbdata.el
+++ b/hbdata.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Apr-91
-;; Last-Mod:      8-Jul-22 at 22:47:23 by Mats Lidell
+;; Last-Mod:      7-Oct-22 at 23:17:52 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -149,7 +149,7 @@ Search is case-insensitive.  Return list with elements:
   "Construct button data from optional MOD-LBL-KEY and BUT-SYM.
 Modify BUT-SYM attributes.  MOD-LBL-KEY nil means create a new
 entry, otherwise modify existing one.  Nil BUT-SYM means use
-'hbut:current'.  If successful, return a cons of
+`hbut:current'  If successful, return a cons of
  (button-data . button-instance-str), else nil."
   (let* ((b (hattr:copy (or but-sym 'hbut:current) 'but))
 	 (l (hattr:get b 'loc))
@@ -315,7 +315,7 @@ Hbdata is given by LBL-KEY, KEY-SRC and optional DIRECTORY.
 With optional CREATE-FLAG, if no such line exists, insert a new file entry at
 the beginning of the hbdata file (which is created if necessary).
 INSTANCE-FLAG non-nil means search for any button instance matching LBL-KEY and
-call FUNC with point right after any 'ebut:instance-sep' in match.
+call FUNC with point right after any `ebut:instance-sep' in match.
 Return value of evaluation when a matching entry is found or nil."
   (let (found
 	rtn
@@ -442,7 +442,7 @@ Return non-nil if KEY-SRC is found or created, else nil."
 (defun hbdata:write (&optional orig-lbl-key but-sym)
   "Try to write Hyperbole button data from optional ORIG-LBL-KEY and BUT-SYM.
 ORIG-LBL-KEY nil means create a new entry, otherwise modify existing one.
-BUT-SYM nil means use 'hbut:current'.  If successful, return
+BUT-SYM nil means use `hbut:current'.  If successful, return
 a button instance string to append to button label or t when first instance.
 On failure, return nil."
   (let ((cons (hbdata:build orig-lbl-key but-sym))

--- a/hbmap.el
+++ b/hbmap.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     6-Oct-91 at 06:34:05
-;; Last-Mod:     24-Jan-22 at 00:18:23 by Bob Weiner
+;; Last-Mod:      7-Oct-22 at 23:18:45 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -113,12 +113,12 @@ the error.  Optional NO-SAVE disables saving of the map after operation."
       "c:/_hyperb/" "~/.hyperb/")
   "Per user directory in which to store top level Hyperbole map data.
 Must end with a directory separator.
-Hyperbole will try to create it whenever 'hyperb:init' is called.")
+Hyperbole will try to create it whenever `hyperb:init' is called.")
 
 (defvar hbmap:dir-filename
   (expand-file-name  "HBMAP" hbmap:dir-user)
   "Name of a file that lists all dirs to which a user has written buttons.
-See also 'hbmap:dir-user'.
+See also `hbmap:dir-user'.
 If you change its value, you will be unable to search for buttons created by
 others who use a different value!")
 

--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:     29-Aug-22 at 01:35:59 by Bob Weiner
+;; Last-Mod:      7-Oct-22 at 23:28:56 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -2166,7 +2166,7 @@ log entries.  The buttons use this format: [<text to match>].
 The following defines the button type called search-git-log which
 calls hypb:fgrep-git-log with the text of the button as an argument:
 
-  (defil search-git-log \"[<\" \">]\" \".*\" #'hypb:fgrep-git-log)
+  (defil search-git-log \"[<\" \">]\" \".*\" #\\='hypb:fgrep-git-log)
 
 Place point after one of the above expressions and evaluate it with
 \\[eval-last-sexp] to define the implicit button type.  Then if you
@@ -2253,7 +2253,7 @@ PYTHONPATH environment variable setup, then pressing
 
    (defal pylib \"${PYTHONPATH}/%s\")
 
-defines a new action button link type called 'pylib' whose buttons
+defines a new action button link type called `pylib' whose buttons
 take the form of:
 
    <pylib PYTHON-LIBRARY-FILENAME>

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:      8-Oct-22 at 00:20:28 by Mats Lidell
+;; Last-Mod:      9-Oct-22 at 22:38:15 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022 Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -136,7 +136,7 @@ PATH-style variable, the path at point is used; empty paths, e.g. ::
 represent the current directory, '.'.
 
 Also works for delimited and non-delimited remote pathnames,
-recursive 'ls' listings, Texinfo @file{} entries, and hash-style
+recursive \\='ls' listings, Texinfo @file{} entries, and hash-style
 link references to HTML, XML, SGML, Markdown or Emacs outline
 headings, shell script comments, and MSWindows paths (see
 \"${hyperb:dir}/DEMO#POSIX and MSWindows Paths\" for details).

--- a/hmouse-drv.el
+++ b/hmouse-drv.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-90
-;; Last-Mod:     25-Jul-22 at 23:20:53 by Mats Lidell
+;; Last-Mod:      7-Oct-22 at 23:30:30 by Mats Lidell
 ;;
 ;; Copyright (C) 1989-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -213,14 +213,14 @@ This permits the Smart Keys to behave as paste keys.")
 
 ;;; Smart Key Release Functions
 (defun action-mouse-key-emacs (event)
-  "Set point to the current mouse cursor position and execute 'action-key'.
-EVENT will be passed to 'hmouse-function'."
+  "Set point to the current mouse cursor position and execute `action-key'.
+EVENT will be passed to `hmouse-function'."
   (interactive "e")
   (apply #'action-mouse-key (hmouse-key-release-args-emacs event)))
 
 (defun assist-mouse-key-emacs (event)
-  "Set point to the current mouse cursor position and execute 'assist-key'.
-EVENT will be passed to 'hmouse-function'."
+  "Set point to the current mouse cursor position and execute `assist-key'.
+EVENT will be passed to `hmouse-function'."
   (interactive "e")
   (apply #'assist-mouse-key (hmouse-key-release-args-emacs event)))
 
@@ -1446,7 +1446,7 @@ return current point as a marker."
 
 (defun hmouse-set-point-at (set-point-arg-list)
   "Set point to cursor position using SET-POINT-ARG-LIST and return t.
-If 'hmouse-set-point-command' is not bound to a function, this does nothing
+If `hmouse-set-point-command' is not bound to a function, this does nothing
 and returns nil."
   (when (fboundp hmouse-set-point-command)
     (or (if set-point-arg-list

--- a/hmouse-tag.el
+++ b/hmouse-tag.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    24-Aug-91
-;; Last-Mod:     14-Aug-22 at 19:18:17 by Mats Lidell
+;; Last-Mod:      7-Oct-22 at 23:31:35 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -72,7 +72,7 @@ Examples include:
 (defcustom smart-c-cpp-include-path '("/usr/include/")
   "*Ordered list of include directories by default searched by C/C++ preprocessor.
 Each directory must end with a directory separator.  See also
-'smart-c-include-path'."
+`smart-c-include-path'."
   :type '(repeat directory)
   :group 'hyperbole-commands)
 

--- a/hpath.el
+++ b/hpath.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Nov-91 at 00:44:23
-;; Last-Mod:      7-Oct-22 at 00:19:55 by Mats Lidell
+;; Last-Mod:     10-Oct-22 at 22:50:52 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -102,7 +102,7 @@ path variable values.")
   "\\([^ \t\n\r\f:][^\t\n\r\f:]+\\(:[^0-9\t\n\r\f]*\\)*\\):\\([0-9]+\\)\\(:\\([0-9]+\\)\\)?$"
   "Regexp that matches to a path with optional #section and :line-num:col-num.
 Grouping 1 is path, grouping 3 is line number, grouping 4 is
-column number.  Allow for 'c:' single letter drive prefixes on
+column number.  Allow for \\='c:' single letter drive prefixes on
 MSWindows and Elisp vars with colons in them.")
 
 (defconst hpath:variable-regexp "\\$@?\{\\([^\}]+\\)@?\}"
@@ -136,7 +136,7 @@ The format is ${variable}.  Match grouping 1 is the name of the variable.")
 
 (defvar hpath:posix-mount-points-regexp
   "^\\(Filesystem\\|rootfs\\|none\\) "
-  "Regexp of 'mount' output lines that are not mount points of MSWindows paths.")
+  "Regexp of \\='mount' output lines that are not mount points of MSWindows paths.")
 
 (defvar hpath:mswindows-mount-prefix
   (cond ((eq system-type 'cygwin)
@@ -153,7 +153,7 @@ Must include a trailing directory separator or be nil.")
   "Regular expression matching an MSWindows drive letter.
 Matches at the beginning of a path string.  Grouping 2 is the
 actual letter of the drive.  If the value of
-'hpath:mswindows-mount-prefix' changes, then re-initialize this
+`hpath:mswindows-mount-prefix' changes, then re-initialize this
 constant.")
 
 (defconst hpath:mswindows-path-regexp "\\`.*\\.*[a-zA-Z0-9_.]"
@@ -170,7 +170,7 @@ posix-to-mswindows conversion.")
 (defun hpath:mswindows-to-posix (path)
   "Convert a MSWindows PATH to a Posix-style path or return the path unchanged.
 If path begins with an MSWindows drive letter, prefix the
-converted path with the value of 'hpath:mswindows-mount-prefix'."
+converted path with the value of `hpath:mswindows-mount-prefix'."
   (interactive "sMSWindows path to convert to POSIX: ")
   (when (and (stringp path) (not (equal path "\\\\")))
     (setq path (hpath:mswindows-to-posix-separators path))
@@ -191,7 +191,7 @@ converted path with the value of 'hpath:mswindows-mount-prefix'."
 (defun hpath:mswindows-to-posix-separators (path)
   "Replace backslashes with forward slashes and abbreviate the PATH if possible.
 Path must be a string or an error will be triggered.  See
-'abbreviate-file-name' for how path abbreviation is handled."
+`abbreviate-file-name' for how path abbreviation is handled."
     (setq path (replace-regexp-in-string "\\\\" "/" path)
           ;; Downcase any host and domain for mount-point matching
           path (if (string-match "\\`//[^/:]+" path)
@@ -206,7 +206,7 @@ Path must be a string or an error will be triggered.  See
 (defun hpath:posix-to-mswindows (path)
   "Convert a Posix-style PATH to an MSWindows path or return the path unchanged.
 If path begins with an optional mount prefix,
-'hpath:mswindows-mount-prefix', followed by an MSWindows drive
+`hpath:mswindows-mount-prefix', followed by an MSWindows drive
 letter, remove the mount prefix."
   (interactive "sPOSIX path to convert to MSWindows: ")
   (when (stringp path)
@@ -231,7 +231,7 @@ letter, remove the mount prefix."
 (defun hpath:posix-to-mswindows-separators (path)
   "Replace forward slashes with backslashes and abbreviate the PATH if possible.
 Path must be a string or an error will be triggered.  See
-'abbreviate-file-name' for how path abbreviation is handled."
+`abbreviate-file-name' for how path abbreviation is handled."
   (let ((directory-abbrev-alist hpath:posix-mount-point-to-mswindows-alist))
     (replace-regexp-in-string "/" "\\\\" (hpath:abbreviate-file-name path))))
 
@@ -268,7 +268,7 @@ Path must be a string or an error will be triggered.  See
 ;;;###autoload
 (defun hpath:cache-mswindows-mount-points ()
   "Cache valid MSWindows mounts when under a non-MSWindows OS, e.g. WSL.
-Mount points are cached in 'directory-abbrev-alist'.
+Mount points are cached in `directory-abbrev-alist'.
 Call this function manually if mount points change after Hyperbole is loaded."
   (interactive)
   (when (not hyperb:microsoft-os-p)
@@ -915,8 +915,8 @@ if (hpath:remote-available-p) returns nil."
 Path is expanded and normalized.  World-Wide Web urls are ignored
 and therefore dealt with by other code.  Delimiters may be:
 double quotes, open and close single quote, whitespace, or
-Texinfo file references.  If optional TYPE is the symbol 'file or
-'directory, then only that path type is accepted as a match.
+Texinfo file references.  If optional TYPE is the symbol \\='file or
+\\='directory, then only that path type is accepted as a match.
 Only locally reachable paths are checked for existence.  With
 optional NON-EXIST, nonexistent local paths are allowed.
 Absolute pathnames must begin with a `/' or `~'."
@@ -964,7 +964,7 @@ Absolute pathnames must begin with a `/' or `~'."
   "Call FUNC with a PATH and optional NON-EXIST flag.
 Path is stripped of any prefix operator and suffix location,
 NON-EXIST may be either t (path cannot contain whitespace) or
-'allow-spaces to allow for whitespace.
+\\='allow-spaces to allow for whitespace.
 
 Return the result of calling FUNC, which must be either nil or the
 possibly modified path, but with the prefix and suffix reattached.
@@ -1220,9 +1220,9 @@ PATH unchanged."
 	    (t (expand-file-name substituted-path))))))
 
 (defun hpath:prepend-shell-directory (&optional filename)
-  "Prepend subdir to a filename in an 'ls'-file listing.
-When in a shell buffer and on a filename result of an 'ls *' or
-recursive 'ls -R' or 'dir' command, prepend the subdir to the
+  "Prepend subdir to a filename in an \\='ls'-file listing.
+When in a shell buffer and on a filename result of an \\='ls *' or
+recursive \\='ls -R' or \\='dir' command, prepend the subdir to the
 filename at point, or optional FILENAME, when needed and return
 it, else return nil."
   (when (derived-mode-p #'shell-mode)
@@ -1629,13 +1629,13 @@ See also `hpath:internal-display-alist' for internal,
 
 (defun hpath:is-p (path &optional type non-exist)
   "Return normalized PATH if PATH is a Posix or MSWindows path, else nil.
-If optional TYPE is the symbol 'file or 'directory, then only that path type
+If optional TYPE is the symbol \\='file or \\='directory, then only that path type
 is accepted as a match.  The existence of the path is checked only for
 locally reachable paths (Info paths are not checked).
 
 Single spaces are permitted in the middle of existing pathnames, but not at
 the start or end.  With optional NON-EXIST equal to t, nonexistent local
-paths without spaces are allowed.  Set NON-EXIST to 'allow-spaces to allow
+paths without spaces are allowed.  Set NON-EXIST to \\='allow-spaces to allow
 spaces in non-existent paths.
 
 Before the pathname is checked for existence, sequences of tabs and newlines

--- a/hsmail.el
+++ b/hsmail.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     9-May-91 at 04:50:20
-;; Last-Mod:     17-Apr-22 at 11:23:02 by Bob Weiner
+;; Last-Mod:      7-Oct-22 at 23:52:10 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -55,7 +55,7 @@ for a comment.")
   "Add a comment to the current outgoing message.
 Only if Hyperbole has been loaded and `inhibit-hyperbole-messaging' is nil.
 Optional COMMENT-FORM is evaluated to obtain the string to add to the
-message.  If not given, 'smail:comment' is evaluated by default."
+message.  If not given, `smail:comment' is evaluated by default."
   (if (and (featurep 'hyperbole) (not inhibit-hyperbole-messaging))
       (let ((comment (eval (or comment-form smail:comment) t)))
 	(if comment
@@ -77,7 +77,7 @@ message.  If not given, 'smail:comment' is evaluated by default."
   "See `message-yank-original'.
 
 If supercite is in use, header fields are never deleted.
-Use (setq sc-nuke-mail-headers 'all) to have them removed."
+Use (setq sc-nuke-mail-headers \\='all) to have them removed."
   (let ((modified (buffer-modified-p))
 	body-text)
 	(when (and message-reply-buffer
@@ -141,7 +141,7 @@ Use (setq sc-nuke-mail-headers 'all) to have them removed."
 Put point before the text and mark after.
 
 Normally indent each nonblank line ARG spaces (default 3).
-However, if ‘mail-yank-prefix’ is non-nil, insert that prefix
+However, if `mail-yank-prefix’ is non-nil, insert that prefix
 on each line when `mail-indent-citation' is called.
 
 Apply `mail-citation-hook', `mail-yank-hook' or `mail-yank-hooks'
@@ -151,7 +151,7 @@ Just \\[universal-argument] as argument means don't indent,
 insert no prefix, and don't delete any header fields.
 
 If supercite is in use, header fields are never deleted.
-Use (setq sc-nuke-mail-headers 'all) to have them removed."
+Use (setq sc-nuke-mail-headers \\='all) to have them removed."
   (interactive "P")
   (if mail-reply-action
       (let ((start (point))

--- a/hsys-org.el
+++ b/hsys-org.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Jul-16 at 14:54:14
-;; Last-Mod:      7-Oct-22 at 22:08:03 by Mats Lidell
+;; Last-Mod:     10-Oct-22 at 22:55:01 by Mats Lidell
 ;;
 ;; Copyright (C) 2016-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -56,7 +56,7 @@
 ;;;###autoload
 (defcustom hsys-org-enable-smart-keys 'unset
   "This applies in Org major/minor modes only when `hyperbole-mode' is active.
-If set to 'unset prior to loading Hyperbole, then Hyperbole
+If set to \\='unset prior to loading Hyperbole, then Hyperbole
 initialization will set its value.
 
 The following table shows what the Smart Keys do in various contexts

--- a/hsys-youtube.el
+++ b/hsys-youtube.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    10-Jul-22 at 18:10:56
-;; Last-Mod:      2-Aug-22 at 14:50:45 by Mats Lidell
+;; Last-Mod:      7-Oct-22 at 23:54:20 by Mats Lidell
 ;;
 ;; Copyright (C) 2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -58,7 +58,7 @@ minutes, 45 seconds), where the hours and minutes are optional.")
 
 (defvar hsys-youtube-end-format "https://www.youtube.com/embed/%s?autoplay=1&start=%s&end=%s"
   "Format string used to play a section of a Youtube video.
-This requires use of the 'embed' api.
+This requires use of the `embed' api.
 
 The first %s is where the video id string is inserted; the second %s is
 where the start time string in seconds is inserted; the third %s is

--- a/hui-mini.el
+++ b/hui-mini.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Oct-91 at 20:13:17
-;; Last-Mod:      7-Oct-22 at 21:57:23 by Mats Lidell
+;; Last-Mod:     10-Oct-22 at 22:55:17 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -33,7 +33,7 @@ Also exits any active minibuffer menu.")
 (defvar hui:menu-quit            "Q"
   "*Upper case character string which quits selecting from a Hyperbole menu item.")
 (defvar hui:menu-abort           "\C-g"
-  "*Same function as 'hui:menu-quit'.")
+  "*Same function as `hui:menu-quit'.")
 (defvar hui:menu-top             "\C-t"
   "*Character string which returns to top Hyperbole menu.")
 
@@ -63,7 +63,7 @@ mini-menu).
 
 Two optional arguments may be given to invoke alternative menus.
 MENU (a symbol) specifies the menu to invoke from MENU-LIST, (a
-Hyperbole menu list structure).  MENU defaults to 'hyperbole and MENU-LIST
+Hyperbole menu list structure).  MENU defaults to \\='hyperbole and MENU-LIST
 to `hui:menus'.  See `hui:menus' definition for the format of the menu list
 structure.
 

--- a/hui-mouse.el
+++ b/hui-mouse.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-89
-;; Last-Mod:      3-Oct-22 at 22:15:54 by Mats Lidell
+;; Last-Mod:      7-Oct-22 at 23:42:31 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -73,35 +73,35 @@ In other context signal an error."
 
 (defcustom action-key-default-function #'action-key-error
   "*Function run by the Action Key in an unspecified context.
-Set it to #'hyperbole if you want it to display the Hyperbole minibuffer menu."
+Set it to `hyperbole' if you want it to display the Hyperbole minibuffer menu."
   :type 'function
   :group 'hyperbole-keys)
 
 (defcustom assist-key-default-function #'assist-key-error
   "*Function run by the Assist Key in an unspecified context.
-Set it to #'hkey-summarize if you want it to display a summary of
+Set it to `hkey-summarize' if you want it to display a summary of
 Smart Key behavior."
   :type 'function
   :group 'hyperbole-keys)
 
 (defcustom action-key-modeline-buffer-id-function #'dired-jump
   "*Function to call for Action Key clicks on the buffer id portion of a modeline.
-Its default value is #'dired-jump; set it to #'smart-treemacs-modeline
+Its default value is `dired-jump'; set it to `smart-treemacs-modeline'
 to use the Treemacs file manager package instead."
   :type 'function
   :group 'hyperbole-keys)
 
 (defcustom action-key-eol-function #'smart-scroll-up
   "*Function run by the Action Key at the end of a line.
-Its default value is #'smart-scroll-up.  To disable it, set it to
-#'ignore."
+Its default value is `smart-scroll-up'.  To disable it, set it to
+#\\='ignore."
   :type 'function
   :group 'hyperbole-keys)
 
 (defcustom assist-key-eol-function #'smart-scroll-down
   "*Function run by the Assist Key at the end of a line.
-Its default value is #'smart-scroll-down.  To disable it, set it to
-#'ignore."
+Its default value is `smart-scroll-down'.  To disable it, set it to
+#\\='ignore."
   :type 'function
   :group 'hyperbole-keys)
 

--- a/hui-window.el
+++ b/hui-window.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Sep-92
-;; Last-Mod:      5-Aug-22 at 00:02:46 by Mats Lidell
+;; Last-Mod:      7-Oct-22 at 23:39:57 by Mats Lidell
 ;;
 ;; Copyright (C) 1992-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -87,13 +87,13 @@
 
 (defcustom action-key-minibuffer-function #'hyperbole
   "*Function run by the Action Key after a click in an inactive minibuffer.
-Its default value is #'hyperbole, which displays the Hyperbole minibuffer menu."
+Its default value is `hyperbole', which displays the Hyperbole minibuffer menu."
   :type 'function
   :group 'hyperbole-keys)
 
 (defcustom assist-key-minibuffer-function #'hui-menu-screen-commands
   "*Function run by the Assist Key after a click in an inactive minibuffer.
-Its default value is #'hui-menu-screen-commands, which displays a popup menu
+Its default value is `hui-menu-screen-commands', which displays a popup menu
 of screen control commands."
   :type 'function
   :group 'hyperbole-keys)
@@ -605,8 +605,8 @@ southeast, southwest, northwest, northeast."
 (defun hmouse-drag-horizontally ()
   "Return non-nil iff last Action Key use was a horizontal drag in a single window.
 If free variable `assist-flag' is non-nil, use Assist Key.
-Value returned is nil if not a horizontal drag, 'left if drag
-moved left or 'right otherwise."
+Value returned is nil if not a horizontal drag, \\='left if drag
+moved left or \\='right otherwise."
   (when (hmouse-press-release-same-window)
     (let ((last-depress-x) (last-release-x)
 	  (last-depress-y) (last-release-y))
@@ -633,8 +633,8 @@ moved left or 'right otherwise."
 (defun hmouse-drag-vertically-within-emacs ()
   "Return non-nil iff last Action Key use was a vertical drag in the same frame.
 If free variable `assist-flag' is non-nil, use Assist Key.
-Value returned is nil if not a vertical line drag, 'up if drag moved up or
-'down otherwise."
+Value returned is nil if not a vertical line drag, \\='up if drag moved up or
+\\='down otherwise."
   (unless (or (hmouse-drag-between-frames) (hmouse-drag-outside-all-windows))
     (let ((last-depress-x) (last-release-x)
 	  (last-depress-y) (last-release-y))
@@ -662,8 +662,8 @@ Value returned is nil if not a vertical line drag, 'up if drag moved up or
 (defun hmouse-drag-vertically ()
   "Return non-nil iff last Action Key use was a vertical drag in a single window.
 If free variable `assist-flag' is non-nil, uses Assist Key.
-Value returned is nil if not a vertical line drag, 'up if drag moved up or
-'down otherwise."
+Value returned is nil if not a vertical line drag, \\='up if drag moved up or
+\\='down otherwise."
   (when (hmouse-press-release-same-window)
     (hmouse-drag-vertically-within-emacs)))
 

--- a/hui.el
+++ b/hui.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 21:42:03
-;; Last-Mod:      6-Oct-22 at 18:55:54 by Bob Weiner
+;; Last-Mod:      7-Oct-22 at 23:36:14 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -814,7 +814,7 @@ The default is the button at point."
 
 (defun hui:hbut-report (&optional arg)
   "Pretty print attributes of current button, using optional prefix ARG.
-See 'hbut:report'."
+See `hbut:report'."
   (interactive "P")
   (if (and arg (symbolp arg))
       (hui:hbut-help arg)

--- a/hversion.el
+++ b/hversion.el
@@ -4,7 +4,7 @@
 ;; Maintainer:   Bob Weiner, Mats Lidell
 ;;
 ;; Orig-Date:     1-Jan-94
-;; Last-Mod:      6-Aug-22 at 12:23:16 by Mats Lidell
+;; Last-Mod:      7-Oct-22 at 23:35:37 by Mats Lidell
 ;;
 ;; Copyright (C) 1994-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -54,7 +54,7 @@ your specific mouse.")
 (defun hyperb:stack-frame (function-list &optional debug-flag)
   "Return the nearest Elisp stack frame that called a function from FUNCTION-LIST.
 Return nil if there is no match.  FUNCTION-LIST entries must be symbols.
-If FUNCTION-LIST contains 'load, 'autoload or 'require, detect autoloads
+If FUNCTION-LIST contains \\='load, \\='autoload or \\='require, detect autoloads
 not visible within the Lisp level stack frames.
 
 With optional DEBUG-FLAG non-nil, if no matching frame is found, return list
@@ -92,7 +92,7 @@ of stack frames (from innermost to outermost)."
 	(if debug-flag (nreverse frame-list)))))
 
 (defun hyperb:path-being-loaded ()
-  "Return the full pathname used by the innermost `load' or 'require' call.
+  "Return the full pathname used by the innermost `load' or `require' call.
 Removes any matches for `hyperb:automount-prefixes' before returning
 the pathname."
   (let* ((frame (hyperb:stack-frame '(load require)))

--- a/hycontrol.el
+++ b/hycontrol.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Jun-16 at 15:35:36
-;; Last-Mod:      6-Aug-22 at 17:25:25 by Mats Lidell
+;; Last-Mod:      7-Oct-22 at 23:45:01 by Mats Lidell
 ;;
 ;; Copyright (C) 2016-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -146,7 +146,7 @@ the list to display in the windows created by `hycontrol-windows-grid'.
 A predicate may be either a function that takes a single buffer
 argument or a boolean expression, in which case the expression is
 evaluated with the buffer argument as the current buffer, e.g. (eq
-major-mode 'c-mode).")
+major-mode \\='c-mode).")
 
 (defcustom hycontrol-help-flag t
   "*Non-nil means show key binding help in the minibuffer when in a HyControl mode."
@@ -861,7 +861,7 @@ Used after selected buffer list is exhausted.")
 Uses `hycontrol--buffer-list'.
 
 When `hycontrol--invert-display-buffer-predicates' is non-nil and
-not 'ignore, the list of buffers used is further filtered using
+not \\='ignore, the list of buffers used is further filtered using
 the functions and sexpressions in
 `hycontrol-display-buffer-predicate-list', which by default
 filters a frame's buffer-list to just those buffers with attached

--- a/hyrolo-logic.el
+++ b/hyrolo-logic.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    13-Jun-89 at 22:57:33
-;; Last-Mod:      6-Oct-22 at 18:55:17 by Bob Weiner
+;; Last-Mod:      7-Oct-22 at 23:33:17 by Mats Lidell
 ;;
 ;; Copyright (C) 1989-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -87,7 +87,7 @@ A complex example of EXPR might be:
 which means:
   Match neither `time' nor `card'
     or
-  Match exactly one of (`french' and 'balloons') or (`spanish').
+  Match exactly one of (`french' and `balloons') or (`spanish').
     and
   Match `teacher' and `pet'.
 

--- a/kotl/kview.el
+++ b/kotl/kview.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:      3-Oct-22 at 22:22:09 by Mats Lidell
+;; Last-Mod:      9-Oct-22 at 22:38:28 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -60,7 +60,7 @@ Default value is \". \"."
   "Koutline view `outline-regexp' value that handles all label formats.")
 
 (defcustom kview:default-label-type 'alpha
-  "*Default label-type to use for new koutlines.  Default value is 'alpha.
+  "*Default label-type to use for new koutlines.  Default value is \\='alpha.
 It must be one of the following symbols:
   alpha           for `1b3' full alphanumeric labels
   id              for `027' permanent idstamp labels


### PR DESCRIPTION
## What

Update docstrings to not use single quotes, removes warning.

## Why

This silences warnings about "docstring has wrong usage of unescaped single quotes".

See [keys in docs](https://www.gnu.org/software/emacs/manual/html_node/elisp/Keys-in-Documentation) and [doc tips](https://www.gnu.org/software/emacs/manual/html_node/elisp/Documentation-Tips.html)