### PR TITLE
Start trying out better support for composing email

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,16 @@
+2024-04-05  Mats Lidell  <matsl@gnu.org>
+
+* Makefile (EL_COMPILE, ELC_COMPILE): Add hgnus-mail.
+
+* hmail.el (hmail:init-function): Add Gnus-mail-init as an init option.
+    (hmail:compose-mail-func): Add email interface function.
+
+* hibtypes.el (mail-address): Use hmail:compose-mail-func.
+
+* hgnus-mail.el: Mail definitions for Gnus as a mail reader.
+
+* hui-mini.el (hui:menu-choose): Use hui:menu-exit-hyperbole
+
 2024-04-01  Mats Lidell  <matsl@gnu.org>
 
 * test/hpath-tests.el (hpath:prepend-shell-directory-test):
@@ -3771,17 +3784,6 @@ name with 'name' and 'name-key'.
 * hmouse-tag.el (smart-lisp-htype-tag): Fix so expands shortened htype tags
     whose symbols have been interned when defined.  This fixes jumping to
     the definition of htypes in Help buffers.
-
-2023-01-22  Mats Lidell  <matsl@gnu.org>
-
-* Makefile (EL_COMPILE, ELC_COMPILE): Add hgnus-mail.
-
-* hmail.el (hmail:init-function): Add Gnus-mail-init as an init option.
-    (hmail:compose-mail-other-window): Add email interface function.
-
-* hibtypes.el (mail-address): Use hmail:compose-mail-other-window.
-
-* hgnus-mail.el: Mail definitions for Gnus as a mail reader.
 
 2023-01-22  Mats Lidell  <matsl@gnu.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,7 +3,7 @@
 * Makefile (EL_COMPILE, ELC_COMPILE): Add hgnus-mail.
 
 * hmail.el (hmail:init-function): Add Gnus-mail-init as an init option.
-    (hmail:compose-mail-func): Add email interface function.
+    (hmail:compose-mail-function): Add email interface function.
 
 * hibtypes.el (mail-address): Use hmail:compose-mail-func.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -3774,6 +3774,17 @@ name with 'name' and 'name-key'.
 
 2023-01-22  Mats Lidell  <matsl@gnu.org>
 
+* Makefile (EL_COMPILE, ELC_COMPILE): Add hgnus-mail.
+
+* hmail.el (hmail:init-function): Add Gnus-mail-init as an init option.
+    (hmail:compose-mail-other-window): Add email interface function.
+
+* hibtypes.el (mail-address): Use hmail:compose-mail-other-window.
+
+* hgnus-mail.el: Mail definitions for Gnus as a mail reader.
+
+2023-01-22  Mats Lidell  <matsl@gnu.org>
+
 * hypb.el: Add variable and function declarations for package
     interaction-log to silence byte compilation warnings.
     (hypb:activate-interaction-log-mode): Use cl-pushnew.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,6 @@
 2024-04-05  Mats Lidell  <matsl@gnu.org>
 
-* Makefile (EL_COMPILE, ELC_COMPILE): Add hgnus-mail.
+* Makefile (EL_COMPILE, ELC_COMPILE, MANIFEST): Add hgnus-mail.
 
 * hmail.el (hmail:init-function): Add Gnus-mail-init as an init option.
     (hmail:compose-mail-function): Add email interface function.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,6 @@
 2024-04-05  Mats Lidell  <matsl@gnu.org>
 
-* Makefile (EL_COMPILE, ELC_COMPILE, MANIFEST): Add hgnus-mail.
+* Makefile (EL_COMPILE, MANIFEST): Add hgnus-mail.
 
 * hmail.el (hmail:init-function): Add Gnus-mail-init as an init option.
     (hmail:compose-mail-function): Add email interface function.

--- a/MANIFEST
+++ b/MANIFEST
@@ -70,6 +70,7 @@ set.el               - General mathematical operators for unordered sets
 hmh.el               - GNU Hyperbole buttons in mail reader:   Mh
 hrmail.el            - GNU Hyperbole buttons in mail reader:   Rmail
 hsmail.el            - GNU Hyperbole buttons in mail composer: mail
+hgnus-mail.el        - GNU Hyperbole buttons in mail reader/composer:   GNUS
 
 * --- HYPERBOLE KOUTLINER ---
 kotl/MANIFEST        - Summary of Koutliner files

--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ EMACS_PLAIN_BATCH=$(EMACS) $(BATCHFLAGS)
 VPATH = kotl man
 
 EL_COMPILE = hact.el hactypes.el hargs.el hbdata.el hbmap.el hbut.el \
-	     hgnus.el hhist.el hib-debbugs.el hib-doc-id.el hib-kbd.el \
+	     hgnus.el hgnus-mail.el hhist.el hib-debbugs.el hib-doc-id.el hib-kbd.el \
 	     hib-social.el hibtypes.el \
 	     hinit.el hload-path.el hmail.el hmh.el hmoccur.el hmouse-info.el \
 	     hmouse-drv.el hmouse-key.el hmouse-mod.el hmouse-sh.el hmouse-tag.el \

--- a/hgnus-mail.el
+++ b/hgnus-mail.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    17-Dec-22 at 22:04:19
-;; Last-Mod:     17-Dec-22 at 23:45:46 by Mats Lidell
+;; Last-Mod:      8-Jan-23 at 23:50:26 by Mats Lidell
 ;;
 ;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -38,6 +38,9 @@
 ;;   File: hypb-gnus-email.el
 ;;   Function: hypb-gnus-email-init
 
+(require 'gnus-sum)
+(require 'gnus-art)
+
 ;;;###autoload
 (defun Gnus-mail-init ()
   "Initialize Hyperbole support for Gnus mail reading."
@@ -56,10 +59,10 @@
   ;; Setup private abstract interface to mail reader-specific functions
   ;; used in "hmail.el".
   ;;
-  (defalias 'rmail:get-new       'gnus-group-get-new-news)
-  (defalias 'rmail:msg-forward   'gnus-summary-mail-forward)
-  (defalias 'rmail:summ-msg-to   nil)   ;FIXME - What is this for?
-  (defalias 'rmail:summ-new      nil)   ;FIXME - What is this for?
+  (defalias 'rmail:get-new       #'gnus-group-get-new-news)
+  (defalias 'rmail:msg-forward   #'gnus-summary-mail-forward)
+  (defalias 'rmail:summ-msg-to   #'gnus-summary-show-article)
+  (defalias 'rmail:summ-new      #'gnus-summary-rescan-group)
   (if (called-interactively-p 'interactive)
       (message "Hyperbole Gnus mail reader support initialized.")))
 
@@ -73,6 +76,27 @@
 (defun hgnus-mail--message-mail-other-window (_noerase to)
   "Open mail composer in other window with field TO set."
   (gnus-msg-mail to nil nil nil #'switch-to-buffer-other-window))
+
+(defalias 'Gnus-Summ-goto #'gnus-summary-show-article)
+(defalias 'Gnus-msg-next #'gnus-article-goto-next-page)
+
+;; (defun Gnus-Summ-delete ()
+;;   "Delete an article.  No undo for this one I'm afraid."
+;;   (let ((gnus-novice-user t))
+;;     (gnus-summary-delete-article)))
+
+(defun Gnus-Summ-delete ()
+  "Mark article for process so it can be expunged later."
+  (gnus-summary-mark-as-processable 1))
+
+(defun Gnus-Summ-expunge ()
+  "Delete all articles with a process mark."
+  (let ((gnus-novice-user t))
+    (gnus-summary-delete-article)))
+
+(defun Gnus-Summ-undelete-all ()
+  "Undelete all messages."
+  (error "Sorry.  Deleted messages can't be undeleted"))
 
 (provide 'hgnus-mail.el)
 ;;; hgnus-mail.el ends here

--- a/hgnus-mail.el
+++ b/hgnus-mail.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    17-Dec-22 at 22:04:19
-;; Last-Mod:     18-Feb-23 at 10:31:45 by Mats Lidell
+;; Last-Mod:     31-Oct-23 at 15:00:34 by Mats Lidell
 ;;
 ;; Copyright (C) 2023  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -21,6 +21,7 @@
 
 (require 'gnus-sum)
 (require 'gnus-art)
+(require 'hmail)
 
 ;;; ************************************************************************
 ;;; Public functions
@@ -30,7 +31,7 @@
 (defun Gnus-mail-init ()
   "Initialize Hyperbole support for Gnus mail reading."
   (interactive)
-  (setq hmail:compose-mail-func 'hgnus-mail--message-mail-other-window
+  (setq hmail:compose-mail-function 'hgnus-mail--message-mail-other-window
         hmail:composer  'message-mode
 	hmail:lister    'gnus-summary-mode
 	hmail:modifier  'message-mode

--- a/hgnus-mail.el
+++ b/hgnus-mail.el
@@ -3,9 +3,9 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    17-Dec-22 at 22:04:19
-;; Last-Mod:      8-Jan-23 at 23:50:26 by Mats Lidell
+;; Last-Mod:     28-Jan-23 at 10:12:32 by Mats Lidell
 ;;
-;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
+;; Copyright (C) 2023  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.
@@ -16,30 +16,15 @@
 ;;; Code:
 
 ;;; ************************************************************************
-;;; Requirements
+;;; Other required Elisp libraries
 ;;; ************************************************************************
 
-;;; ************************************************************************
-;;; Public variables
-;;; ************************************************************************
-
-;;; ************************************************************************
-;;; Private variables
-;;; ************************************************************************
+(require 'gnus-sum)
+(require 'gnus-art)
 
 ;;; ************************************************************************
 ;;; Public functions
 ;;; ************************************************************************
-
-;; FIXME - Start to use common prefix such as hypb for file name and
-;; functions?
-;;
-;; Would be:
-;;   File: hypb-gnus-email.el
-;;   Function: hypb-gnus-email-init
-
-(require 'gnus-sum)
-(require 'gnus-art)
 
 ;;;###autoload
 (defun Gnus-mail-init ()
@@ -71,7 +56,7 @@
 ;;; ************************************************************************
 
 ;; FIXME - noerase arg is nil in the other invocation so really not
-;; needed. We can use a local defun in the other case as well and so
+;; needed. We could use a local defun in the other case as well and so
 ;; the noerase can go away.
 (defun hgnus-mail--message-mail-other-window (_noerase to)
   "Open mail composer in other window with field TO set."
@@ -79,11 +64,6 @@
 
 (defalias 'Gnus-Summ-goto #'gnus-summary-show-article)
 (defalias 'Gnus-msg-next #'gnus-article-goto-next-page)
-
-;; (defun Gnus-Summ-delete ()
-;;   "Delete an article.  No undo for this one I'm afraid."
-;;   (let ((gnus-novice-user t))
-;;     (gnus-summary-delete-article)))
 
 (defun Gnus-Summ-delete ()
   "Mark article for process so it can be expunged later."

--- a/hgnus-mail.el
+++ b/hgnus-mail.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    17-Dec-22 at 22:04:19
-;; Last-Mod:     28-Jan-23 at 10:12:32 by Mats Lidell
+;; Last-Mod:      5-Feb-23 at 23:08:54 by Mats Lidell
 ;;
 ;; Copyright (C) 2023  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -30,7 +30,7 @@
 (defun Gnus-mail-init ()
   "Initialize Hyperbole support for Gnus mail reading."
   (interactive)
-  (setq hmail:compose-mail-other-window 'hgnus-mail--message-mail-other-window
+  (setq hmail:compose-mail-func 'hgnus-mail--message-mail-other-window
         hmail:composer  'message-mode
 	hmail:lister    'gnus-summary-mode
 	hmail:modifier  'message-mode
@@ -55,11 +55,10 @@
 ;;; Private functions
 ;;; ************************************************************************
 
-;; FIXME - noerase arg is nil in the other invocation so really not
-;; needed. We could use a local defun in the other case as well and so
-;; the noerase can go away.
 (defun hgnus-mail--message-mail-other-window (_noerase to)
-  "Open mail composer in other window with field TO set."
+  "Open mail composer in other window with field TO set.
+_NOERASE is for compatibility with `mail-other-window' type of
+mail functions."
   (gnus-msg-mail to nil nil nil #'switch-to-buffer-other-window))
 
 (defalias 'Gnus-Summ-goto #'gnus-summary-show-article)
@@ -78,5 +77,5 @@
   "Undelete all messages."
   (error "Sorry.  Deleted messages can't be undeleted"))
 
-(provide 'hgnus-mail.el)
+(provide 'hgnus-mail)
 ;;; hgnus-mail.el ends here

--- a/hgnus-mail.el
+++ b/hgnus-mail.el
@@ -1,0 +1,78 @@
+;;; hgnus-mail.el --- Gnus mailer support                -*- lexical-binding: t; -*-
+;;
+;; Author:       Mats Lidell
+;;
+;; Orig-Date:    17-Dec-22 at 22:04:19
+;; Last-Mod:     17-Dec-22 at 23:45:46 by Mats Lidell
+;;
+;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
+;; See the "HY-COPY" file for license information.
+;;
+;; This file is part of GNU Hyperbole.
+
+;;; Commentary:
+;;
+
+;;; Code:
+
+;;; ************************************************************************
+;;; Requirements
+;;; ************************************************************************
+
+;;; ************************************************************************
+;;; Public variables
+;;; ************************************************************************
+
+;;; ************************************************************************
+;;; Private variables
+;;; ************************************************************************
+
+;;; ************************************************************************
+;;; Public functions
+;;; ************************************************************************
+
+;; FIXME - Start to use common prefix such as hypb for file name and
+;; functions?
+;;
+;; Would be:
+;;   File: hypb-gnus-email.el
+;;   Function: hypb-gnus-email-init
+
+;;;###autoload
+(defun Gnus-mail-init ()
+  "Initialize Hyperbole support for Gnus mail reading."
+  (interactive)
+  (setq hmail:compose-mail-other-window 'hgnus-mail--message-mail-other-window
+        hmail:composer  'message-mode
+	hmail:lister    'gnus-summary-mode
+	hmail:modifier  'message-mode
+	hmail:reader    'gnus-article-mode)
+  ;;
+  ;; Setup public abstract interface to Hyperbole defined mail
+  ;; reader-specific functions used in "hmail.el".
+  ;;
+  (rmail:init)
+  ;;
+  ;; Setup private abstract interface to mail reader-specific functions
+  ;; used in "hmail.el".
+  ;;
+  (defalias 'rmail:get-new       'gnus-group-get-new-news)
+  (defalias 'rmail:msg-forward   'gnus-summary-mail-forward)
+  (defalias 'rmail:summ-msg-to   nil)   ;FIXME - What is this for?
+  (defalias 'rmail:summ-new      nil)   ;FIXME - What is this for?
+  (if (called-interactively-p 'interactive)
+      (message "Hyperbole Gnus mail reader support initialized.")))
+
+;;; ************************************************************************
+;;; Private functions
+;;; ************************************************************************
+
+;; FIXME - noerase arg is nil in the other invocation so really not
+;; needed. We can use a local defun in the other case as well and so
+;; the noerase can go away.
+(defun hgnus-mail--message-mail-other-window (_noerase to)
+  "Open mail composer in other window with field TO set."
+  (gnus-msg-mail to nil nil nil #'switch-to-buffer-other-window))
+
+(provide 'hgnus-mail.el)
+;;; hgnus-mail.el ends here

--- a/hgnus-mail.el
+++ b/hgnus-mail.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    17-Dec-22 at 22:04:19
-;; Last-Mod:      5-Feb-23 at 23:08:54 by Mats Lidell
+;; Last-Mod:     18-Feb-23 at 10:31:45 by Mats Lidell
 ;;
 ;; Copyright (C) 2023  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -48,7 +48,7 @@
   (defalias 'rmail:msg-forward   #'gnus-summary-mail-forward)
   (defalias 'rmail:summ-msg-to   #'gnus-summary-show-article)
   (defalias 'rmail:summ-new      #'gnus-summary-rescan-group)
-  (if (called-interactively-p 'interactive)
+  (when (called-interactively-p 'interactive)
       (message "Hyperbole Gnus mail reader support initialized.")))
 
 ;;; ************************************************************************

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:      5-Apr-24 at 23:23:04 by Mats Lidell
+;; Last-Mod:      6-Apr-24 at 00:06:20 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -219,8 +219,14 @@ in all buffers."
                             (mapcar #'get-file-buffer (hyrolo-get-file-list))))))
     (let ((address (mail-address-at-p)))
       (when address
+        ;; Initialize user-specified mail reader if need be.
+        (if (and (symbolp hmail:init-function)
+	         (fboundp hmail:init-function)
+	         (listp (symbol-function hmail:init-function))
+	         (eq 'autoload (car (symbol-function hmail:init-function))))
+	    (funcall hmail:init-function))
         (ibut:label-set address (match-beginning 1) (match-end 1))
-        (hact 'mail-other-window nil address)))))
+        (hact hmail:compose-mail-function nil address)))))
 
 ;;; ========================================================================
 ;;; Displays files and directories when a valid pathname is activated.
@@ -341,60 +347,6 @@ display options."
 ;;; ========================================================================
 
 (load "hsys-www")
-
-;;; ========================================================================
-;;; Composes mail, in another window, to the e-mail address at point.
-;;; ========================================================================
-
-(defun mail-address-at-p ()
-  "Return e-mail address, a string, that point is within or nil."
-  (let ((case-fold-search t))
-    (save-excursion
-      (skip-chars-backward "^ \t\n\r\f\"\'(){}[];:<>|")
-      (and (or (looking-at hypb:mail-address-regexp)
-               (looking-at (concat "mailto:" hypb:mail-address-regexp)))
-           (save-match-data
-             (string-match hypb:mail-address-tld-regexp (match-string-no-properties 1)))
-           (match-string-no-properties 1)))))
-
-(defib mail-address ()
-  "If on an e-mail address, compose mail to that address in another window.
-
-Applies to any major mode in `hypb:mail-address-mode-list', the HyRolo match
-buffer, any buffer attached to a file in `hyrolo-file-list', or any buffer with
-\"mail\" or \"rolo\" (case-insensitive) within its name.
-
-If `hypb:mail-address-mode-list' is set to nil, this button type is active
-in all buffers."
-  (when (let ((case-fold-search t))
-          (or
-           (and (or (null hypb:mail-address-mode-list)
-		    (apply #'derived-mode-p hypb:mail-address-mode-list))
-                (not (string-match "-Elements\\'" (buffer-name)))
-                ;; Don't want this to trigger within an OOBR-FTR buffer.
-                (not (string-match "\\`\\(OOBR.*-FTR\\|oobr.*-ftr\\)"
-                                   (buffer-name)))
-                (not (string-equal "*Implementors*" (buffer-name))))
-           (and
-            (string-match "mail\\|rolo" (buffer-name))
-            ;; Don't want this to trigger in a mail/news summary buffer.
-            (not (or (hmail:lister-p) (hnews:lister-p))))
-           (when (boundp 'hyrolo-display-buffer)
-             (equal (buffer-name) hyrolo-display-buffer))
-           (and buffer-file-name
-                (boundp 'hyrolo-file-list)
-                (set:member (current-buffer)
-                            (mapcar #'get-file-buffer (hyrolo-get-file-list))))))
-    (let ((address (mail-address-at-p)))
-      (when address
-        ;; Initialize user-specified mail reader if need be.
-        (if (and (symbolp hmail:init-function)
-	         (fboundp hmail:init-function)
-	         (listp (symbol-function hmail:init-function))
-	         (eq 'autoload (car (symbol-function hmail:init-function))))
-	    (funcall hmail:init-function))
-        (ibut:label-set address (match-beginning 1) (match-end 1))
-        (hact hmail:compose-mail-function nil address)))))
 
 ;;; ========================================================================
 ;;; Handles internal references within an annotated bibliography, delimiters=[]

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -400,7 +400,7 @@ in all buffers."
 	         (eq 'autoload (car (symbol-function hmail:init-function))))
 	    (funcall hmail:init-function))
         (ibut:label-set address (match-beginning 1) (match-end 1))
-        (hact hmail:compose-mail-other-window nil address)))))
+        (hact hmail:compose-mail-func nil address)))))
 
 ;;; ========================================================================
 ;;; Handles internal references within an annotated bibliography, delimiters=[]

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:     31-Mar-24 at 15:17:46 by Bob Weiner
+;; Last-Mod:      5-Apr-24 at 23:23:04 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -341,6 +341,66 @@ display options."
 ;;; ========================================================================
 
 (load "hsys-www")
+
+;;; ========================================================================
+;;; Composes mail, in another window, to the e-mail address at point.
+;;; ========================================================================
+
+(defun mail-address-at-p ()
+  "Return e-mail address, a string, that point is within or nil."
+  (let ((case-fold-search t))
+    (save-excursion
+      (skip-chars-backward "^ \t\n\r\f\"\'(){}[];:<>|")
+      (and (or (looking-at hypb:mail-address-regexp)
+               (looking-at (concat "mailto:" hypb:mail-address-regexp)))
+           (save-match-data
+             (string-match hypb:mail-address-tld-regexp (match-string-no-properties 1)))
+           (match-string-no-properties 1)))))
+
+(defib mail-address ()
+  "If on an e-mail address, compose mail to that address in another window.
+
+Applies to any major mode in `hypb:mail-address-mode-list', the HyRolo match
+buffer, any buffer attached to a file in `hyrolo-file-list', or any buffer with
+\"mail\" or \"rolo\" (case-insensitive) within its name.
+
+If `hypb:mail-address-mode-list' is set to nil, this button type is active
+in all buffers."
+  (when (let ((case-fold-search t))
+          (or
+           (and (or (null hypb:mail-address-mode-list)
+		    (apply #'derived-mode-p hypb:mail-address-mode-list))
+                (not (string-match "-Elements\\'" (buffer-name)))
+                ;; Don't want this to trigger within an OOBR-FTR buffer.
+                (not (string-match "\\`\\(OOBR.*-FTR\\|oobr.*-ftr\\)"
+                                   (buffer-name)))
+                (not (string-equal "*Implementors*" (buffer-name))))
+           (and
+            (string-match "mail\\|rolo" (buffer-name))
+            ;; Don't want this to trigger in a mail/news summary buffer.
+            (not (or (hmail:lister-p) (hnews:lister-p))))
+           (when (boundp 'hyrolo-display-buffer)
+             (equal (buffer-name) hyrolo-display-buffer))
+           (and buffer-file-name
+                (boundp 'hyrolo-file-list)
+                (set:member (current-buffer)
+                            (mapcar #'get-file-buffer (hyrolo-get-file-list))))))
+    (let ((address (mail-address-at-p)))
+      (when address
+
+        ;; FIXME - Shall we not initialize the user preferred mail
+        ;; reader at startup instead? Code below copied from
+        ;; "hactypes.el:576". The only other place the
+        ;; hmail:init-function is used.
+
+        ;; Initialize user-specified mail reader if need be.
+        (if (and (symbolp hmail:init-function)
+	         (fboundp hmail:init-function)
+	         (listp (symbol-function hmail:init-function))
+	         (eq 'autoload (car (symbol-function hmail:init-function))))
+	    (funcall hmail:init-function))
+        (ibut:label-set address (match-beginning 1) (match-end 1))
+        (hact hmail:compose-mail-other-window nil address)))))
 
 ;;; ========================================================================
 ;;; Handles internal references within an annotated bibliography, delimiters=[]

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -400,7 +400,7 @@ in all buffers."
 	         (eq 'autoload (car (symbol-function hmail:init-function))))
 	    (funcall hmail:init-function))
         (ibut:label-set address (match-beginning 1) (match-end 1))
-        (hact hmail:compose-mail-func nil address)))))
+        (hact hmail:compose-mail-function nil address)))))
 
 ;;; ========================================================================
 ;;; Handles internal references within an annotated bibliography, delimiters=[]

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -387,12 +387,6 @@ in all buffers."
                             (mapcar #'get-file-buffer (hyrolo-get-file-list))))))
     (let ((address (mail-address-at-p)))
       (when address
-
-        ;; FIXME - Shall we not initialize the user preferred mail
-        ;; reader at startup instead? Code below copied from
-        ;; "hactypes.el:576". The only other place the
-        ;; hmail:init-function is used.
-
         ;; Initialize user-specified mail reader if need be.
         (if (and (symbolp hmail:init-function)
 	         (fboundp hmail:init-function)

--- a/hmail.el
+++ b/hmail.el
@@ -58,8 +58,8 @@ Valid values are: nil, Mh-init, Rmail-init or Gnus-mail-init."
 		 (function-item :tag "Gnus" :value Gnus-mail-init))
   :group 'hyperbole-commands)
 
-(defvar hmail:compose-mail-other-window 'mail-other-window
-  "Function for starting to compose a mail in the other window.")
+(defvar hmail:compose-mail-func 'mail-other-window
+  "Function for starting to compose a mail.")
 (defvar hmail:composer  'message-mode
  "Major mode for composing mail to be sent with Hyperbole buttons.")
 (defvar hmail:lister    nil

--- a/hmail.el
+++ b/hmail.el
@@ -51,12 +51,15 @@
 
 (defcustom hmail:init-function nil
   "*Function (a symbol) to initialize Hyperbole support for a mail reader/composer.
-Valid values are: nil, Mh-init or Rmail-init."
+Valid values are: nil, Mh-init, Rmail-init  or Gnus-mail-init."
   :type '(choice (const nil)
 		 (const Mh-init)
-		 (const Rmail-init))
+		 (const Rmail-init)
+                 (const Gnus-mail-init))
   :group 'hyperbole-commands)
 
+(defvar hmail:compose-mail-other-window 'mail-other-window
+  "Function for starting to compose a mail in the other window.")
 (defvar hmail:composer  'message-mode
  "Major mode for composing mail to be sent with Hyperbole buttons.")
 (defvar hmail:lister    nil

--- a/hmail.el
+++ b/hmail.el
@@ -51,11 +51,11 @@
 
 (defcustom hmail:init-function nil
   "*Function (a symbol) to initialize Hyperbole support for a mail reader/composer.
-Valid values are: nil, Mh-init, Rmail-init  or Gnus-mail-init."
+Valid values are: nil, Mh-init, Rmail-init or Gnus-mail-init."
   :type '(choice (const nil)
-		 (const Mh-init)
-		 (const Rmail-init)
-                 (const Gnus-mail-init))
+                 (function-item :tag "MH" :value Mh-init)
+		 (function-item :tag "Rmail" :value Rmail-init)
+		 (function-item :tag "Gnus" :value Gnus-mail-init))
   :group 'hyperbole-commands)
 
 (defvar hmail:compose-mail-other-window 'mail-other-window

--- a/hmail.el
+++ b/hmail.el
@@ -58,7 +58,7 @@ Valid values are: nil, Mh-init, Rmail-init or Gnus-mail-init."
 		 (function-item :tag "Gnus" :value Gnus-mail-init))
   :group 'hyperbole-commands)
 
-(defvar hmail:compose-mail-func 'mail-other-window
+(defvar hmail:compose-mail-function 'mail-other-window
   "Function for starting to compose a mail.")
 (defvar hmail:composer  'message-mode
  "Major mode for composing mail to be sent with Hyperbole buttons.")


### PR DESCRIPTION
## What 

~~Start trying out better support for composing email.~~ Implement the mail reader functionality for gnus and add a way to override the mail composer function. 

## Why

The mail reader support provides slightly different functionality for gnus. So could be seen as an alternative to using the Hyperbole news support. If providing this support is valuable is another question. 

Users need to be able to setup their favorite mail client and have it configured for editing with as little effort as possible. This is also a start in exploring this for ideas and feedback. The variable `hmail:compose-mail-other-window` is the way for the user to specify how the mail composer should be started. 

## Discussion

This adds a new function to the email interface. A function that opens up the mail composer. The idea being that the user selects the preferred emailer and by that gets the proper setup for using email address buttons etc. 

~~Not sure though if that fits in there. Maybe it should be its own abstraction just for this purpose? The later would maybe make it easier for users with a strange setup to customize just the function that brings up the composer!?~~ Decided to go forward with this implementation thinking that even if the `Gnus-mail-init` is not called the composer can still use the `hmail:compose-mail-other-window`

There can still be details with composing and reading email with embedded buttons that is missing in this PR. This can be added later.  

With current email standards, to not klick on something someone sent you, maybe suggests that this part of Hyperbole is not the most important to implement, or would need some redesign? I leave that discussion to later. 

~~Would not the email interface be a good candidate to refactor to use the object oriented support, similar to the registry code?~~ Also leaving this idea to later as the current implementation is good enough. 