### PR TITLE
Add SPDX-License-Identifier

### DIFF
--- a/hact.el
+++ b/hact.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    18-Sep-91 at 02:57:09
 ;; Last-Mod:     27-Jan-23 at 17:40:04 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hactypes.el
+++ b/hactypes.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    23-Sep-91 at 20:34:36
 ;; Last-Mod:      7-Jan-23 at 19:59:13 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hargs.el
+++ b/hargs.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    31-Oct-91 at 23:17:35
 ;; Last-Mod:      7-Jan-23 at 14:00:52 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hbdata.el
+++ b/hbdata.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:     2-Apr-91
 ;; Last-Mod:     29-Jan-23 at 02:34:21 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hbmap.el
+++ b/hbmap.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:     6-Oct-91 at 06:34:05
 ;; Last-Mod:      7-Oct-22 at 23:18:45 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hbut.el
+++ b/hbut.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    18-Sep-91 at 02:57:09
 ;; Last-Mod:     29-Jan-23 at 02:39:52 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hgnus.el
+++ b/hgnus.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    24-Dec-91 at 22:29:28
 ;; Last-Mod:      9-May-22 at 00:01:49 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hhist.el
+++ b/hhist.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    24-Apr-91 at 03:36:23
 ;; Last-Mod:      6-Nov-22 at 12:22:44 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hib-debbugs.el
+++ b/hib-debbugs.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    21-Jun-16 at 14:24:53
 ;; Last-Mod:     24-Jul-22 at 10:41:16 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 2016, 2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hib-doc-id.el
+++ b/hib-doc-id.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    30-Sep-92 at 19:39:59
 ;; Last-Mod:     25-Sep-22 at 02:39:34 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hib-kbd.el
+++ b/hib-kbd.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    22-Nov-91 at 01:37:57
 ;; Last-Mod:     29-Jan-23 at 10:11:10 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hib-social.el
+++ b/hib-social.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    20-Jul-16 at 22:41:34
 ;; Last-Mod:     24-Jul-22 at 10:08:17 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 2016-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    19-Sep-91 at 20:45:31
 ;; Last-Mod:      7-Jan-23 at 19:54:51 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1991-2022 Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hinit.el
+++ b/hinit.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:     1-Oct-91 at 02:32:51
 ;; Last-Mod:     25-Jul-22 at 17:44:31 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hload-path.el
+++ b/hload-path.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    29-Jun-16 at 14:39:33
 ;; Last-Mod:     23-Oct-22 at 00:38:27 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1992-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hmail.el
+++ b/hmail.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:     9-Oct-91 at 18:38:05
 ;; Last-Mod:     29-Jan-23 at 02:03:03 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the HY-COPY (Hyperbole) or BR-COPY (OO-Browser) file for license
 ;; information.

--- a/hmh.el
+++ b/hmh.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    21-May-91 at 17:06:36
 ;; Last-Mod:      9-May-22 at 22:36:31 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hmoccur.el
+++ b/hmoccur.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:     1-Aug-91
 ;; Last-Mod:     25-Jul-22 at 20:00:01 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hmouse-drv.el
+++ b/hmouse-drv.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    04-Feb-90
 ;; Last-Mod:     15-Jan-23 at 17:08:53 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1989-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hmouse-info.el
+++ b/hmouse-info.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    04-Apr-89
 ;; Last-Mod:     20-Jan-23 at 22:19:33 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1989-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hmouse-key.el
+++ b/hmouse-key.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    30-May-94 at 00:11:57
 ;; Last-Mod:     25-Jul-22 at 23:47:01 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1994-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hmouse-mod.el
+++ b/hmouse-mod.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:     8-Oct-92 at 19:08:31
 ;; Last-Mod:     26-Jul-22 at 23:56:52 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1992-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hmouse-sh.el
+++ b/hmouse-sh.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:     3-Sep-91 at 21:40:58
 ;; Last-Mod:     16-Oct-22 at 19:32:50 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hmouse-tag.el
+++ b/hmouse-tag.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    24-Aug-91
 ;; Last-Mod:     28-Jan-23 at 23:51:50 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hpath.el
+++ b/hpath.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:     1-Nov-91 at 00:44:23
 ;; Last-Mod:      3-Dec-22 at 02:20:47 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hrmail.el
+++ b/hrmail.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:     9-May-91 at 04:22:02
 ;; Last-Mod:      5-Jun-22 at 17:59:19 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hsettings.el
+++ b/hsettings.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    15-Apr-91 at 00:48:49
 ;; Last-Mod:     12-Oct-22 at 22:46:00 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hsmail.el
+++ b/hsmail.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:     9-May-91 at 04:50:20
 ;; Last-Mod:     16-Oct-22 at 00:30:39 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hsys-org.el
+++ b/hsys-org.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:     2-Jul-16 at 14:54:14
 ;; Last-Mod:      3-Dec-22 at 02:33:37 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 2016-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hsys-www.el
+++ b/hsys-www.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:     7-Apr-94 at 17:17:39 by Bob Weiner
 ;; Last-Mod:     11-May-22 at 00:01:48 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1994-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hsys-youtube.el
+++ b/hsys-youtube.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    10-Jul-22 at 18:10:56
 ;; Last-Mod:     22-Nov-22 at 18:11:43 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/htz.el
+++ b/htz.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    14-Oct-91 at 07:22:08
 ;; Last-Mod:      2-Aug-22 at 15:02:15 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hui-dired-sidebar.el
+++ b/hui-dired-sidebar.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    25-Jul-20
 ;; Last-Mod:     24-Jan-22 at 00:18:47 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 2020-2021 Free Software Foundation, Inc.  See the
 ;; "HY-COPY" file for license information.
 ;;

--- a/hui-em-but.el
+++ b/hui-em-but.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    21-Aug-92
 ;; Last-Mod:      7-Oct-22 at 00:17:10 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1992-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hui-jmenu.el
+++ b/hui-jmenu.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:     9-Mar-94 at 23:37:28
 ;; Last-Mod:      2-Aug-22 at 19:50:39 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1994-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hui-menu.el
+++ b/hui-menu.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    28-Oct-94 at 10:59:44
 ;; Last-Mod:      6-Nov-22 at 12:23:29 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1994-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hui-mini.el
+++ b/hui-mini.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    15-Oct-91 at 20:13:17
 ;; Last-Mod:      6-Nov-22 at 13:09:42 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hui-mouse.el
+++ b/hui-mouse.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    04-Feb-89
 ;; Last-Mod:     29-Jan-23 at 03:47:20 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hui-register.el
+++ b/hui-register.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:     6-Oct-91 at 03:42:38
 ;; Last-Mod:     18-Sep-22 at 00:40:52 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hui-select.el
+++ b/hui-select.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    19-Oct-96 at 02:25:27
 ;; Last-Mod:      3-Oct-22 at 20:21:48 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1996-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hui-treemacs.el
+++ b/hui-treemacs.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    19-Nov-17
 ;; Last-Mod:     19-Jun-22 at 13:58:47 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 2017-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hui-window.el
+++ b/hui-window.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    21-Sep-92
 ;; Last-Mod:      7-Oct-22 at 23:39:57 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1992-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hui.el
+++ b/hui.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    19-Sep-91 at 21:42:03
 ;; Last-Mod:     20-Jan-23 at 23:16:41 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hvar.el
+++ b/hvar.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:     1-Oct-91 at 14:00:24
 ;; Last-Mod:      6-Aug-22 at 12:07:16 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hversion.el
+++ b/hversion.el
@@ -6,6 +6,8 @@
 ;; Orig-Date:     1-Jan-94
 ;; Last-Mod:      4-Dec-22 at 03:57:42 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1994-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hvm.el
+++ b/hvm.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    10-Oct-91 at 01:51:12
 ;; Last-Mod:      8-May-22 at 23:59:33 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1991-2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hycontrol.el
+++ b/hycontrol.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:     1-Jun-16 at 15:35:36
 ;; Last-Mod:     27-Nov-22 at 11:21:28 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 2016-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hypb-ert.el
+++ b/hypb-ert.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    31-Mar-21 at 21:11:00
 ;; Last-Mod:     11-May-22 at 00:00:42 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hypb-maintenance.el
+++ b/hypb-maintenance.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    31-Mar-21 at 21:11:00
 ;; Last-Mod:      1-May-22 at 19:06:09 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hypb.el
+++ b/hypb.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:     6-Oct-91 at 03:42:38
 ;; Last-Mod:     29-Jan-23 at 10:30:14 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hyperbole.el
+++ b/hyperbole.el
@@ -1,5 +1,7 @@
 ;;; hyperbole.el --- GNU Hyperbole: The Everyday Hypertextual Information Manager  -*- lexical-binding: t; -*-
 
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1992-2022  Free Software Foundation, Inc.
 
 ;; Author:           Bob Weiner

--- a/hyrolo-demo.el
+++ b/hyrolo-demo.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:     4-Nov-17 at 13:56:47
 ;; Last-Mod:      7-Oct-22 at 00:16:24 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 2017-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hyrolo-logic.el
+++ b/hyrolo-logic.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    13-Jun-89 at 22:57:33
 ;; Last-Mod:     24-Oct-22 at 22:49:42 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1989-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hyrolo-menu.el
+++ b/hyrolo-menu.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    28-Oct-94 at 10:59:44
 ;; Last-Mod:     18-Apr-22 at 00:29:31 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1994-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:     7-Jun-89 at 22:08:29
 ;; Last-Mod:     15-Jan-23 at 16:55:37 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/hywconfig.el
+++ b/hywconfig.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    15-Mar-89
 ;; Last-Mod:     20-Jan-23 at 22:20:55 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1989-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
 ;;

--- a/kotl/kcell.el
+++ b/kotl/kcell.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:     1-May-93
 ;; Last-Mod:      1-Oct-22 at 15:11:43 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1993-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
 ;;

--- a/kotl/kexport.el
+++ b/kotl/kexport.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    26-Feb-98
 ;; Last-Mod:     28-Jan-23 at 23:11:25 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1998-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
 ;;

--- a/kotl/kfile.el
+++ b/kotl/kfile.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    10/31/93
 ;; Last-Mod:     22-Jul-22 at 15:17:31 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1993-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
 ;;

--- a/kotl/kfill.el
+++ b/kotl/kfill.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    23-Jan-94
 ;; Last-Mod:      4-Jul-22 at 23:34:12 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1994-2021  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
 ;;

--- a/kotl/kimport.el
+++ b/kotl/kimport.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    15-Nov-93 at 11:57:05
 ;; Last-Mod:     20-Nov-22 at 23:23:23 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1993-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
 ;;

--- a/kotl/klabel.el
+++ b/kotl/klabel.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    17-Apr-94
 ;; Last-Mod:     18-Jul-22 at 21:58:23 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1994-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
 ;;

--- a/kotl/klink.el
+++ b/kotl/klink.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    15-Nov-93 at 12:15:16
 ;; Last-Mod:     12-Oct-22 at 21:21:34 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1993-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
 ;;

--- a/kotl/kmenu.el
+++ b/kotl/kmenu.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    28-Mar-94 at 11:22:09
 ;; Last-Mod:     17-Apr-22 at 23:51:03 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1994-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
 ;;

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    6/30/93
 ;; Last-Mod:     16-Oct-22 at 19:29:20 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1993-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
 ;;

--- a/kotl/kotl-orgtbl.el
+++ b/kotl/kotl-orgtbl.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    10/18/2020
 ;; Last-Mod:     24-Jan-22 at 00:25:29 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 2020-2021  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
 ;;

--- a/kotl/kproperty.el
+++ b/kotl/kproperty.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    7/27/93
 ;; Last-Mod:     16-Oct-22 at 10:01:41 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1993-2021  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
 ;;

--- a/kotl/kview.el
+++ b/kotl/kview.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    6/30/93
 ;; Last-Mod:     16-Oct-22 at 18:32:03 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1993-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
 ;;

--- a/kotl/kvspec.el
+++ b/kotl/kvspec.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    21-Oct-95 at 15:17:07
 ;; Last-Mod:     18-Jul-22 at 21:57:01 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1995-2022  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
 ;;

--- a/set.el
+++ b/set.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    26-Sep-91 at 19:24:19
 ;; Last-Mod:      6-Aug-22 at 23:23:08 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 1991-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/test/demo-tests.el
+++ b/test/demo-tests.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    30-Jan-21 at 12:00:00
 ;; Last-Mod:      6-Nov-22 at 12:23:00 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/test/hactypes-tests.el
+++ b/test/hactypes-tests.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    30-Jan-21 at 12:00:00
 ;; Last-Mod:      6-Feb-22 at 00:56:35 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/test/hargs-tests.el
+++ b/test/hargs-tests.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    04-Feb-22 at 23:00:00
 ;; Last-Mod:     04-Feb-22 at 23:00:00 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/test/hbut-tests.el
+++ b/test/hbut-tests.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    30-may-21 at 09:33:00
 ;; Last-Mod:     23-Jul-22 at 20:04:45 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/test/hib-kbd-tests.el
+++ b/test/hib-kbd-tests.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    30-Jan-21 at 12:00:00
 ;; Last-Mod:     26-Mar-22 at 11:25:43 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/test/hib-social-tests.el
+++ b/test/hib-social-tests.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    20-Feb-21 at 23:24:00
 ;; Last-Mod:     24-Jan-22 at 00:38:39 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/test/hibtypes-tests.el
+++ b/test/hibtypes-tests.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    20-Feb-21 at 23:45:00
 ;; Last-Mod:     12-Feb-22 at 13:33:53 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/test/hibtypes-tests.el
+++ b/test/hibtypes-tests.el
@@ -217,7 +217,7 @@
 (ert-deftest ibtypes::ctags-vgrind-test ()
   (unwind-protect
       (with-temp-buffer
-        (insert "hy-test-helpers:consume-input-events hy-test-helpers.el 23\n")
+        (insert "hy-test-helpers:consume-input-events hy-test-helpers.el 25\n")
         (goto-char (point-min))
         (forward-char 4)
         (let ((default-directory (expand-file-name "test" hyperb:dir)))
@@ -233,7 +233,7 @@
       (with-temp-buffer
         (insert "\n")
         (insert "hy-test-helpers.el,237\n")
-        (insert "(defun hy-test-helpers:consume-input-events 23,518\n")
+        (insert "(defun hy-test-helpers:consume-input-events 25,518\n")
         (rename-buffer (concat "TAGS" (buffer-name)))
         (goto-char (point-min))
         (forward-line 2)

--- a/test/hmouse-drv-tests.el
+++ b/test/hmouse-drv-tests.el
@@ -376,7 +376,7 @@
 (ert-deftest hbut-ctags-vgrind-test ()
   (unwind-protect
       (with-temp-buffer
-        (insert "hy-test-helpers:consume-input-events hy-test-helpers.el 23\n")
+        (insert "hy-test-helpers:consume-input-events hy-test-helpers.el 25\n")
         (goto-char (point-min))
         (forward-char 4)
         (let ((default-directory (expand-file-name "test" hyperb:dir)))
@@ -392,7 +392,7 @@
       (with-temp-buffer
         (insert "\n")
         (insert "hy-test-helpers.el,237\n")
-        (insert "(defun hy-test-helpers:consume-input-events 23,518\n")
+        (insert "(defun hy-test-helpers:consume-input-events 25,518\n")
         (rename-buffer (concat "TAGS" (buffer-name)))
         (goto-char (point-min))
         (forward-line 2)

--- a/test/hmouse-drv-tests.el
+++ b/test/hmouse-drv-tests.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    28-Feb-21 at 22:52:00
 ;; Last-Mod:     22-May-22 at 11:13:48 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/test/hmouse-info-tests.el
+++ b/test/hmouse-info-tests.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    29-Dec-21 at 09:02:00
 ;; Last-Mod:     22-May-22 at 11:11:53 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/test/hpath-tests.el
+++ b/test/hpath-tests.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    28-Feb-21 at 23:26:00
 ;; Last-Mod:     12-Sep-22 at 22:11:14 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/test/hsys-org-tests.el
+++ b/test/hsys-org-tests.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    23-Apr-21 at 20:55:00
 ;; Last-Mod:      3-Dec-22 at 00:12:39 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/test/hui-register-tests.el
+++ b/test/hui-register-tests.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    10-Sep-22 at 20:43:17
 ;; Last-Mod:      2-Oct-22 at 11:21:13 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/test/hui-select-tests.el
+++ b/test/hui-select-tests.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    14-Apr-22 at 23:45:52
 ;; Last-Mod:     11-Jul-22 at 23:29:45 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 2021  Free Software Foundation, Inc.
 ;; See the "../HY-COPY" file for license information.
 ;;

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    30-Jan-21 at 12:00:00
 ;; Last-Mod:      1-Jan-23 at 22:36:28 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/test/hy-test-dependencies.el
+++ b/test/hy-test-dependencies.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    20-Feb-21 at 23:16:00
 ;; Last-Mod:     23-Jul-22 at 18:37:43 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 2021  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/test/hy-test-helpers.el
+++ b/test/hy-test-helpers.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    30-Jan-21 at 12:00:00
 ;; Last-Mod:     23-Jul-22 at 18:39:05 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/test/hypb-tests.el
+++ b/test/hypb-tests.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:     5-Apr-21 at 18:53:10
 ;; Last-Mod:     15-Jul-22 at 23:26:35 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/test/hyperbole-tests.el
+++ b/test/hyperbole-tests.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:     8-Jan-22 at 23:40:00
 ;; Last-Mod:     24-Jan-22 at 00:41:15 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/test/hyrolo-tests.el
+++ b/test/hyrolo-tests.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    19-Jun-21 at 22:42:00
 ;; Last-Mod:     24-Sep-22 at 12:27:35 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/test/kcell-tests.el
+++ b/test/kcell-tests.el
@@ -9,6 +9,8 @@
 ;; orig-date:    16-Feb-22 at 23:28:49
 ;; last-mod:     18-Feb-22 at 19:03:54 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 2021  Free Software Foundation, Inc.
 ;; Licensed under the GNU General Public License, version 3.
 ;;

--- a/test/kexport-tests.el
+++ b/test/kexport-tests.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    10-Oct-21 at 17:30:00
 ;; Last-Mod:     22-May-22 at 10:57:14 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/test/kotl-mode-tests.el
+++ b/test/kotl-mode-tests.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    18-May-21 at 22:14:10
 ;; Last-Mod:     18-Apr-22 at 22:40:33 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/test/kotl-orgtbl-tests.el
+++ b/test/kotl-orgtbl-tests.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:     2-Nov-21 at 17:04:30
 ;; Last-Mod:      1-Mar-22 at 23:24:01 by Mats Lidell
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;

--- a/test/smart-org-tests.el
+++ b/test/smart-org-tests.el
@@ -5,6 +5,8 @@
 ;; Orig-Date:    23-Apr-21 at 22:21:00
 ;; Last-Mod:     22-May-22 at 15:04:44 by Bob Weiner
 ;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
 ;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;


### PR DESCRIPTION
## What

Add SPDX-License-Identifier

## Why

It was mentioned in the Melpa PR and seems to be used by many packages,

>Next, I would consider using a formal license header or an [SPDX-License-Identifier](https://spdx.dev/ids/) to denote the licenses in each of the files. I think HY-COPY is not included by the recipe, but since this is GPL-3+ licensed code the SPDX license is straightforward, machine-detectable, and totally unambiguous.