### PR TITLE
Use kotl mode copy regions as kill in kotl mode

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,9 @@
 2023-01-08  Mats Lidell  <matsl@gnu.org>
 
+* test/hui-tests.el (hui--kill-ring-save-in-kotl-mode-copies-region)
+    (hui--kill-ring-save-in-kotl-mode-between-cells-fails): Add tests for
+    hui-kill-ring-save.
+
 * hui.el (hui-kill-ring-save): Call use kotl-mode:copy-region-as-kill when
     in kotl-mode.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2023-01-08  Mats Lidell  <matsl@gnu.org>
 
+* hui.el (hui-kill-ring-save): Call use kotl-mode:copy-region-as-kill when
+    in kotl-mode.
+
 * man/hyperbole.texi (Implicit Button Types): Remove ibtypes::org-mode
     from function index.
 

--- a/hui.el
+++ b/hui.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 21:42:03
-;; Last-Mod:      7-Jan-23 at 19:58:18 by Bob Weiner
+;; Last-Mod:      8-Jan-23 at 10:22:39 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -28,6 +28,7 @@
 ;;; ************************************************************************
 
 (declare-function texinfo-copy-node-name "texnfo-upd")
+(declare-function kotl-mode:copy-region-as-kill "kotl-mode")
 
 ;;; ************************************************************************
 ;;; Public variables
@@ -139,7 +140,9 @@ visual feedback indicating the extent of the region being copied."
     (if (or (use-region-p)
 	    (null transient-mark-mode)
 	    (not (called-interactively-p 'interactive)))
-	(copy-region-as-kill beg end region)
+        (if (derived-mode-p 'kotl-mode)
+            (kotl-mode:copy-region-as-kill beg end)
+	  (copy-region-as-kill beg end region))
       (setq thing (hui:delimited-selectable-thing))
       (if (stringp thing)
 	  (progn (kill-new thing)

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     23-Jul-22 at 20:06:18 by Bob Weiner
+;; Last-Mod:      1-Jan-23 at 22:36:28 by Mats Lidell
 ;;
 ;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -512,6 +512,33 @@ Ensure modifying the button but keeping the label does not create a double label
       (delete-file kotl-file)
       (delete-file other-file)
       (delete-directory other-dir))))
+
+(ert-deftest hui--kill-ring-save-in-kotl-mode-copies-region ()
+  "Copy region in kotl-mode does not copy left margin."
+  (let ((kotl-file (make-temp-file "hypb" nil ".kotl")))
+    (unwind-protect
+        (progn
+          (find-file kotl-file)
+          (set-mark (point))
+          (insert "a")
+          (kotl-mode:newline 1)
+          (insert "b")
+          (hui-kill-ring-save (region-beginning) (region-end))
+          (should (string= (current-kill 0 t) "a\nb")))
+      (delete-file kotl-file))))
+
+(ert-deftest hui--kill-ring-save-in-kotl-mode-between-cells-fails ()
+  "Copy region in kotl-mode between cells fails."
+  (let ((kotl-file (make-temp-file "hypb" nil ".kotl")))
+    (unwind-protect
+        (progn
+          (find-file kotl-file)
+          (set-mark (point))
+          (insert "a")
+          (kotl-mode:add-cell)
+          (insert "b")
+          (should-error (hui-kill-ring-save (region-beginning) (region-end)) :type 'error))
+      (delete-file kotl-file))))
 
 ;; This file can't be byte-compiled without `with-simulated-input' which
 ;; is not part of the actual dependencies, so:


### PR DESCRIPTION
## What

Use `kotl-mode:copy-region-as-kill` in `kotl-mode.`

## Why

Looked at why`M-w` i `kotl-mode` copies the left margin and found that it is bound to `hui-kill-ring-save` which calls `kill-region-as-kill` directly. We have `kotl-mode:copy-region-as-kill` that seems to do the proper copying without picking up the left margin whitespace. This PR uses that function for copying the region when in `kotl-mode.`