### PR TITLE
Call mapc with two arguments

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2023-05-14  Mats Lidell  <matsl@gnu.org>
+
+* hypb.el (hypb:oct-to-int): mapc takes two args.
+
+* test/hypb-tests.el: Add tests for hypb:oct-to-int.
+
 2023-05-14  Bob Weiner  <rsw@gnu.org>
 
 * hibtypes.el (action): Remove unneeded comma before args that triggered

--- a/hypb.el
+++ b/hypb.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     6-Oct-91 at 03:42:38
-;; Last-Mod:     14-May-23 at 10:51:09 by Bob Weiner
+;; Last-Mod:     14-May-23 at 22:54:11 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1049,7 +1049,7 @@ Without file, the banner is prepended to the current buffer."
 	    (setq dec-num (+ (* dec-num 8)
 			     (when (and (>= o ?0) (<= o ?7))
 			       (- o ?0)))))
-	  oct-str "")
+	  oct-str)
     dec-num))
 
 ;;; ************************************************************************

--- a/test/hypb-tests.el
+++ b/test/hypb-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:     5-Apr-21 at 18:53:10
-;; Last-Mod:     13-May-23 at 10:10:25 by Bob Weiner
+;; Last-Mod:     14-May-23 at 23:12:39 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -64,6 +64,15 @@
     (with-mock
       (mock (file-exists-p "/home/user/hyperbole/.git") => nil)
       (should (equal (car (hypb:installation-type)) "unknown")))))
+
+(ert-deftest hypb--oct-to-int ()
+  "Verify oct to int conversion."
+  (should (= (hypb:oct-to-int 0) 0))
+  (should (= (hypb:oct-to-int 1) 1))
+  (should (= (hypb:oct-to-int 7) 7))
+  (should (= (hypb:oct-to-int 10) 8))
+  (should (= (hypb:oct-to-int 2000) 1024))
+  (should-error (hypb:oct-to-int 8) :type 'error))
 
 ;; This file can't be byte-compiled without the `el-mock' package (because of
 ;; the use of the `with-mock' macro), which is not a dependency of Hyperbole.


### PR DESCRIPTION
## What

Call mapc with two arguments

## Why

mapc only takes two args and native compile fails hard on that. Bonus: Added a test.