### PR TITLE
Silence warning about reference to free variable

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,24 @@
 
 2022-10-16  Mats Lidell  <matsl@gnu.org>
 
+* kotl/klink.el (hmouse-tag): Require hmouse-tag.
+* hui-mouse.el (imenu): Require imenu.
+* hmouse-sh.el (kmacro): Require kmacro.
+
+* kotl/kotl-mode.el (cmpl-last-insert-location, cmpl-original-string)
+    (completion-to-accept):
+* hyrolo.el (org-roam-directory, org-roam-db-autosync-mode)
+    (markdown-regex-header):
+* hui-mouse.el (magit-root-section):
+* hsettings.el (helm-allow-mouse):
+* hmouse-info.el (Info-complete-menu-buffer):
+* hmouse-drv.el (start-window):
+* hload-path.el (generated-autoload-file): Declare variable.
+
+* hargs.el (hargs:reading-symbol): Define variable.
+
+2022-10-16  Mats Lidell  <matsl@gnu.org>
+
 * kotl/kview.el (kview:insert-contents): Don't use global name for
     parameter.
     (kview:set-label-separator): Remove unused variable.

--- a/hargs.el
+++ b/hargs.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    31-Oct-91 at 23:17:35
-;; Last-Mod:      7-Oct-22 at 22:40:26 by Mats Lidell
+;; Last-Mod:     12-Oct-22 at 22:30:53 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -30,6 +30,7 @@
 (require 'hpath)
 (require 'hypb)
 (require 'set)
+(require 'info)
 
 ;;; ************************************************************************
 ;;; Public variables
@@ -664,6 +665,9 @@ help when appropriate."
 ;;; ************************************************************************
 ;;; Private variables
 ;;; ************************************************************************
+
+(defvar hargs:reading-symbol nil
+  "Remember what symbol is being read.")
 
 (defconst hargs:iform-vector
   (hargs:make-iform-vector

--- a/hload-path.el
+++ b/hload-path.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    29-Jun-16 at 14:39:33
-;; Last-Mod:     20-Oct-22 at 23:20:50 by Mats Lidell
+;; Last-Mod:     23-Oct-22 at 00:38:27 by Mats Lidell
 ;;
 ;; Copyright (C) 1992-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -13,6 +13,11 @@
 ;;; Commentary:
 
 ;;; Code:
+
+;;; ************************************************************************
+;;; Public declarations
+;;; ************************************************************************
+(defvar generated-autoload-file)
 
 ;;; ************************************************************************
 ;;; Public variables

--- a/hmouse-drv.el
+++ b/hmouse-drv.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-90
-;; Last-Mod:      7-Oct-22 at 23:30:30 by Mats Lidell
+;; Last-Mod:     12-Oct-22 at 23:12:43 by Mats Lidell
 ;;
 ;; Copyright (C) 1989-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -19,6 +19,11 @@
 
 (require 'hui-window)
 (require 'hypb)
+
+;;; ************************************************************************
+;;; Public declarations
+;;; ************************************************************************
+(defvar start-window)
 
 ;;; ************************************************************************
 ;;; Public variables

--- a/hmouse-info.el
+++ b/hmouse-info.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Apr-89
-;; Last-Mod:     25-Jul-22 at 23:34:19 by Mats Lidell
+;; Last-Mod:     12-Oct-22 at 22:52:44 by Mats Lidell
 ;;
 ;; Copyright (C) 1989-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -22,6 +22,11 @@
 ;;; ************************************************************************
 
 (require 'info)
+
+;;; ************************************************************************
+;;; Public declarations
+;;; ************************************************************************
+(defvar Info-complete-menu-buffer)
 
 ;;; ************************************************************************
 ;;; Public functions

--- a/hmouse-sh.el
+++ b/hmouse-sh.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     3-Sep-91 at 21:40:58
-;; Last-Mod:     13-Oct-22 at 22:02:30 by Mats Lidell
+;; Last-Mod:     16-Oct-22 at 19:32:50 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -20,6 +20,7 @@
 ;;; ************************************************************************
 
 (require 'hvar)
+(require 'kmacro)
 
 ;;; ************************************************************************
 ;;; Public declarations

--- a/hsettings.el
+++ b/hsettings.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Apr-91 at 00:48:49
-;; Last-Mod:      1-Aug-22 at 21:34:56 by Mats Lidell
+;; Last-Mod:     12-Oct-22 at 22:46:00 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -32,6 +32,8 @@
 ;;; Public declarations
 ;;; ************************************************************************
 (declare-function hproperty:but-create "hui-em-but")
+
+(defvar helm-allow-mouse)
 
 ;;; Read the comments and modify as desired.
 

--- a/hui-mouse.el
+++ b/hui-mouse.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-89
-;; Last-Mod:      9-Oct-22 at 18:14:25 by Bob Weiner
+;; Last-Mod:     16-Oct-22 at 19:29:34 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -45,8 +45,14 @@
   (require 'hmouse-info))
 (unless (fboundp 'smart-c-at-tag-p)
   (require 'hmouse-tag))
+(require 'imenu)
 
 (eval-when-compile (require 'tar-mode))
+
+;;; ************************************************************************
+;;; Public declarations
+;;; ************************************************************************
+(defvar magit-root-section)
 
 ;;; ************************************************************************
 ;;; Public variables

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Jun-89 at 22:08:29
-;; Last-Mod:      7-Oct-22 at 22:03:04 by Mats Lidell
+;; Last-Mod:     12-Oct-22 at 22:47:51 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -39,6 +39,13 @@
   (unless (require 'google-contacts nil t)
     (defvar google-contacts-buffer-name nil))
   (defvar next-entry-exists nil))
+
+;;; ************************************************************************
+;;; Public declarations
+;;; ************************************************************************
+(defvar org-roam-directory)
+(defvar org-roam-db-autosync-mode)
+(defvar markdown-regex-header)
 
 ;;; ************************************************************************
 ;;; Public variables

--- a/kotl/klink.el
+++ b/kotl/klink.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Nov-93 at 12:15:16
-;; Last-Mod:     18-Sep-22 at 09:55:49 by Bob Weiner
+;; Last-Mod:     12-Oct-22 at 21:21:34 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -62,6 +62,7 @@
 ;;; ************************************************************************
 
 (require 'subr-x) ;; For string-trim
+(require 'hmouse-tag) ;; For smart-c-include-regexp
 (eval-when-compile (require 'hbut)) ;; For defib.
 
 ;;; ************************************************************************

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:      9-Oct-22 at 16:25:35 by Bob Weiner
+;; Last-Mod:     16-Oct-22 at 19:29:20 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -19,6 +19,14 @@
 
 (eval-and-compile (mapc #'require '(cl-lib delsel hsettings hmail hypb kfile
 				    kvspec kcell outline org org-table kotl-orgtbl)))
+
+;;; ************************************************************************
+;;; Public declarations
+;;; ************************************************************************
+
+(defvar cmpl-last-insert-location)
+(defvar cmpl-original-string)
+(defvar completion-to-accept)
 
 ;;; ************************************************************************
 ;;; Public variables


### PR DESCRIPTION
## What

Silence warnings about referencing free variables.

## Before

```
kotl/klink.el:175:35: Warning: reference to free variable ‘smart-c-include-regexp’
kotl/kotl-mode.el:728:37: Warning: reference to free variable ‘cmpl-last-insert-location’
kotl/kotl-mode.el:729:22: Warning: reference to free variable ‘cmpl-original-string’
kotl/kotl-mode.el:730:20: Warning: assignment to free variable ‘completion-to-accept’
kotl/kview.el:481:13: Warning: assignment to free variable ‘found’
kotl/kview.el:807:54: Warning: Lexical argument shadows the dynamic variable fill-prefix
kotl/kview.el:1399:10: Warning: Variable ‘pos’ left uninitialized
hargs.el:381:33: Warning: reference to free variable ‘Info-current-node’
hargs.el:671:11: Warning: assignment to free variable ‘hargs:reading-symbol’
hargs.el:776:43: Warning: reference to free variable ‘hargs:reading-symbol’
hargs.el:782:42: Warning: reference to free variable ‘Info-current-file-completions’
hargs.el:785:51: Warning: assignment to free variable ‘Info-current-file-completions’
hload-path.el:134:9: Warning: assignment to free variable ‘generated-autoload-file’
hmouse-info.el:43:13: Warning: assignment to free variable ‘Info-complete-menu-buffer’
hmouse-info.el:49:20: Warning: reference to free variable ‘Info-complete-menu-buffer’
hmouse-info.el:238:24: Warning: reference to free variable ‘Info-complete-menu-buffer’
hmouse-info.el:381:30: Warning: reference to free variable ‘Info-complete-menu-buffer’
hmouse-drv.el:438:22: Warning: reference to free variable ‘start-window’
hmouse-sh.el:276:29: Warning: Lexical argument shadows the dynamic variable hmouse-middle-flag
hmouse-sh.el:472:30: Warning: Lexical argument shadows the dynamic variable hmouse-middle-flag
hmouse-sh.el:488:11: Warning: assignment to free variable ‘kmacro-call-mouse-event’
hpath.el:1656:27: Warning: Variable ‘modifier’ left uninitialized
hsettings.el:84:36: Warning: assignment to free variable ‘helm-allow-mouse’
hui-mouse.el:1365:26: Warning: reference to free variable ‘imenu--index-alist’
hui-mouse.el:1406:21: Warning: assignment to free variable ‘imenu--index-alist’
hui-mouse.el:1494:24: Warning: reference to free variable ‘magit-root-section’
hyrolo.el:1104:99: Warning: reference to free variable ‘child’
hyrolo.el:1284:28: Warning: reference to free variable ‘org-roam-directory’
hyrolo.el:1286:11: Warning: reference to free variable ‘org-roam-db-autosync-mode’
hyrolo.el:1844:39: Warning: reference to free variable ‘markdown-regex-header’
```

## After

```
kotl/kview.el:481:13: Warning: assignment to free variable ‘found’
kotl/kview.el:807:54: Warning: Lexical argument shadows the dynamic variable fill-prefix
kotl/kview.el:1399:10: Warning: Variable ‘pos’ left uninitialized
hmouse-sh.el:277:29: Warning: Lexical argument shadows the dynamic variable hmouse-middle-flag
hmouse-sh.el:473:30: Warning: Lexical argument shadows the dynamic variable hmouse-middle-flag
hpath.el:1656:27: Warning: Variable ‘modifier’ left uninitialized
hyrolo.el:1111:99: Warning: reference to free variable ‘child’
```
## Note

Added some comments below about some specific changes.
