### PR TITLE
Silence byte compilation warnings for interaction-log

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@
 
 * hypb.el: Add variable and function declarations for package
     interaction-log to silence byte compilation warnings.
+    (hypb:activate-interaction-log-mode): Use cl-pushnew.
 
 2023-01-20  Mats Lidell  <matsl@gnu.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2023-01-22  Mats Lidell  <matsl@gnu.org>
+
+* hypb.el: Add variable and function declarations for package
+    interaction-log to silence byte compilation warnings.
+
 2023-01-20  Mats Lidell  <matsl@gnu.org>
 
 * Remove docstring warnings.

--- a/hypb.el
+++ b/hypb.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     6-Oct-91 at 03:42:38
-;; Last-Mod:     10-Dec-22 at 00:52:04 by Mats Lidell
+;; Last-Mod:     21-Jan-23 at 00:38:07 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -50,6 +50,28 @@ It must end with a space."
 (declare-function helm-info "ext:helm")
 (declare-function helm-apropos "ext:helm")
 (declare-function devdocs-lookup "ext:devdocs")
+
+;; interaction-log
+(defvar ilog-buffer-name)
+(defvar ilog-display-state)
+(defvar ilog-idle-time)
+(defvar ilog-insertion-timer)
+(defvar ilog-print-lambdas)
+(defvar ilog-self-insert-command-regexps)
+(defvar ilog-truncation-timer)
+(defvar interaction-log-mode)
+(defvar interaction-log-mode-hook)
+
+(declare-function ilog-note-buffer-change "ext:interaction-log")
+(declare-function ilog-post-command "ext:interaction-log")
+(declare-function ilog-record-this-command "ext:interaction-log")
+(declare-function ilog-show-in-other-frame "ext:interaction-log")
+(declare-function ilog-timer-function "ext:interaction-log")
+(declare-function ilog-toggle-view "ext:interaction-log")
+(declare-function ilog-truncate-log-buffer "ext:interaction-log")
+(declare-function interaction-log-mode "ext:interaction-log")
+
+(declare-function pushnew "ext:???") ;; FIXME - Unknown function
 
 ;;; ************************************************************************
 ;;; Public functions
@@ -99,8 +121,7 @@ This displays a clean log of Emacs keys used and commands executed."
 	  (setq ilog-truncation-timer (run-at-time 30 30 #'ilog-truncate-log-buffer))
 	  (setq ilog-insertion-timer (run-with-timer ilog-idle-time ilog-idle-time
 						     #'ilog-timer-function))
-	  (message "Interaction Log: started logging in %s" ilog-buffer-name)
-	  (easy-menu-add ilog-minor-mode-menu))
+	  (message "Interaction Log: started logging in %s" ilog-buffer-name))
       (remove-hook 'after-change-functions #'ilog-note-buffer-change)
       (remove-hook 'post-command-hook      #'ilog-record-this-command)
       (remove-hook 'post-command-hook      #'ilog-post-command)

--- a/hypb.el
+++ b/hypb.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     6-Oct-91 at 03:42:38
-;; Last-Mod:     21-Jan-23 at 00:38:07 by Mats Lidell
+;; Last-Mod:     22-Jan-23 at 16:57:36 by Mats Lidell
 ;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
@@ -17,7 +17,7 @@
 ;;; Other required Elisp libraries
 ;;; ************************************************************************
 
-(eval-and-compile (mapc #'require '(compile hversion hact locate)))
+(eval-and-compile (mapc #'require '(compile hversion hact locate cl-lib)))
 
 ;;; ************************************************************************
 ;;; Public variables
@@ -71,8 +71,6 @@ It must end with a space."
 (declare-function ilog-truncate-log-buffer "ext:interaction-log")
 (declare-function interaction-log-mode "ext:interaction-log")
 
-(declare-function pushnew "ext:???") ;; FIXME - Unknown function
-
 ;;; ************************************************************************
 ;;; Public functions
 ;;; ************************************************************************
@@ -100,7 +98,7 @@ This displays a clean log of Emacs keys used and commands executed."
   (setq ilog-print-lambdas 'not-compiled)
 
   ;; Omit display of some lower-level Hyperbole commands for cleaner logs
-  (mapc (lambda (cmd-str) (pushnew (format "^%s$" cmd-str) ilog-self-insert-command-regexps))
+  (mapc (lambda (cmd-str) (cl-pushnew (format "^%s$" cmd-str) ilog-self-insert-command-regexps))
         '("hyperbole" "hui:menu-enter"))
 
   ;; Redefine the mode to display commands on post-command-hook rather


### PR DESCRIPTION
## What

Silence byte compilation warnings for interaction-log

## Why

`hypb:activate-interaction-log-mode` uses many variables and functions from the interaction-log package. This produces many byte compilation warnings. This uses the technique to use `defvar` and `declare-function` to tell the byte compiler that these things exists.

This is a bit verbose way to accomplish this but is there any other way? One idea is to provide these utility functions as a file that is not included in the files that are compiled. Rather a separate file to be loaded by the user and as such could require the interaction-log package? wdyt?

See notes below for other issues. 