### PR TITLE
Fix lexical-dynamic warnings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,14 @@
+2022-10-16  Mats Lidell  <matsl@gnu.org>
+
+* kotl/kview.el (kview:insert-contents): Don't use global name for
+    parameter.
+    (kview:set-label-separator): Remove unused variable.
+
+* hpath.el (hpath:is-p): Initialize variable.
+
+* hmouse-sh.el (hmouse-get-bindings, hmouse-shifted-setup): Don't use
+    global name for parameter.
+
 2022-10-15  Bob Weiner  <rsw@gnu.org>
 
 * hui-em-but.el (hproperty:but-flash): Remove 'a' and 'b' internal

--- a/hmouse-sh.el
+++ b/hmouse-sh.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     3-Sep-91 at 21:40:58
-;; Last-Mod:     27-Jul-22 at 00:20:49 by Mats Lidell
+;; Last-Mod:     13-Oct-22 at 22:02:30 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -273,15 +273,15 @@ This includes depresses and drags.  Shifted Mouse Key 1 is
 	   [mode-line S-drag-mouse-5]
 	   [mode-line S-mouse-5])))))
 	   
-(defun hmouse-get-bindings (hmouse-middle-flag)
+(defun hmouse-get-bindings (middle-flag)
   "Return the list of active bindings of mouse keys used by Hyperbole.
-If HMOUSE-MIDDLE-FLAG is non-nil, include the middle mouse key
+If MIDDLE-FLAG is non-nil, include the middle mouse key
 binding as well.  These may be the bindings prior to initializing
 Hyperbole or the Hyperbole bindings."
   ;; Do nothing when running in batch mode.
   (unless noninteractive
     (nconc
-     (when hmouse-middle-flag (hmouse-get-unshifted-bindings))
+     (when middle-flag (hmouse-get-unshifted-bindings))
      ;; Get mouse bindings under Emacs, even if not under a window
      ;; system, since there can be frames on ttys and windowed
      ;; displays at the same time.
@@ -469,14 +469,14 @@ point determined by `mouse-select-region-move-to-beginning'."
   (mapc (lambda (key) (hkey-set-key key binding)) key-list)
   nil)
 
-(defun hmouse-shifted-setup (hmouse-middle-flag)
+(defun hmouse-shifted-setup (middle-flag)
   "Call `hmouse-install' instead of this and see its documentation."
   (interactive)
   ;; Do nothing when running in batch mode.
   (unless noninteractive
     (or hmouse-bindings-flag hmouse-previous-bindings
-	(setq hmouse-previous-bindings (hmouse-get-bindings hmouse-middle-flag)))
-    (when hmouse-middle-flag (hmouse-unshifted-setup hmouse-middle-flag))
+	(setq hmouse-previous-bindings (hmouse-get-bindings middle-flag)))
+    (when middle-flag (hmouse-unshifted-setup middle-flag))
     ;; Ensure Gillespie's Info mouse support is off since
     ;; Hyperbole handles that.
     (when (boundp 'Info-mouse-support) (setq Info-mouse-support nil))
@@ -501,7 +501,7 @@ point determined by `mouse-select-region-move-to-beginning'."
 	(define-key company-active-map [S-mouse-2] 'smart-company-to-definition)
 	(define-key company-active-map [S-down-mouse-3] 'ignore)
 	(define-key company-active-map [S-mouse-3] 'smart-company-help)))
-    (setq hmouse-bindings (hmouse-get-bindings hmouse-middle-flag)
+    (setq hmouse-bindings (hmouse-get-bindings middle-flag)
 	  hmouse-bindings-flag t)))
 
 (defun hmouse-unshifted-setup (&optional middle-key-only-flag)

--- a/hpath.el
+++ b/hpath.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Nov-91 at 00:44:23
-;; Last-Mod:     10-Oct-22 at 22:50:52 by Mats Lidell
+;; Last-Mod:     13-Oct-22 at 21:54:38 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -1653,7 +1653,7 @@ form is what is returned for PATH."
 		(file-readable-p path))
       (setq path (hpath:call
 		  (lambda (path non-exist)
-		    (let (modifier
+		    (let ((modifier nil)
 			  suffix)
 		      (and (not (or (string-equal path "")
 				    (string-match-p "\\`\\s-\\|\\s-\\'" path)))

--- a/kotl/kview.el
+++ b/kotl/kview.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:      8-Oct-22 at 19:46:51 by Bob Weiner
+;; Last-Mod:     16-Oct-22 at 18:32:03 by Mats Lidell
 ;;
 ;; Copyright (C) 1993-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
@@ -811,10 +811,10 @@ On success, return t, else nil."
     (when (kotl-mode:goto-cell permanent-id)
       (kcell-view:label))))
 
-(defun kview:insert-contents (kcell contents no-fill fill-prefix)
+(defun kview:insert-contents (kcell contents no-fill cell-fill-prefix)
   "Insert KCELL's CONTENTS into view at point and fill resulting paragraphs.
 Do not fill if NO-FILL is non-nil.
-FILL-PREFIX is the indentation string for the current cell.  If
+CELL-FILL-PREFIX is the indentation string for the current cell.  If
 CONTENTS is nil, get contents from the cell at point.  Return contents
 inserted (this value may differ from the value passed in) due to
 filling."
@@ -837,7 +837,7 @@ filling."
 	    (narrow-to-region start end)
 	    (goto-char (point-min))
 	    (while (re-search-forward "[\n\r]" nil t)
-	      (insert fill-prefix))
+	      (insert cell-fill-prefix))
 	    (goto-char (point-max)))
 	;;
 	;; Filling cell will insert proper indent on all lines.
@@ -845,15 +845,15 @@ filling."
 	  (goto-char start)
 	  (beginning-of-line)
 	  (narrow-to-region (point) end)
-	  ;; Add fill-prefix to all but paragraph separator lines, so
+	  ;; Add cell-fill-prefix to all but paragraph separator lines, so
 	  ;; filling is done properly.
 	  (while (re-search-forward "[\n\r][^\n\r]" nil t)
-	    (forward-char -1) (insert fill-prefix))
+	    (forward-char -1) (insert cell-fill-prefix))
 	  (kview:fill-region start end kcell)
 	  (goto-char (point-min))
-	  ;; Now add fill-prefix to paragraph separator lines.
+	  ;; Now add cell-fill-prefix to paragraph separator lines.
 	  (while (re-search-forward "[\n\r][\n\r]" nil t)
-	    (forward-char -1) (insert fill-prefix))
+	    (forward-char -1) (insert cell-fill-prefix))
 	  ;;
 	  (goto-char (point-max))))))
   contents)
@@ -1415,8 +1415,7 @@ new outlines is also set to this new value."
 				  (- sep-len-increase) ?\ )))
 		   (while (re-search-forward indent nil t)
 		     (delete-region
-		      (+ (match-beginning 0) 2) (match-end 0)))))))
-	 pos)
+		      (+ (match-beginning 0) 2) (match-end 0))))))))
     (save-excursion
       (goto-char (point-min))
       (kproperty:replace-separator pos label-separator old-sep-len)


### PR DESCRIPTION
## What

Fix lexical-dynamic warnings.

## Why

```
kotl/kview.el:807:54: Warning: Lexical argument shadows the dynamic variable fill-prefix
kotl/kview.el:1399:10: Warning: Variable ‘pos’ left uninitialized
hmouse-sh.el:276:29: Warning: Lexical argument shadows the dynamic variable hmouse-middle-flag
hmouse-sh.el:472:30: Warning: Lexical argument shadows the dynamic variable hmouse-middle-flag
hpath.el:1656:27: Warning: Variable ‘modifier’ left uninitialized
```
