### PR TITLE
Do not insert ebut data section when looking for it

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2023-04-22  Mats Lidell  <matsl@gnu.org>
+
+* test/hbut-tests.el
+    (hypb--ebut-at-p-should-not-insert-hbdata-section-in-non-file-buffers):
+    Add test to verify that no but data section is inserted.
+
 2023-04-16  Bob Weiner  <rsw@gnu.org>
 
 * hui.el (hui:link-possible-types): Fix link to outline heading where

--- a/hbdata.el
+++ b/hbdata.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Apr-91
-;; Last-Mod:     29-Mar-23 at 21:04:06 by Bob Weiner
+;; Last-Mod:      9-Apr-23 at 01:22:24 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -460,8 +460,9 @@ Return non-nil if KEY-SRC is found or created, else nil."
 	;; Button buffer has no file attached
 	(progn (if (hmail:hbdata-to-p) ;; Might change the buffer
 		   (setq buffer-read-only nil)
-		 (setq buffer-read-only nil)
-		 (insert "\n" hmail:hbdata-sep "\n"))
+		 (when create
+		   (setq buffer-read-only nil)
+		   (insert "\n" hmail:hbdata-sep "\n")))
 	       (backward-char 1)
 	       (setq rtn t))
       (setq directory (or (file-name-directory key-src) directory))

--- a/test/hbut-tests.el
+++ b/test/hbut-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-may-21 at 09:33:00
-;; Last-Mod:     23-Jul-22 at 20:04:45 by Bob Weiner
+;; Last-Mod:      9-Apr-23 at 00:55:07 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -172,6 +172,15 @@ Needed since hyperbole expands all links to absolute paths and
           (ebut:program "label" 'link-to-file-line-and-column test-file 2 3)
           (hy-test-helpers-verify-hattr-at-p :actype 'actypes::link-to-file-line-and-column :args (list test-file 2 3) :loc test-file :lbl-key "label"))
       (delete-file test-file))))
+
+(ert-deftest hypb--ebut-at-p-should-not-insert-hbdata-section-in-non-file-buffers ()
+  "Verify that ebut:at-p does not insert a hbdata section in a non file buffer."
+  (with-temp-buffer
+    (let ((button "<(unknown)>"))
+      (insert button)
+      (goto-char 3)
+      (should-not (ebut:at-p))
+      (should (string= button (buffer-string))))))
 
 ;; This file can't be byte-compiled without the `el-mock' package (because of
 ;; the use of the `with-mock' macro), which is not a dependency of Hyperbole.


### PR DESCRIPTION
## What

Do not insert ebut data section when looking for it.

## Why

A data section is inserted when executing buttons in non file buffers such as *scratch*, news summary or temp buffers. Test case for temp buffer with non existing ebut added. (Not an ideal test case since verifying that something does not happen is not the best test. The test can be applied locally before trying the fix to demonstrate that it happens.)

The fix is more of a hack. It locally check if the create flag is set, using the fact it should not be set when only looking for if button data exists!?, and if it is not set avoids the insertion. 

But maybe we should refactor this part of the code? It feels odd to me that `ebut:at-p` would even come close to code that does insertion. Also the explicit checks in there on the email and news interface looks like a code smell to me. 