### PR TITLE
Do not mention removed function-in-buffer

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-01-08  Mats Lidell  <matsl@gnu.org>
+
+* FAST-DEMO: (bug#60596) Do not mention 'function-in-buffer', it's removed.
+
 2023-01-07  Bob Weiner  <rsw@gnu.org>
 
 * TAGS: Add to distribution, as is utilized in the Hyperbole DEMO.
@@ -32,7 +36,6 @@
 2022-12-18  Mats Lidell  <matsl@gnu.org>
 
 * Makefile (ELC_COMPILE, ELC_KOTL): Use function to derive elc files.
-
 
 2022-12-11  Bob Weiner  <rsw@gnu.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 2023-01-08  Mats Lidell  <matsl@gnu.org>
 
 * FAST-DEMO: (bug#60596) Do not mention 'function-in-buffer', it's removed.
+    (bug#60597) Replace 'org-mode' with 'org-link-outside-org-mode'.
 
 2023-01-07  Bob Weiner  <rsw@gnu.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2023-01-08  Mats Lidell  <matsl@gnu.org>
 
+* man/hyperbole.texi (Implicit Button Types): Remove ibtypes::org-mode
+    from function index.
+
 * FAST-DEMO: (bug#60596) Do not mention 'function-in-buffer', it's removed.
     (bug#60597) Replace 'org-mode' with 'org-link-outside-org-mode'.
 

--- a/FAST-DEMO
+++ b/FAST-DEMO
@@ -274,23 +274,23 @@ pspell-config(1)         - prints information about a libpspell installation
   will jump to its Lisp definition.  Use this if you want to see what each
   type can do.  <normal-mode> reverts to the standard mode.
 
-|------------------------+--------------------------+-----------------------|
-|                          Implicit Button Types                            |
-|------------------------+--------------------------+-----------------------|
-| action                 | annot-bib                | completion            |
-| cscope                 | ctags                    | debbugs-gnu-mode      |
-| debbugs-gnu-query      | debugger-source          | dir-summary           |
-| doc-id                 | elink                    | elisp-compiler-msg    |
-| etags                  | git-commit-reference     | glink                 |
-| gnus-push-button       | grep-msg                 | hyp-address           |
-| hyp-source             | id-cflow                 | ilink                 |
-| Info-node              | ipython-stack-frame      | kbd-key               |
-| klink                  | mail-address             | man-apropos           |
-| markdown-internal-link | org-mode                 | patch-msg             |
-| pathname               | pathname-line-and-column | rfc                   |
-| rfc-toc                | ripgrep-msg              | social-reference      |
-| texinfo-ref            | text-toc                 | www-url               |
-|---------------------------------------------------------------------------|
+|------------------------+---------------------------+-----------------------|
+|                          Implicit Button Types                             |
+|------------------------+---------------------------+-----------------------|
+| action                 | annot-bib                 | completion            |
+| cscope                 | ctags                     | debbugs-gnu-mode      |
+| debbugs-gnu-query      | debugger-source           | dir-summary           |
+| doc-id                 | elink                     | elisp-compiler-msg    |
+| etags                  | git-commit-reference      | glink                 |
+| gnus-push-button       | grep-msg                  | hyp-address           |
+| hyp-source             | id-cflow                  | ilink                 |
+| Info-node              | ipython-stack-frame       | kbd-key               |
+| klink                  | mail-address              | man-apropos           |
+| markdown-internal-link | org-link-outside-org-mode | patch-msg             |
+| pathname               | pathname-line-and-column  | rfc                   |
+| rfc-toc                | ripgrep-msg               | social-reference      |
+| texinfo-ref            | text-toc                  | www-url               |
+|----------------------------------------------------------------------------|
 
 Implicit button types are stored in their own namespace, 'ibtypes::', so to
 see the doc on the 'pathname' ibtype, use {C-h f ibtypes::pathname RET}.  To

--- a/FAST-DEMO
+++ b/FAST-DEMO
@@ -274,23 +274,22 @@ pspell-config(1)         - prints information about a libpspell installation
   will jump to its Lisp definition.  Use this if you want to see what each
   type can do.  <normal-mode> reverts to the standard mode.
 
-|-----------------------+------------------------+--------------------------|
+|------------------------+--------------------------+-----------------------|
 |                          Implicit Button Types                            |
-|-----------------------+------------------------+--------------------------|
-| action                | annot-bib              | completion               |
-| cscope                | ctags                  | debbugs-gnu-mode         |
-| debbugs-gnu-query     | debugger-source        | dir-summary              |
-| doc-id                | elink                  | elisp-compiler-msg       |
-| etags                 | function-in-buffer     | git-commit-reference     |
-| glink                 | gnus-push-button       | grep-msg                 |
-| hyp-address           | hyp-source             | id-cflow                 |
-| ilink                 | Info-node              | ipython-stack-frame      |
-| kbd-key               | klink                  | mail-address             |
-| man-apropos           | markdown-internal-link | org-mode                 |
-| patch-msg             | pathname               | pathname-line-and-column |
-| rfc                   | rfc-toc                | ripgrep-msg              |
-| social-reference      | texinfo-ref            | text-toc                 |
-| www-url               |                        |                          |
+|------------------------+--------------------------+-----------------------|
+| action                 | annot-bib                | completion            |
+| cscope                 | ctags                    | debbugs-gnu-mode      |
+| debbugs-gnu-query      | debugger-source          | dir-summary           |
+| doc-id                 | elink                    | elisp-compiler-msg    |
+| etags                  | git-commit-reference     | glink                 |
+| gnus-push-button       | grep-msg                 | hyp-address           |
+| hyp-source             | id-cflow                 | ilink                 |
+| Info-node              | ipython-stack-frame      | kbd-key               |
+| klink                  | mail-address             | man-apropos           |
+| markdown-internal-link | org-mode                 | patch-msg             |
+| pathname               | pathname-line-and-column | rfc                   |
+| rfc-toc                | ripgrep-msg              | social-reference      |
+| texinfo-ref            | text-toc                 | www-url               |
 |---------------------------------------------------------------------------|
 
 Implicit button types are stored in their own namespace, 'ibtypes::', so to

--- a/man/hyperbole.texi
+++ b/man/hyperbole.texi
@@ -7,7 +7,7 @@
 @c Author:       Bob Weiner
 @c
 @c Orig-Date:     6-Nov-91 at 11:18:03
-@c Last-Mod:      7-Jan-23 at 20:23:20 by Bob Weiner
+@c Last-Mod:      8-Jan-23 at 10:13:37 by Mats Lidell
 
 @c %**start of header (This is for running Texinfo on a region.)
 @setfilename hyperbole.info
@@ -2116,7 +2116,6 @@ implicit button types (they are listed in increasing order of priority).
 
 @table @code
 
-@findex ibtypes smart-org
 @cindex org-mode
 @cindex radio target
 @cindex code block


### PR DESCRIPTION
## What

 * Do not mention removed `function-in-buffer`,
 * Replace mention of `org-mode` with `org-link-outside-org-mode`  and
 * Remove `ibtypes::org-mode` from function index in hyperbole info pages

## Why

The function was removed in commit `81cebfec471ca72c8d0c9cbabc9c9bdd986c7117`, See also [emacs-bug](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=60596)

The implicit button for `org-mode` was removed in commit `5544a6c22b0bcc1c77970273f51fe521d56c5ff6` in favor of
other ways to support org-mode, See also [emacs-bug](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=60597)

## Note

Not sure what makes sense here in documentation. If I understand correct smart-org have taken over the role of the implicit org-mode button. org-mode is still mentioned under implicit buttons in the info pages!? But the smart-key functionality is like implicit buttons. I think of them as the same concept wise more or less. So not sure if these changes require some modification to the docs or if we should just keep things as they are.