### PR TITLE
Make kotl-autoloads without building hyperbole-autoloads.el

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,7 +2,7 @@
 
 * Makefile (EMACS_PLAIN_BATCH, kotl/kotl-autoloads.el): Use
     EMACS_PLAIN_BATCH macro in autoloads target to avoid triggering
-    building huperbole-autoloads. Patch from Stefan Monnier. Thanks Stefan.
+    building hyperbole-autoloads. Patch from Stefan Monnier. Thanks Stefan.
 
 2023-02-13  Mats Lidell  <matsl@gnu.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2023-02-15  Mats Lidell  <matsl@gnu.org>
+
+* Makefile (EMACS_PLAIN_BATCH, kotl/kotl-autoloads.el): Use
+    EMACS_PLAIN_BATCH macro in autoloads target to avoid triggering
+    building huperbole-autoloads. Patch from Stefan Monnier. Thanks Stefan.
+
 2023-02-13  Mats Lidell  <matsl@gnu.org>
 
 * hversion.el (id-info-item): Use two args with looking-back.

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:     16-Feb-23 at 00:51:09 by Mats Lidell
+# Last-Mod:     17-Feb-23 at 00:32:14 by Mats Lidell
 #
 # Copyright (C) 1994-2023  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -424,16 +424,10 @@ ftp: package $(pkg_parent)/hyperbole-$(HYPB_VERSION).tar.gz
 autoloads: kotl/kotl-autoloads.el hyperbole-autoloads.el
 
 hyperbole-autoloads.el: $(EL_COMPILE)
-	@echo "DEBUG: Scraping autloads using this command"
-	@echo $(EMACS_BATCH) --debug --eval "(progn (setq generated-autoload-file (expand-file-name \"hyperbole-autoloads.el\") backup-inhibited t) (let (find-file-hooks) (hload-path--make-directory-autoloads \".\" generated-autoload-file)))"
 	$(EMACS_BATCH) --debug --eval "(progn (setq generated-autoload-file (expand-file-name \"hyperbole-autoloads.el\") backup-inhibited t) (let (find-file-hooks) (hload-path--make-directory-autoloads \".\" generated-autoload-file)))"
-	@echo "DEBUG: Scarping done"
 
 kotl/kotl-autoloads.el: $(EL_KOTL)
-	@echo "DEBUG: Scraping autloads using this command"
-	@echo $(EMACS_PLAIN_BATCH) --debug --eval "(progn (setq generated-autoload-file (expand-file-name \"kotl/kotl-autoloads.el\") backup-inhibited t) (let (find-file-hooks) (make-directory-autoloads \"kotl/\" generated-autoload-file)))"
-	$(EMACS_PLAIN_BATCH) --debug --eval "(progn (setq generated-autoload-file (expand-file-name \"kotl/kotl-autoloads.el\") backup-inhibited t) (let (find-file-hooks) (make-directory-autoloads \"kotl/\" generated-autoload-file)))"
-	@echo "DEBUG: Scarping done"
+	$(EMACS_PLAIN_BATCH) --debug --eval "(let ((autoload-file (expand-file-name \"kotl/kotl-autoloads.el\")) (backup-inhibited t) (find-file-hooks)) (if (functionp (quote make-directory-autoloads)) (make-directory-autoloads \"kotl/\" autoload-file) (progn (setq generated-autoload-file autoload-file) (update-directory-autoloads \"kotl/\"))))"
 
 # Used for ftp.gnu.org tarball distributions.
 $(pkg_parent)/hyperbole-$(HYPB_VERSION).tar.gz:

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:      7-Jan-23 at 20:45:26 by Bob Weiner
+# Last-Mod:     15-Feb-23 at 00:32:24 by Mats Lidell
 #
-# Copyright (C) 1994-2022  Free Software Foundation, Inc.
+# Copyright (C) 1994-2023  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
 #
 # This file is part of GNU Hyperbole.
@@ -170,6 +170,7 @@ BATCHFLAGS = -batch -Q --eval "(progn (setq debug-on-error t) (setq backtrace-li
                                  (message \"  emacs-version = %s\n  system-configuration = %s\n  emacs = %s%s\" emacs-version system-configuration invocation-directory invocation-name))"
 
 EMACS_BATCH=$(EMACS) $(BATCHFLAGS) $(PRELOADS)
+EMACS_PLAIN_BATCH=$(EMACS) $(BATCHFLAGS)
 
 # Directories other than the current directory in which to find files.
 # This doesn't seem to work in all versions of make, so we also add kotl/
@@ -426,7 +427,7 @@ hyperbole-autoloads.el: $(EL_COMPILE)
 	$(EMACS_BATCH) --debug --eval "(progn (setq generated-autoload-file (expand-file-name \"hyperbole-autoloads.el\") backup-inhibited t) (let (find-file-hooks) (hload-path--make-directory-autoloads \".\" generated-autoload-file)))"
 
 kotl/kotl-autoloads.el: $(EL_KOTL)
-	$(EMACS_BATCH) --debug --eval "(progn (setq generated-autoload-file (expand-file-name \"kotl/kotl-autoloads.el\") backup-inhibited t) (let (find-file-hooks) (hload-path--make-directory-autoloads \"kotl/\" generated-autoload-file)))"
+	$(EMACS_PLAIN_BATCH) --debug --eval "(progn (setq generated-autoload-file (expand-file-name \"kotl/kotl-autoloads.el\") backup-inhibited t) (let (find-file-hooks) (make-directory-autoloads \"kotl/\" generated-autoload-file)))"
 
 # Used for ftp.gnu.org tarball distributions.
 $(pkg_parent)/hyperbole-$(HYPB_VERSION).tar.gz:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:     15-Feb-23 at 00:32:24 by Mats Lidell
+# Last-Mod:     16-Feb-23 at 00:51:09 by Mats Lidell
 #
 # Copyright (C) 1994-2023  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -421,13 +421,19 @@ ftp: package $(pkg_parent)/hyperbole-$(HYPB_VERSION).tar.gz
 	cd $(pkg_parent) && $(GNUFTP) hyperbole-$(HYPB_VERSION).tar.gz
 
 # Autoloads
-autoloads: hyperbole-autoloads.el kotl/kotl-autoloads.el
+autoloads: kotl/kotl-autoloads.el hyperbole-autoloads.el
 
 hyperbole-autoloads.el: $(EL_COMPILE)
+	@echo "DEBUG: Scraping autloads using this command"
+	@echo $(EMACS_BATCH) --debug --eval "(progn (setq generated-autoload-file (expand-file-name \"hyperbole-autoloads.el\") backup-inhibited t) (let (find-file-hooks) (hload-path--make-directory-autoloads \".\" generated-autoload-file)))"
 	$(EMACS_BATCH) --debug --eval "(progn (setq generated-autoload-file (expand-file-name \"hyperbole-autoloads.el\") backup-inhibited t) (let (find-file-hooks) (hload-path--make-directory-autoloads \".\" generated-autoload-file)))"
+	@echo "DEBUG: Scarping done"
 
 kotl/kotl-autoloads.el: $(EL_KOTL)
+	@echo "DEBUG: Scraping autloads using this command"
+	@echo $(EMACS_PLAIN_BATCH) --debug --eval "(progn (setq generated-autoload-file (expand-file-name \"kotl/kotl-autoloads.el\") backup-inhibited t) (let (find-file-hooks) (make-directory-autoloads \"kotl/\" generated-autoload-file)))"
 	$(EMACS_PLAIN_BATCH) --debug --eval "(progn (setq generated-autoload-file (expand-file-name \"kotl/kotl-autoloads.el\") backup-inhibited t) (let (find-file-hooks) (make-directory-autoloads \"kotl/\" generated-autoload-file)))"
+	@echo "DEBUG: Scarping done"
 
 # Used for ftp.gnu.org tarball distributions.
 $(pkg_parent)/hyperbole-$(HYPB_VERSION).tar.gz:


### PR DESCRIPTION
## What

Make `kotl/kotl-autoloads` without building `hyperbole-autoloads.el`

## Why

The target `kotl/kotl-autoloads.el` has as a side effect to also build the `hyperbole-autoloads.el.` That is not correct and can lead to unexpected problems and even errors. Patch by Stefan Monnier.  This PR fixed this so that only `kotl-autoloads` are produced as a result of that make target.