### PR TITLE
Use view-mode for fast demo

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-02-19  Mats Lidell  <matsl@gnu.org>
+
+* hypb.el (hypb:display-file-with-logo): Use view-mode for fast demo.
+
 2023-02-18  Mats Lidell  <matsl@gnu.org>
 
 * test/hmouse-drv-tests.el (hbut-defil-it): Do not follow symbolic

--- a/hypb.el
+++ b/hypb.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     6-Oct-91 at 03:42:38
-;; Last-Mod:      5-Feb-23 at 23:44:24 by Mats Lidell
+;; Last-Mod:     19-Feb-23 at 22:43:13 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -980,7 +980,7 @@ If FILE is not an absolute path, expand it relative to `hyperb:dir'."
       (skip-syntax-forward "-")
       (set-window-start (selected-window) 1)
       (set-buffer-modified-p nil)
-      (help-mode)
+      (view-mode)
       ;; On some versions of Emacs like Emacs28, need a slight delay
       ;; for file loading before searches will work properly.
       ;; Otherwise, "test/demo-tests.el" may fail.


### PR DESCRIPTION
## What

Use view-mode for fast demo

## Why

There are some problems with Help-mode that make the keyseries for shell commands to not work properly. View-mode does not give the same problem so this is a quick fix and view-mode might work as well for the user.

## Note

I noticed that we do not suggest any mode when visiting file like `DEMO` or `FAST-DEMO`. We could add a Local variables section at the end suggesting view-mode?