### PR TITLE
Silence various byte compiler warnings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-04-23  Mats Lidell  <matsl@gnu.org>
+
+* Silence various byte compiler warnings.
+
 2023-04-22  Mats Lidell  <matsl@gnu.org>
 
 * test/hbut-tests.el

--- a/hbdata.el
+++ b/hbdata.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Apr-91
-;; Last-Mod:      9-Apr-23 at 01:22:24 by Mats Lidell
+;; Last-Mod:     26-Apr-23 at 00:11:40 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -55,6 +55,15 @@
 (require 'hversion) ;; For hyperb:microsoft-os-p
 (require 'hbmap)
 (require 'hgnus)
+
+;;; ************************************************************************
+;;; Public declarations
+;;; ************************************************************************
+
+;; Functions from abstract mail and news interface. See "hmail.el"
+(declare-function lmail:to nil)
+(declare-function rmail:to nil)
+(declare-function rmail:summ-msg-to nil)
 
 ;;; ************************************************************************
 ;;; Public functions
@@ -314,10 +323,9 @@ If the hbdata buffer is blank/empty, kill it and remove the associated file."
 (defun hbdata:delete-entry-at-point ()
   (delete-region (point) (progn (forward-line 1) (point))))
 
-(defun hbdata:ibut-instance-last (lbl-key key-src &optional directory)
+(defun hbdata:ibut-instance-last (lbl-key _key-src &optional _directory)
   "Return highest instance number for repeated implicit button label.
-1 if not repeated, nil if no instance.
-Utilize arguments LBL-KEY, KEY-SRC and optional DIRECTORY."
+1 if not repeated, nil if no instance.  Utilize argument LBL-KEY."
   (let ((key (car (ibut:label-sort-keys (ibut:label-key-match lbl-key)))))
     (cond ((null key) nil)
 	  ((string-match (concat (regexp-quote hbut:instance-sep)

--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:     10-Apr-23 at 23:39:18 by Bob Weiner
+;; Last-Mod:     23-Apr-23 at 20:12:05 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -29,6 +29,7 @@
 (declare-function www-url "hsys-www" (url))
 
 (defvar hproperty:but-face)
+(defvar hproperty:ibut-face)
 
 ;;; ************************************************************************
 ;;; Public definitions

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:     27-Mar-23 at 23:35:16 by Bob Weiner
+;; Last-Mod:     23-Apr-23 at 20:04:58 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -159,7 +159,7 @@ If the referenced location is found, return non-nil."
 			      (org-id-find id 'marker))))
 	    (hact #'link-to-org-id-marker m)))))))
 
-(defun org-id:help (hbut)
+(defun org-id:help (_hbut)
   "Copy link to kill ring of an Org roam or Org node referenced by id at point.
 If on the :ID: definition line, do nothing and return nil.
 If the referenced location is found, return non-nil."

--- a/hmail.el
+++ b/hmail.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     9-Oct-91 at 18:38:05
-;; Last-Mod:     29-Jan-23 at 02:03:03 by Bob Weiner
+;; Last-Mod:     23-Apr-23 at 20:08:38 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -59,6 +59,12 @@ Valid values are: nil, Mh-init, Rmail-init or Vm-init."
  "Major mode for editing received mail with Hyperbole buttons.")
 (defvar hmail:reader    nil
  "Major mode for reading mail with Hyperbole buttons.")
+
+;;; ************************************************************************
+;;; Public declarations
+;;; ************************************************************************
+
+(declare-function rmail:msg-widen nil)
 
 ;;; ************************************************************************
 ;;; Public functions

--- a/hmouse-drv.el
+++ b/hmouse-drv.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-90
-;; Last-Mod:      8-Apr-23 at 15:15:47 by Bob Weiner
+;; Last-Mod:     23-Apr-23 at 22:36:29 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -26,6 +26,7 @@
 ;;; Public declarations
 ;;; ************************************************************************
 (defvar start-window)
+(declare-function mouse-drag-frame nil) ;; Obsolete from Emacs 28
 
 ;;; ************************************************************************
 ;;; Public variables

--- a/hrmail.el
+++ b/hrmail.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     9-May-91 at 04:22:02
-;; Last-Mod:      5-Jun-22 at 17:59:19 by Bob Weiner
+;; Last-Mod:     23-Apr-23 at 22:16:50 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -179,7 +179,7 @@ Return t if successful, else nil."
 ;; hidden Hyperbole button data when computing message length.
 ;; FIXME: Copy&redefine like this is *evil*.  Use an advice or a hook.
 ;; We can make changes to `rmail.el' if needed.
-(advice-add 'rmail-cease-edit :override #'hrmail--rmail-cease-edit)
+(advice-add 'rmail-cease-edit :override 'hrmail--rmail-cease-edit)
 (defun hrmail--rmail-cease-edit ()
   "Finish editing message; switch back to Rmail proper."
   (interactive)
@@ -260,10 +260,10 @@ Return t if successful, else nil."
 ;; Hyperbole button data.
 ;; FIXME: Copy&redefine like this is *evil*.  Use an advice or a hook.
 ;; We can make changes to `rmail.el' if needed.
-(advice-add 'rmail-forward :override #'hrmail--rmail-forward)
+(advice-add 'rmail-forward :override 'hrmail--rmail-forward)
 (defun hrmail--rmail-forward (resend)
   "Forward the current message to another user.
-With prefix argument, \"resend\" the message instead of forwarding it;
+With prefix argument, RESEND the message instead of forwarding it;
 see the documentation of `rmail-resend'."
   (interactive "P")
   (if resend
@@ -337,9 +337,9 @@ see the documentation of `rmail-resend'."
       (progn (widen) (hproperty:but-create)
 	     (rmail-show-message))))
 (if (boundp 'rmail-get-new-mail-post-hook) ;FIXME: Doesn't exist.  XEmacs?
-    (add-hook 'rmail-get-new-mail-post-hook #'hrmail--show-msg-and-buttons)
+    (add-hook 'rmail-get-new-mail-post-hook 'hrmail--show-msg-and-buttons)
   ;; FIXME: Why change `rmail-get-new-mail' rather than `rmail-show-message'?
-  (advice-add 'rmail-get-new-mail :after #'hrmail--show-msg-and-buttons))
+  (advice-add 'rmail-get-new-mail :after 'hrmail--show-msg-and-buttons))
 
 ;; Redefine version of 'rmail-new-summary' from "rmailsum.el" to
 ;; highlight Hyperbole buttons when possible.
@@ -347,8 +347,8 @@ see the documentation of `rmail-resend'."
 (defun hrmail--highlight-buttons (&rest _)
   (if (fboundp 'hproperty:but-create) (hproperty:but-create)))
 (if (boundp 'rmail-summary-create-post-hook) ;FIXME: Doesn't exist.  XEmacs?
-    (add-hook 'rmail-summary-create-post-hook #'hrmail--highlight-buttons)
-  (advice-add 'rmail-new-summary :after #'hrmail--highlight-buttons))
+    (add-hook 'rmail-summary-create-post-hook 'hrmail--highlight-buttons)
+  (advice-add 'rmail-new-summary :after 'hrmail--highlight-buttons))
 
 ;; end not InfoDock
 )

--- a/hsys-org-roam.el
+++ b/hsys-org-roam.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    26-Feb-23 at 11:20:15 by Bob Weiner
-;; Last-Mod:     27-Feb-23 at 00:18:03 by Bob Weiner
+;; Last-Mod:     23-Apr-23 at 22:05:38 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -28,6 +28,7 @@
 ;;; ************************************************************************
 
 (defvar consult-org-roam-grep-func)
+(defvar org-roam-directory)
 (declare-function org-roam-db-autosync-mode "ext:org-roam")
 
 ;;; ************************************************************************
@@ -52,3 +53,4 @@ Prompt for the search pattern."
 	     consult-org-roam-grep-func))))
 
 (provide 'hsys-org-roam)
+;;; hsys-org-roam.el ends here

--- a/hsys-org.el
+++ b/hsys-org.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Jul-16 at 14:54:14
-;; Last-Mod:      6-Feb-23 at 09:53:31 by Mats Lidell
+;; Last-Mod:     23-Apr-23 at 22:37:07 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -77,6 +77,12 @@ with different settings of this option.  For example, a nil value makes
 		 (const :tag "t       - In Org, enable all Smart Key contexts" t))
   :initialize #'custom-initialize-default
   :group 'hyperbole-buttons)
+
+;;; ************************************************************************
+;;; Public declarations
+;;; ************************************************************************
+
+(declare-function org-show-context nil) ;; Obsolete as of Org 9.6
 
 ;;; ************************************************************************
 ;;; Public variables

--- a/hui-em-but.el
+++ b/hui-em-but.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Aug-92
-;; Last-Mod:      9-Apr-23 at 13:37:38 by Bob Weiner
+;; Last-Mod:     23-Apr-23 at 18:53:36 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -38,12 +38,13 @@
 ;;; ************************************************************************
 
 (defcustom hproperty:but-highlight-flag t
-"*Non-nil (default) applies `hproperty:but-face' highlight to labeled Hyperbole buttons."
+  "*Non-nil applies `hproperty:but-face' highlight to labeled Hyperbole buttons."
   :type 'boolean
   :group 'hyperbole-buttons)
 
 (defcustom hproperty:but-emphasize-flag nil
-  "*Non-nil means emphasize selectability of Hyperbole button labels when hovering with the mouse."
+  "*Non-nil means emphasize selectability of Hyperbole button labels.
+This is shown when hovering over the button with the mouse."
   :type 'boolean
   :group 'hyperbole-buttons)
 

--- a/hui-mouse.el
+++ b/hui-mouse.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-89
-;; Last-Mod:      1-Mar-23 at 21:45:58 by Bob Weiner
+;; Last-Mod:     23-Apr-23 at 22:31:26 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -50,6 +50,22 @@
 (require 'imenu)
 
 (eval-when-compile (require 'tar-mode))
+
+;;; ************************************************************************
+;;; Public declarations
+;;; ************************************************************************
+
+;; Functions from abstract mail and news interface. See "hmail.el"
+(declare-function lmail:delete nil)
+(declare-function lmail:undelete nil)
+(declare-function rmail:msg-prev nil)
+(declare-function lmail:goto nil)
+(declare-function lmail:expunge nil)
+(declare-function rmail:msg-next nil)
+(declare-function lmail:undelete-all nil)
+
+(declare-function helm-get-actions-from-current-source "ext:helm-core")
+(declare-function helm-get-default-action "ext:helm-core")
 
 ;;; ************************************************************************
 ;;; Public variables
@@ -1067,7 +1083,8 @@ a helm section header."
 
 (defun smart-helm-get-current-action (&optional action)
   "Return the helm default action.
-Get it from optional ACTION, the helm saved action or from the selected helm item."
+Get it from optional ACTION, the helm saved action or from the
+selected helm item."
   (helm-get-default-action (or action
                                helm-saved-action
                                (if (get-buffer helm-action-buffer)

--- a/hycontrol.el
+++ b/hycontrol.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Jun-16 at 15:35:36
-;; Last-Mod:     21-Feb-23 at 21:27:15 by Bob Weiner
+;; Last-Mod:     23-Apr-23 at 22:12:41 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -134,6 +134,12 @@
 ;; Frame face enlarging/shrinking (zooming) requires this separately available library.
 ;; Everything else works fine without it, so don't make it a required dependency.
 (require 'zoom-frm nil t)
+
+;;; ************************************************************************
+;;; Public declarations
+;;; ************************************************************************
+
+(declare-function fm-next-frame "ext:framemove")
 
 ;;; ************************************************************************
 ;;; Public variables
@@ -1732,13 +1738,13 @@ columns (rightmost) of the grid."
 ;;;###autoload
 (defun hycontrol-windows-grid-by-file-pattern (arg pattern &optional full-flag)
   "Display up to an abs(prefix ARG)-sized window grid of files matching PATTERN.
-Use absolute file paths if called interactively or optional FULL-FLAG is non-nil.
-PATTERN is a shell glob pattern.
+Use absolute file paths if called interactively or optional
+FULL-FLAG is non-nil.  PATTERN is a shell glob pattern.
 
 Left digit of ARG is the number of grid rows and the right digit
 is the number of grid columns.  If ARG is nil, 0, 1, less than
 11, greater than 99, then autosize the grid to fit the number of
-files matched by PATTERN. Otherwise, if ARG ends in a 0, adjust the
+files matched by PATTERN.  Otherwise, if ARG ends in a 0, adjust the
 grid size to the closest valid size."
   (interactive
    (list current-prefix-arg

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Jun-89 at 22:08:29
-;; Last-Mod:      8-Apr-23 at 16:13:51 by Bob Weiner
+;; Last-Mod:     23-Apr-23 at 22:20:14 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -54,6 +54,7 @@
 (defvar markdown-regex-header)
 (defvar org-roam-directory)
 (defvar org-roam-db-autosync-mode)
+(defvar hproperty:but-emphasize-flag)
 (declare-function consult-grep "ext:consult")
 (declare-function consult-ripgrep "ext:consult")
 (declare-function helm-org-rifle-files "ext:helm-org-rifle")


### PR DESCRIPTION
## What

Fix a mix of different types of byte compiler warnings.

## Why

Taking yet another stab at getting the warnings down to a low number.