### PR TITLE
Add startup check hyperbole is found

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2023-02-18  Mats Lidell  <matsl@gnu.org>
 
+* test/hmouse-drv-tests.el (hbut-defil-it): Do not follow symbolic
+    links to make path check work.
+
 * install-test/local-install-test.sh: Add normal Emacs start to verify
     Hyperbole is installed.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2023-02-18  Mats Lidell  <matsl@gnu.org>
+
+* install-test/local-install-test.sh: Add normal Emacs start to verify
+    Hyperbole is installed.
+
 2023-02-15  Mats Lidell  <matsl@gnu.org>
 
 * Makefile (EMACS_PLAIN_BATCH, kotl/kotl-autoloads.el): Use

--- a/install-test/local-install-test.sh
+++ b/install-test/local-install-test.sh
@@ -2,6 +2,8 @@
 
 echo *** Install test ***
 
+set -e
+
 install_method="$1"
 
 app=/tmp/hypb-$$
@@ -13,8 +15,13 @@ export HOME=$app/$install_method
 [ -e $app/$install_method/install-local.sh ] && cd $app/$install_method && ./install-local.sh
 
 cd $app/$install_method
+
+## Initial install with ert tests
 emacs --batch -l $app/$install_method/.emacs \
       --eval '(load (expand-file-name "test/hy-test-dependencies.el" hyperb:dir))' \
       -l hypb-ert \
       --eval "(hypb-ert-require-libraries)" \
       -f ert-run-tests-batch-and-exit
+
+## Startup again interactive - check hyperbole is found
+emacs -nw --eval "(if (boundp 'hyperb:version) (kill-emacs 0) (kill-emacs 1))"

--- a/test/hmouse-drv-tests.el
+++ b/test/hmouse-drv-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    28-Feb-21 at 22:52:00
-;; Last-Mod:     22-May-22 at 11:13:48 by Mats Lidell
+;; Last-Mod:     19-Feb-23 at 15:49:31 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -106,13 +106,13 @@
 
 (ert-deftest hbut-defil-it ()
   (defil defil-path-it "<<<" ">>>" ".*" "${hyperb:dir}/\\&")
-  (unwind-protect
-      (with-temp-buffer
-        (insert "<<<DEMO>>>")
-        (goto-char 4)
-        (action-key)
-        (should (string= (expand-file-name "DEMO" hyperb:dir) buffer-file-name)))
-    (progn
+  (let ((vc-follow-symlinks nil))
+    (unwind-protect
+	(with-temp-buffer
+          (insert "<<<DEMO>>>")
+          (goto-char 4)
+          (action-key)
+          (should (string= (expand-file-name "DEMO" hyperb:dir) buffer-file-name)))
       (kill-buffer "DEMO")
       (ibtype:delete 'ibtypes::defil-path-it))))
 


### PR DESCRIPTION
## What

Add startup check to ensure hyperbole is found.

## Why

Complete the install test after install; start Emacs and check that Hyperbole is found.  This has been tested with the latest elpa-devel which verifies that elpa-devel now works after the #307 PR.

## Note

One of the tests that compare file paths had to be adjusted to ignore following symbolic links in order to work with the straight package manager. 

The straight package manager requires this change to be merged to the git repo to check that it works properly.  It has been tested manually. 