### PR TITLE
Test for shell commands in view mode

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2023-02-20  Mats Lidell  <matsl@gnu.org>
+
+* test/demo-tests.el (fast-demo-key-series-shell-cd-hyperb-dir-help-mode)
+    (fast-demo-key-series-shell-grep-help-mode): Add tests for acting on
+    key series in help-mode.
+
 2023-02-19  Mats Lidell  <matsl@gnu.org>
 
 * hypb.el (hypb:display-file-with-logo): Use view-mode for fast demo.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,8 +1,8 @@
 2023-02-20  Mats Lidell  <matsl@gnu.org>
 
-* test/demo-tests.el (fast-demo-key-series-shell-cd-hyperb-dir-help-mode)
-    (fast-demo-key-series-shell-grep-help-mode): Add tests for acting on
-    key series in help-mode.
+* test/demo-tests.el (fast-demo-key-series-shell-cd-hyperb-dir-view-mode)
+    (fast-demo-key-series-shell-grep-view-mode): Add tests for acting on
+    key series in view-mode.
 
 2023-02-19  Mats Lidell  <matsl@gnu.org>
 

--- a/test/demo-tests.el
+++ b/test/demo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     11-Feb-23 at 23:33:49 by Mats Lidell
+;; Last-Mod:     19-Feb-23 at 23:16:00 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -595,8 +595,8 @@ enough files with matching mode loaded."
 	(set-process-query-on-exit-flag (get-buffer-process shell-buffer-name) nil)
 	(hy-test-helpers:kill-buffer shell-buffer-name)))))
 
-(ert-deftest fast-demo-key-series-shell-cd-hyperb-dir-help-mode ()
-  "Action key executes cd shell command from buffer in `help-mode`."
+(ert-deftest fast-demo-key-series-shell-cd-hyperb-dir-view-mode ()
+  "Action key executes cd shell command from buffer in `view-mode`."
   (skip-unless (not noninteractive))
   (let* ((shell-file-name (executable-find "sh"))
          (shell-buffer-name "*shell*")
@@ -605,7 +605,7 @@ enough files with matching mode loaded."
         (with-temp-buffer
           (insert "{ M-x shell RET M-> (cd ${hyperb:dir} && echo \"PWD=$(pwd)\") RET }")
           (goto-char 5)
-          (help-mode)
+          (view-mode)
           (action-key)
           (hy-test-helpers:consume-input-events)
           (with-current-buffer shell-buffer-name
@@ -619,8 +619,8 @@ enough files with matching mode loaded."
 	(set-process-query-on-exit-flag (get-buffer-process shell-buffer-name) nil)
 	(hy-test-helpers:kill-buffer shell-buffer-name)))))
 
-(ert-deftest fast-demo-key-series-shell-grep-help-mode ()
-  "Action key executes grep shell command from buffer in `help-mode`."
+(ert-deftest fast-demo-key-series-shell-grep-view-mode ()
+  "Action key executes grep shell command from buffer in `view-mode`."
   (skip-unless (not noninteractive))
   (let* ((shell-file-name (executable-find "sh"))
          (shell-buffer-name "*shell*")
@@ -629,7 +629,7 @@ enough files with matching mode loaded."
         (with-temp-buffer
           (insert "{M-x shell RET M-> (export HYPERBOLE_DIR=${hyperb:dir} && cd $HYPERBOLE_DIR && grep -n gbut:label-list *.el) RET}")
           (goto-char 5)
-          (help-mode)
+          (view-mode)
           (action-key)
           (hy-test-helpers:consume-input-events)
           (with-current-buffer shell-buffer-name

--- a/test/demo-tests.el
+++ b/test/demo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:      6-Nov-22 at 12:23:00 by Bob Weiner
+;; Last-Mod:     11-Feb-23 at 23:33:49 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -591,6 +591,52 @@ enough files with matching mode loaded."
               (while (not (string-match-p "grep ?(1).*-" (buffer-substring-no-properties (point-min) (point-max))))
                 (accept-process-output (get-buffer-process shell-buffer-name))))
             (should (string-match-p "grep ?(1).*-" (buffer-substring-no-properties (point-min) (point-max))))))
+      (unless existing-shell-flag
+	(set-process-query-on-exit-flag (get-buffer-process shell-buffer-name) nil)
+	(hy-test-helpers:kill-buffer shell-buffer-name)))))
+
+(ert-deftest fast-demo-key-series-shell-cd-hyperb-dir-help-mode ()
+  "Action key executes cd shell command from buffer in `help-mode`."
+  (skip-unless (not noninteractive))
+  (let* ((shell-file-name (executable-find "sh"))
+         (shell-buffer-name "*shell*")
+	 (existing-shell-flag (get-buffer-process shell-buffer-name)))
+    (unwind-protect
+        (with-temp-buffer
+          (insert "{ M-x shell RET M-> (cd ${hyperb:dir} && echo \"PWD=$(pwd)\") RET }")
+          (goto-char 5)
+          (help-mode)
+          (action-key)
+          (hy-test-helpers:consume-input-events)
+          (with-current-buffer shell-buffer-name
+            (goto-char (point-min))
+            (end-of-line)
+            (with-timeout (5 (ert-fail "Test timed out"))
+              (while (not (search-forward "PWD=" nil t))
+                (accept-process-output (get-buffer-process shell-buffer-name))))
+            (should (looking-at-p (directory-file-name hyperb:dir)))))
+      (unless existing-shell-flag
+	(set-process-query-on-exit-flag (get-buffer-process shell-buffer-name) nil)
+	(hy-test-helpers:kill-buffer shell-buffer-name)))))
+
+(ert-deftest fast-demo-key-series-shell-grep-help-mode ()
+  "Action key executes grep shell command from buffer in `help-mode`."
+  (skip-unless (not noninteractive))
+  (let* ((shell-file-name (executable-find "sh"))
+         (shell-buffer-name "*shell*")
+	 (existing-shell-flag (get-buffer-process shell-buffer-name)))
+    (unwind-protect
+        (with-temp-buffer
+          (insert "{M-x shell RET M-> (export HYPERBOLE_DIR=${hyperb:dir} && cd $HYPERBOLE_DIR && grep -n gbut:label-list *.el) RET}")
+          (goto-char 5)
+          (help-mode)
+          (action-key)
+          (hy-test-helpers:consume-input-events)
+          (with-current-buffer shell-buffer-name
+            (with-timeout (5 (ert-fail "Test timed out"))
+              (while (not (string-match-p "\n.*\\.el:[0-9]+:.*defun.*gbut:label-list ()" (buffer-substring-no-properties (point-min) (point-max))))
+                (accept-process-output (get-buffer-process shell-buffer-name))))
+            (should (string-match-p "\n.*\\.el:[0-9]+:.*defun.*gbut:label-list ()" (buffer-substring-no-properties (point-min) (point-max))))))
       (unless existing-shell-flag
 	(set-process-query-on-exit-flag (get-buffer-process shell-buffer-name) nil)
 	(hy-test-helpers:kill-buffer shell-buffer-name)))))


### PR DESCRIPTION
## What

Add tests for key-series in view-mode

## Why

Fast demo has been changed to use view mode. The test defined in #305 is here changed to use view-mode. See #309 for the actual change of opening fast demo.

## Note

The changed tests only runs in interactive mode so can not be triggered here. So need to be tested in an interactive session such as using `make test-all`