### PR TITLE
Cleanup patch, use old functions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2023-02-06  Mats Lidell  <matsl@gnu.org>
+
+* Cleanup from Stefan Monnier. Thanks Stefan.
+* hypb.el (hypb:indirect-function): Use indirect-function directly.
+* hgnus.el: Use add-hook directly.
+
 2023-02-06  Bob Weiner  <rsw@gnu.org>
 
 * set.el (set:member): Optimize for common equality operators.
@@ -7,7 +13,7 @@
          (set:members): Keep members in stable order; previously returned in
     reverse order.
 
-2023-02-05  Bob Weiner  <rsw@gnu.org>
+2023-02-05  Mats Lidell  <matsl@gnu.org>-02-05  Bob Weiner  <rsw@gnu.org>
 
 * hsys-org.el (hsys-org-mode-function): Improve doc string.
 

--- a/hgnus.el
+++ b/hgnus.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    24-Dec-91 at 22:29:28
-;; Last-Mod:      9-May-22 at 00:01:49 by Bob Weiner
+;; Last-Mod:      5-Feb-23 at 23:40:25 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -107,17 +107,13 @@ as ARG means don't indent and don't delete any header fields."
 (if (fboundp 'hproperty:but-create)
     (var:append 'gnus-summary-prepare-hook '(hproperty:but-create)))
 
-;;; Try to setup comment addition as the first element of these hooks.
-(if (fboundp 'add-hook)
-    ;; Called from 'news-post-news' if prev unsent article exists and user
-    ;; says erase it.  Add a comment on Hyperbole button support.
-    (progn
-      (add-hook 'news-setup-hook #'smail:comment-add)
-      ;; Called from 'news-post-news' if no prev unsent article exists.
-      ;; Add a comment on Hyperbole button support.
-      (add-hook 'news-reply-mode-hook #'smail:comment-add))
-  (var:append 'news-setup-hook '(smail:comment-add))
-  (var:append 'news-reply-mode-hook '(smail:comment-add)))
+;; Try to setup comment addition as the first element of these hooks.
+;; Called from 'news-post-news' if prev unsent article exists and user
+;; says erase it.  Add a comment on Hyperbole button support.
+(add-hook 'news-setup-hook #'smail:comment-add)
+;; Called from 'news-post-news' if no prev unsent article exists.
+;; Add a comment on Hyperbole button support.
+(add-hook 'news-reply-mode-hook #'smail:comment-add)
 
 (provide 'hgnus)
 

--- a/hypb.el
+++ b/hypb.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     6-Oct-91 at 03:42:38
-;; Last-Mod:     29-Jan-23 at 10:30:14 by Bob Weiner
+;; Last-Mod:      5-Feb-23 at 23:44:24 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -611,12 +611,7 @@ This will this install the Emacs helm package when needed."
 (defun hypb:indirect-function (obj)
   "Return the function at the end of OBJ's function chain.
 Resolves autoloadable function symbols properly."
-  (let ((func
-	 (if (fboundp 'indirect-function)
-	     (indirect-function obj)
-	   (while (symbolp obj)
-	     (setq obj (symbol-function obj)))
-	   obj)))
+  (let ((func (indirect-function obj)))
     ;; Handle functions with autoload bodies.
     (if (and (symbolp obj) (listp func) (eq (car func) 'autoload))
 	(let ((load-file (car (cdr func))))


### PR DESCRIPTION
## What 

Cleanup patch, use old functions.  From Stefan Monnier. Thanks.

## Why

Cleanup is a good thing. I picked out this cleanup from the patch #118 originating from Stefan. I suggest we close that PR now since it is only the `hbut--inhibit-something` refactoring that is left in that. It will still be available in closed state so we will not loos it in case we forget why it was once created.