### PR TITLE
Add ebut rename tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2023-04-30  Mats Lidell  <matsl@gnu.org>
+
+* test/hui-tests.el (hui--ebut-rename)
+    (hui--ebut-rename-only-button-with-that-label)
+    (hui--ebut-rename-nonumbered-label, hui--ebut-rename-numbered-label)
+  test/hbut-tests.el (hypb:program-create-ebut-in-buffer-with-same-label):
+    Tests for ebut label rename.
+
 2023-04-30  Bob Weiner  <rsw@gnu.org>
 
 * hbut.el (hbut:label-regexp): If label does not contain an instance number

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@
 * test/hui-tests.el (hui--ebut-rename)
     (hui--ebut-rename-only-button-with-that-label)
     (hui--ebut-rename-nonumbered-label, hui--ebut-rename-numbered-label)
+    (hui--ebut-rename-all-copies)
   test/hbut-tests.el (hypb:program-create-ebut-in-buffer-with-same-label):
     Tests for ebut label rename.
 

--- a/test/hbut-tests.el
+++ b/test/hbut-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-may-21 at 09:33:00
-;; Last-Mod:      9-Apr-23 at 00:55:07 by Mats Lidell
+;; Last-Mod:     30-Apr-23 at 11:04:33 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -162,6 +162,14 @@ Needed since hyperbole expands all links to absolute paths and
     (should (eq (hattr:get (hbut:at-p) 'actype) 'actypes::link-to-directory))
     (hbut-tests:should-match-tmp-folder (hattr:get (hbut:at-p) 'args))
     (should (equal (hattr:get (hbut:at-p) 'lbl-key) "label"))))
+
+(ert-deftest hypb:program-create-ebut-in-buffer-with-same-label ()
+  "Create button with same label shall add number so it is unique."
+  (with-temp-buffer
+    (ebut:program "label" 'link-to-directory "/tmp")
+    (should (equal (hattr:get (hbut:at-p) 'lbl-key) "label"))
+    (ebut:program "label" 'link-to-directory "/tmp")
+    (should (equal (hattr:get (hbut:at-p) 'lbl-key) "label:2"))))
 
 (ert-deftest hypb:program-create-link-to-file-line-and-column-but-in-file ()
   "Create button that links to file with line and column with hypb:program in buffer."

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:      7-Apr-23 at 12:19:58 by Mats Lidell
+;; Last-Mod:     30-Apr-23 at 11:15:21 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -638,6 +638,54 @@ With point on label suggest that ibut for rename."
           (with-simulated-input "RET"
 	    (should-error (hui:ibut-rename "notalabel") :type 'error)))
       (delete-file file))))
+
+(ert-deftest hui--ebut-rename ()
+  "Rename an ebut shall change the name."
+  (with-temp-buffer
+    (ebut:program "label" 'link-to-directory "/tmp")
+    (should (equal (hattr:get (hbut:at-p) 'lbl-key) "label"))
+    (hui:ebut-rename "label" "new")
+    (should (equal (hattr:get (hbut:at-p) 'lbl-key) "new"))))
+
+(ert-deftest hui--ebut-rename-only-button-with-that-label ()
+  "Rename an ebut shall change the name of only button with that label."
+  (with-temp-buffer
+    (ebut:program "label" 'link-to-directory "/tmp")
+    (goto-char (point-max))
+    (ebut:program "label2" 'link-to-directory "/tmp")
+    (goto-char (point-min))
+    (should (equal (hattr:get (hbut:at-p) 'lbl-key) "label"))
+    (hui:ebut-rename "label" "new")
+    (should (equal (hattr:get (hbut:at-p) 'lbl-key) "new"))
+    (goto-char (- (point-max) 1))
+    (should (equal (hattr:get (hbut:at-p) 'lbl-key) "label2"))))
+
+(ert-deftest hui--ebut-rename-nonumbered-label ()
+  "Rename an ebut shall rename the label with no number."
+  (skip-unless false) ;; Skip until label rename bug is fixed
+  (with-temp-buffer
+    (ebut:program "label" 'link-to-directory "/tmp")
+    (goto-char (point-max))
+    (ebut:program "label" 'link-to-directory "/tmp")
+    (goto-char (point-min))
+    (should (equal (hattr:get (hbut:at-p) 'lbl-key) "label"))
+    (hui:ebut-rename "label" "new")
+    (should (equal (hattr:get (hbut:at-p) 'lbl-key) "new"))
+    (goto-char (- (point-max) 1))
+    (should (equal (hattr:get (hbut:at-p) 'lbl-key) "label:2"))))
+
+(ert-deftest hui--ebut-rename-numbered-label ()
+  "Rename an ebut shall rename the label with number."
+  (with-temp-buffer
+    (ebut:program "label" 'link-to-directory "/tmp")
+    (goto-char (point-max))
+    (ebut:program "label" 'link-to-directory "/tmp")
+    (goto-char (- (point-max) 1))
+    (should (equal (hattr:get (hbut:at-p) 'lbl-key) "label:2"))
+    (hui:ebut-rename "label:2" "new")
+    (should (equal (hattr:get (hbut:at-p) 'lbl-key) "new"))
+    (goto-char (point-min))
+    (should (equal (hattr:get (hbut:at-p) 'lbl-key) "label"))))
 
 ;; This file can't be byte-compiled without `with-simulated-input' which
 ;; is not part of the actual dependencies, so:

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     30-Apr-23 at 11:15:21 by Mats Lidell
+;; Last-Mod:     30-Apr-23 at 16:43:06 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -662,7 +662,6 @@ With point on label suggest that ibut for rename."
 
 (ert-deftest hui--ebut-rename-nonumbered-label ()
   "Rename an ebut shall rename the label with no number."
-  (skip-unless false) ;; Skip until label rename bug is fixed
   (with-temp-buffer
     (ebut:program "label" 'link-to-directory "/tmp")
     (goto-char (point-max))

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     30-Apr-23 at 16:43:06 by Mats Lidell
+;; Last-Mod:     30-Apr-23 at 17:51:22 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -685,6 +685,19 @@ With point on label suggest that ibut for rename."
     (should (equal (hattr:get (hbut:at-p) 'lbl-key) "new"))
     (goto-char (point-min))
     (should (equal (hattr:get (hbut:at-p) 'lbl-key) "label"))))
+
+(ert-deftest hui--ebut-rename-all-copies ()
+  "Rename an ebut shall rename all copies."
+  (with-temp-buffer
+    (ebut:program "label" 'link-to-directory "/tmp")
+    (end-of-line)
+    (hui-kill-ring-save (point-min) (point))
+    (yank)
+    (goto-char (point-min))
+    (should (looking-at-p "<(label)><(label)>"))
+    (hui:ebut-rename "label" "new")
+    (goto-char (point-min))
+    (should (looking-at-p "<(new)><(new)>"))))
 
 ;; This file can't be byte-compiled without `with-simulated-input' which
 ;; is not part of the actual dependencies, so:


### PR DESCRIPTION
## What

Add ebut rename tests.

## Why

More test cases are good and we have a bug with ebut rename with ebuts that has been made unique due to autonumbering of labels. This includes a test of the bug that is disable and should be able to use when the bug has been fixed.