### PR TITLE
Allow cross-window drags to display hbut referents

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,34 @@
+2023-05-20  Bob Weiner  <rsw@gnu.org>
+
+* hsys-org.el (hsys-org-link-at-p): Stop using (org-in-regexp org-link-any-re nil t)
+    to avoid rx warnings.  Use (eq (org-element-type (org-element-context)) 'link)
+    instead.
+
+* hibtypes.el (grep-msg): Add support for *Warning* buffer entries like:
+    Warning (comp): hbut.el:224:10: Warning: reference to free variable...
+
+* hbut.el (ibut:insert-text): Add actype:elisp-symbol call to ensure all actype symbols
+    are expanded to Hyperbole internal namespace.  This fixes some link-to-rfc tests.
+
+* hui.el (hui:ibut-create): Add name property from label to ibut.
+
+* hpath.el (hpath:find): Simplify and fix so noselect argument is always handled
+    properly and findable path is used in places instead of pathname.
+    This fixes an issue with ilinks that include a pathname where hpath:find
+    was switching the current buffer improperly.
+           (hpath:display-buffer-alist, hpath:display-where-alist): Fix
+    'other-frame-one-window' option to return found buffer by adding a 'prog1'
+    call.
+  hbut.el (hbut:funcall): Update to use '(current-buffer)' when both buffer
+    and key-src args are null.
+  hbut.el (ebut:to, ibut:to, ibut:to-name, ibut:to-text):
+    Send (current-buffer) as _buffer arg to hbut:funcall so does not try to use
+     _key-src arg and end up in the wrong buffer.
+
+* hui-mouse.el (smart-imenu-item-at-p): Fix so only returns non-nil
+    when smart-menu-item-p call is non-nil.  Stops from triggering
+    when not on an imenu item.
+
 2023-05-20  Mats Lidell  <matsl@gnu.org>
 
 * test/MANIFEST: Add missing hargs-tests.el.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,53 @@
+2023-05-19  Bob Weiner  <rsw@gnu.org>
+
+* hui.el (hui:ebut-link-directly, hui:ibut-link-directly): Display msg at
+    the end only when called interactively.
+
+* hmouse-drv.el (hkey-window-link): With prefix arg, create an ibut link
+    rather than an ebut link.
+
+* hui.el (hui:ibut-link-directly): Add.
+
+2023-05-18  Bob Weiner  <rsw@gnu.org>
+
+* man/hyperbole.texi (Keyboard Drags): Rename 'hui:link-directly'
+    to 'hui:ebut-link-directly'.
+          (ibut:insert-text): Add 'hpath:substitute-var' calls to
+    substitute variables into link paths.
+  hmouse-drv.el (hkey-window-link): Call 'hui:ebut-link-directly'.
+
+2023-05-17  Bob Weiner  <rsw@gnu.org>
+
+* hui-window.el (hmouse-alist-add-window-handlers): Move cons . operators
+    to start of line to avoid syntax highlighting errors when at eol.
+
+* hbut.el (ibut:insert-text): Fix to match to long form of actype
+  symbol name since short form is not part of obarray and so will not
+  match.  Also, add link-to-file handler with position mapping to line:col.
+          (ibut:operate): Fix to increment ibut instance number properly.
+
+2023-05-15  Bob Weiner  <rsw@gnu.org>
+
+* hbut.el (hbut:action): Fix to handle ibuts properly (no diff than ebuts).
+
+* hui-window.el (hmouse-at-item-p): Make two changes:
+    1. Return non-nil if on a Hyperbole button
+    2. Switch back to start-window rather than just the buffer; so always utilize
+       correct point.
+                (hmouse-item-to-window): Make change to long-time ebut behavior.
+    Previously, a drag from an ebut across windows links it to the new location;
+    now such a drag executes the button's action in the drag release window; ibuts
+    behave the same.
+  DEMO:
+  HY-NEWS:
+  man/hkey-help.txt: Document above change.
+
+* hsys-org.el (hsys-org-link-at-p): Simplify to use org-link-any-re and require
+    an Org version with this.
+
 2023-05-14  Bob Weiner  <rsw@gnu.org>
+
+* hui-window.el: Change context-specific commentary to refer to "man/hkey-help.txt".
 
 * hibtypes.el (action): Remove unneeded comma before args that triggered
     byte compilation error.

--- a/DEMO
+++ b/DEMO
@@ -1164,17 +1164,19 @@ with the Action Mouse Key or by using the Hyperbole menus.
 
 *** Creation via Dragging
 
-An efficient way to create an explicit button interactively is
-to use the Action Mouse Key to drag from a button source window to a
-window showing its link referent.  More specifically, you should split
-your current Emacs frame into two windows: one which contains the
-point at which you want a button to be inserted and another which
-shows the point to which you want to link, the referent.  Depress the
-Action Mouse Key at the source point for the button (anywhere but on a
-paired delimiter such as double quotes or parentheses).  Then drag to
-the other window and release the Action Mouse Key at the start point
-of the link referent.  The process becomes quite simple with a little
-practice.
+An efficient way to create an explicit button interactively is to use
+the Action Mouse Key to drag from a window where you want the button
+created (button source window) to a window showing its link referent.
+The drag must start outside of an existing Hyperbole button.
+
+More specifically, you should split your current Emacs frame into two
+windows: one which contains the point at which you want a button to be
+inserted and another which shows the point to which you want to link,
+the referent.  Depress the Action Mouse Key at the source point for
+the button (anywhere but on a paired delimiter such as double quotes
+or parentheses).  Then drag to the other window and release the Action
+Mouse Key at the start point of the link referent.  The process
+becomes quite simple with a little practice.
 
 Hyperbole uses the link referent context to determine the type of link
 to make.  If there are a few different types of links which are
@@ -1541,16 +1543,16 @@ If you want a new window where you release (so the original destination window's
 buffer stays onscreen), just drag to a window's modeline; that window will be
 split before the buffer is displayed.
 
-*** Displaying File and Buffer Items and Moving Buffers
+*** Displaying File and Buffer Items, Button Referents and Moving Buffers
 
 You can do the same thing with items in dired, buffer menu and ibuffer menu
-listing buffers rather than buffers themselves.  Drag with the Action Mouse Key
-and the selected item will be displayed in any Emacs window in which you
-release.  To display the last item you want, press the Action Key on it and it
-will display within the listing window itself.  (If you use the Treemacs file
-viewer package, item dragging works there as well).  Under the MacOS window
-manager, you can also drag outside of an Emacs frame and the item will be
-displayed in a newly created and selected frame.
+listing buffers and Hyperbole button referents.  Drag with the Action Mouse Key
+from the item and the selected item/referent will be displayed in the Emacs
+window in which you release.  To display the last item you want, press the
+Action Key on it and it will display within the listing window itself.  (If you
+use the Treemacs file viewer package, item dragging works there as well).  Under
+the MacOS window manager, you can also drag outside of an Emacs frame and the
+item will be displayed in a newly created and selected frame.
 
 So now you can rapidly put a bunch of buffers and files on your screen wherever
 you like.  Typically, a brief visual pulse is shown first at the source item and

--- a/HY-CONCEPTS.kotl
+++ b/HY-CONCEPTS.kotl
@@ -86,7 +86,7 @@
    9. "HYPB" files serve as convenient home pages for embedding Hyperbole
       buttons.  Each user has a personal button file accessed with {C-h h b
       p} and each directory can have a local button file accessed with {C-h
-      h b d}.  See "DEMO#Buton Files".
+      h b d}.  See "DEMO#Button Files".
 
   10. Global buttons are either explicit or named implicit buttons that are
       activated by choosing from a list of names, without the need to have

--- a/HY-NEWS
+++ b/HY-NEWS
@@ -401,6 +401,20 @@
 
 ** SMART (ACTION AND ASSIST) KEYS  (See "(hyperbole)Smart Keys").
 
+  *** Drag Button Referents to Specific Windows: Just as you previously could
+      drag Dired or Buffer Menu items to display in a specific window, you can
+      now do the same with Hyperbole Buttons.  Action Key drag from on a
+      Hyperbole button and release in another window where you want the
+      button's referent (or the result of its action) displayed.  If you
+      release the Action Key outside of an Emacs window, the referent is
+      displayed in a new frame.
+
+      Visual pulsing of the source line and the destination buffer highlights
+      the transfer taking place (hmouse-pulse-flag controls this).
+
+      Dragging a button to a modeline splits the window of the modeline and
+      displays the referent in the leftmost or uppermost of the split windows.
+
   *** Hyperbole Symbol Tags: Hyperbole now includes a pre-built TAGS file so
       that an Action Key press on any Hyperbole symbol jumps to its definition
       without the need for any additional support.  This also works on

--- a/HY-WHY.kotl
+++ b/HY-WHY.kotl
@@ -65,11 +65,11 @@
       with mouse drags and the Hyperbole HyControl system.  See
       "DEMO#HyControl".
 
-    12a. Drag Buffer Menu, Dired or Treemacs items to other windows to
-         display them wherever you want.  Integrate with the Ace
-         Window package to `throw' items to specific windows with
-         quick key sequences.  See "DEMO#Displaying File and Buffer
-         Items and Moving Buffers".
+    12a. Drag Button Referents, Buffer Menu, Dired or Treemacs items
+         to other windows to display them wherever you want.
+         Integrate with the Ace Window package to `throw' items to
+         specific windows with quick key sequences.  See
+         "DEMO#Displaying File and Buffer Items and Moving Buffers".
 
     12b. Drag-and-drop text regions across Emacs frames.  See
          "DEMO#Thing Selection".

--- a/TAGS
+++ b/TAGS
@@ -132,18 +132,18 @@ hbdata.el,874
 (defun hbdata:mod-time 123,4666
 (defun hbdata:referent 128,4836
 (defun hbdata:search 132,4927
-(defun hbdata:ebut-build 159,5998
-(defun hbdata:get-entry 233,9277
-(defun hbdata:ibut-instance 242,9662
-(defun hbdata:instance-next 269,10799
-(defun hbdata:ebut-instance-last 281,11174
-(defun hbdata:delete-entry 292,11576
-(defun hbdata:delete-entry-at-point 323,12722
-(defun hbdata:ibut-instance-last 326,12822
+(defun hbdata:delete-entry 159,5998
+(defun hbdata:delete-entry-at-point 190,7144
+(defun hbdata:ebut-build 193,7244
+(defun hbdata:ebut-instance-last 267,10523
+(defun hbdata:get-entry 278,10925
+(defun hbdata:ibut-instance 287,11310
+(defun hbdata:ibut-instance-last 314,12447
+(defun hbdata:instance-next 325,12909
 (defun hbdata:to-entry 337,13284
 (defun hbdata:apply-entry 360,14246
-(defun hbdata:to-hbdata-buffer 427,16432
-(defun hbdata:to-entry-buf 451,17456
+(defun hbdata:to-entry-buf 427,16432
+(defun hbdata:to-hbdata-buffer 474,18262
 (defun hbdata:write 498,19286
 
 hbmap.el,259
@@ -180,127 +180,127 @@ hbut.el,5492
 (defun    ebut:map 301,11405
 (defun    ebut:next-occurrence 311,11920
 (defun    ebut:operate 326,12599
-(defun    ebut:program 433,16743
-(defun    ebut:search 463,18146
-(defun    ebut:to 542,20810
-(defun    ebut:delimit 575,22143
-(defun    ebut:match-regexp 602,23211
-(defconst ebut:label-start 613,23651
-(defconst ebut:label-end 615,23752
-(defconst hbut:instance-sep 617,23851
-(defun    gbut:act 624,24191
-(defun    gbut:delete 639,24806
-(defun    gbut:ebut-program 644,25029
-(defun    gbut:file 664,25920
-(defun    gbut:get 668,26078
-(defun    gbut:help 680,26492
-(defun    gbut:label-list 691,26914
-(defun    gbut:label-p 695,27033
-(defun    gbut:to 710,27848
-(defun    gbut:key-list 728,28505
-(defun    gbut:ebut-key-list 732,28631
-(defun    gbut:ibut-key-list 746,29092
-(defun    hattr:attributes 759,29601
-(defun    hattr:clear 769,29906
-(defun    hattr:copy 780,30282
-(defun hattr:emacs-button-attributes 791,30672
-(defun hattr:emacs-button-is-p 804,31162
-(defun    hattr:get 811,31448
-(defun    hattr:list 815,31582
-(defun    hattr:memq 823,31859
-(defun    hattr:report 835,32290
-(defun    hattr:save 863,33316
-(defun    hattr:set 881,34168
-(defalias 'hattr:summarize hattr:summarize885,34347
-(defvar   hattr:filename887,34391
-(defconst hbut:max-len 897,34824
-(defsubst hbut:max-len 904,35065
-(defun    hbut:act 908,35215
-(defun    hbut:action 971,37918
-(defun    hbut:at-p 983,38379
-(defun    hbut:comment 996,38779
-(defvar   hbut:fill-prefix-regexps1029,39927
-(defun    hbut:fill-prefix-remove 1053,40775
-(defun    hbut:delete 1063,41167
-(defun    hbut:funcall 1078,41800
-(defun    hbut:get 1104,42863
-(defun    hbut:get-key-src 1115,43391
-(defun    hbut:is-p 1173,45678
-(defun    hbut:key 1178,45837
-(defun    hbut:to-key-src 1185,46057
-(defun    hbut:key-src-fmt 1192,46376
-(defun    hbut:key-src-set-buffer 1208,47026
-(defun    hbut:key-to-label 1230,47725
-(defun    hbut:label 1251,48409
-(defun    hbut:label-list 1267,49023
-(defun    hbut:label-p 1271,49177
-(defun    hbut:label-regexp 1284,49952
-(defun    hbut:label-to-key 1318,51179
-(defun    hbut:map 1331,51769
-(defvar   hbut:syntax-table 1387,53956
-(defun    hbut:modify-syntax 1393,54226
-(defun    hbut:outside-comment-p 1408,54853
-(defun    hbut:rename 1416,55213
-(defun    hbut:report 1427,55619
-(defun    hbut:source 1486,57553
-(defalias 'hbut:summarize hbut:summarize1501,58126
-(defun    hbut:to 1503,58167
-(defvar   hbut:current 1510,58495
-(defconst hbut:source-prefix 1513,58600
-(defun    hbut:key-list 1520,58931
-(defun    hbut:ebut-key-list 1524,59096
-(defun    hbut:ibut-key-list 1539,59621
-(defun    ibut:act 1553,60164
-(defun    ibut:alist 1564,60570
-(defun    ibut:at-p 1570,60799
-(defun    ibut:at-type-p 1614,62638
-(cl-defun ibut:create 1630,63362
-(def-edebug-spec cl-defun1754,67641
-(def-edebug-spec lambda-key-list1759,67788
-(defun    ibut:delete 1765,67960
-(defun    ibut:delimit 1792,68966
-(defun    ibut:edit 1819,70035
-(defun    ibut:get 1830,70509
-(defun    ibut:is-p 1852,71326
-(defun    ibut:label-map 1858,71581
-(defun    ibut:label-key-match 1873,72370
-(defun    ibut:label-p 1883,72750
-(defun    ibut:label-regexp 1901,73740
-(defun    ibut:label-set 1907,74031
-(defun    ibut:label-sort-keys 1929,75062
-(defun    ibut:list 1948,75692
-(defun    ibut:key 1970,76543
-(defalias 'ibut:to-key-src ibut:to-key-src1977,76781
-(defalias 'ibut:key-to-label ibut:key-to-label1978,76828
-(defalias 'ibut:label-to-key ibut:label-to-key1979,76877
-(defalias 'map-ibut map-ibut1980,76926
-(defun    ibut:map 1982,76967
-(defun    ibut:next-occurrence 1993,77460
-(defun    ibut:operate 2008,78205
-(defun    ibut:insert-text 2120,82408
-(defun    ibut:previous-occurrence 2149,83845
-(defun    ibut:program 2164,84576
-(defun    ibut:rename 2194,85979
-(defalias 'ibut:summarize ibut:summarize2214,86914
-(defun    ibut:to 2216,86955
-(defun    ibut:at-to-name-p 2263,88596
-(defun    ibut:to-name 2287,89394
-(defun    ibut:to-text 2320,90713
-(defconst ibut:label-start 2370,92760
-(defconst ibut:label-end 2372,92861
-(defvar   ibut:label-separator 2375,92961
-(defvar   ibut:label-separator-regexp 2383,93278
-(defmacro defib 2390,93617
-(def-edebug-spec defib2427,95302
-(def-edebug-spec lambda-list2432,95442
-(defalias 'ibtype:create ibtype:create2437,95560
-(defun ibtype:activate-link 2439,95595
-(defmacro defil 2451,96044
-(defmacro defal 2548,100382
-(defalias 'ibtype:create-action-link-type ibtype:create-action-link-type2604,102551
-(defalias 'ibtype:create-regexp-link-type ibtype:create-regexp-link-type2605,102602
-(defun    ibtype:def-symbol 2607,102654
-(defun    ibtype:delete 2617,103011
+(defun    ebut:program 435,16797
+(defun    ebut:search 465,18200
+(defun    ebut:to 544,20864
+(defun    ebut:delimit 577,22197
+(defun    ebut:match-regexp 604,23265
+(defconst ebut:label-start 615,23705
+(defconst ebut:label-end 617,23806
+(defconst hbut:instance-sep 619,23905
+(defun    gbut:act 626,24245
+(defun    gbut:delete 641,24860
+(defun    gbut:ebut-program 646,25083
+(defun    gbut:file 666,25974
+(defun    gbut:get 670,26132
+(defun    gbut:help 682,26546
+(defun    gbut:label-list 693,26968
+(defun    gbut:label-p 697,27087
+(defun    gbut:to 712,27902
+(defun    gbut:key-list 730,28559
+(defun    gbut:ebut-key-list 734,28685
+(defun    gbut:ibut-key-list 748,29146
+(defun    hattr:attributes 761,29655
+(defun    hattr:clear 771,29960
+(defun    hattr:copy 782,30336
+(defun hattr:emacs-button-attributes 793,30726
+(defun hattr:emacs-button-is-p 806,31216
+(defun    hattr:get 813,31502
+(defun    hattr:list 817,31636
+(defun    hattr:memq 825,31913
+(defun    hattr:report 837,32344
+(defun    hattr:save 865,33370
+(defun    hattr:set 883,34222
+(defalias 'hattr:summarize hattr:summarize887,34401
+(defvar   hattr:filename889,34445
+(defconst hbut:max-len 899,34878
+(defsubst hbut:max-len 906,35119
+(defun    hbut:act 910,35269
+(defun    hbut:action 973,37972
+(defun    hbut:at-p 983,38280
+(defun    hbut:comment 996,38680
+(defvar   hbut:fill-prefix-regexps1029,39828
+(defun    hbut:fill-prefix-remove 1053,40676
+(defun    hbut:delete 1063,41068
+(defun    hbut:funcall 1078,41701
+(defun    hbut:get 1104,42764
+(defun    hbut:get-key-src 1115,43292
+(defun    hbut:is-p 1173,45579
+(defun    hbut:key 1178,45738
+(defun    hbut:to-key-src 1185,45958
+(defun    hbut:key-src-fmt 1192,46277
+(defun    hbut:key-src-set-buffer 1208,46927
+(defun    hbut:key-to-label 1230,47626
+(defun    hbut:label 1251,48310
+(defun    hbut:label-list 1267,48924
+(defun    hbut:label-p 1271,49078
+(defun    hbut:label-regexp 1284,49853
+(defun    hbut:label-to-key 1318,51080
+(defun    hbut:map 1331,51670
+(defvar   hbut:syntax-table 1387,53857
+(defun    hbut:modify-syntax 1393,54127
+(defun    hbut:outside-comment-p 1408,54754
+(defun    hbut:rename 1416,55114
+(defun    hbut:report 1427,55520
+(defun    hbut:source 1486,57454
+(defalias 'hbut:summarize hbut:summarize1501,58027
+(defun    hbut:to 1503,58068
+(defvar   hbut:current 1510,58396
+(defconst hbut:source-prefix 1513,58501
+(defun    hbut:key-list 1520,58832
+(defun    hbut:ebut-key-list 1524,58997
+(defun    hbut:ibut-key-list 1539,59522
+(defun    ibut:act 1553,60065
+(defun    ibut:alist 1564,60471
+(defun    ibut:at-p 1570,60700
+(defun    ibut:at-type-p 1614,62539
+(cl-defun ibut:create 1630,63263
+(def-edebug-spec cl-defun1754,67542
+(def-edebug-spec lambda-key-list1759,67689
+(defun    ibut:delete 1765,67861
+(defun    ibut:delimit 1792,68867
+(defun    ibut:edit 1819,69936
+(defun    ibut:get 1830,70410
+(defun    ibut:is-p 1852,71227
+(defun    ibut:label-map 1858,71482
+(defun    ibut:label-key-match 1873,72271
+(defun    ibut:label-p 1883,72651
+(defun    ibut:label-regexp 1901,73641
+(defun    ibut:label-set 1907,73932
+(defun    ibut:label-sort-keys 1929,74963
+(defun    ibut:list 1948,75593
+(defun    ibut:key 1970,76444
+(defalias 'ibut:to-key-src ibut:to-key-src1977,76682
+(defalias 'ibut:key-to-label ibut:key-to-label1978,76729
+(defalias 'ibut:label-to-key ibut:label-to-key1979,76778
+(defalias 'map-ibut map-ibut1980,76827
+(defun    ibut:map 1982,76868
+(defun    ibut:next-occurrence 1993,77361
+(defun    ibut:operate 2008,78106
+(defun    ibut:insert-text 2130,82596
+(defun    ibut:previous-occurrence 2176,84683
+(defun    ibut:program 2191,85414
+(defun    ibut:rename 2221,86817
+(defalias 'ibut:summarize ibut:summarize2241,87752
+(defun    ibut:to 2243,87793
+(defun    ibut:at-to-name-p 2290,89434
+(defun    ibut:to-name 2314,90232
+(defun    ibut:to-text 2347,91551
+(defconst ibut:label-start 2397,93598
+(defconst ibut:label-end 2399,93699
+(defvar   ibut:label-separator 2402,93799
+(defvar   ibut:label-separator-regexp 2410,94116
+(defmacro defib 2417,94455
+(def-edebug-spec defib2454,96140
+(def-edebug-spec lambda-list2459,96280
+(defalias 'ibtype:create ibtype:create2464,96398
+(defun ibtype:activate-link 2466,96433
+(defmacro defil 2478,96882
+(defmacro defal 2575,101220
+(defalias 'ibtype:create-action-link-type ibtype:create-action-link-type2631,103389
+(defalias 'ibtype:create-regexp-link-type ibtype:create-regexp-link-type2632,103440
+(defun    ibtype:def-symbol 2634,103492
+(defun    ibtype:delete 2644,103849
 
 hgnus.el,110
 (defun Gnus-init 54,1683
@@ -452,8 +452,8 @@ hibtypes.el,1664
 (defconst action:start 1446,68600
 (defconst action:end 1449,68709
 (defib action 1458,69059
-(defun action:help 1556,73667
-(defib completion 1583,74759
+(defun action:help 1556,73666
+(defib completion 1583,74758
 
 hinit.el,145
 (defvar   hyperb:user-email 22,623
@@ -602,54 +602,54 @@ hmouse-drv.el,3999
 (defun hkey-drag 435,17168
 (defun hkey-drag-stay 467,18538
 (defun hkey-drag-item 482,19105
-(defun hkey-drag-to 515,20495
-(defun hkey-replace 547,21873
-(defun hkey-swap 557,22322
-(defun hkey-throw 586,23679
-(defun hkey-window-link 619,25149
-(defun hkey-insert-region 633,25743
-(defun hkey-buffer-to 668,27380
-(defun hkey-swap-buffers 679,27810
-(defun hmouse-click-to-drag 697,28592
-(defun hmouse-click-to-drag-stay 705,28877
-(defun hmouse-click-to-drag-item 713,29160
-(defun hmouse-click-to-drag-to 721,29448
-(defun hmouse-click-to-replace 729,29743
-(defun hmouse-click-to-swap 740,30145
-(defun hmouse-click-to-throw 748,30408
-(defun hmouse-choose-windows 755,30700
-(defun hkey-buffer-move-left 787,31951
-(defun hkey-buffer-move-right 793,32128
-(defun hkey-buffer-move-down 799,32307
-(defun hkey-buffer-move-up 805,32481
-(defun hkey-buffer-move 810,32639
-(defun mouse-drag-mode-line 852,34453
-(defun hkey-debug 882,35828
-(defun hkey-execute 903,36605
-(defun hkey-help 935,37942
-(defun hkey-assist-help 1080,43176
-(defun hkey-help-hide 1092,43608
-(defalias 'quit-window quit-window1107,44144
-(defun hkey-help-show 1118,44577
-(defun hkey-mouse-help 1168,46851
-(defun hkey-operate 1195,47868
-(defun hkey-summarize 1239,49680
-(defun hkey-toggle-debug 1260,50441
-(defun hmouse-depress-inactive-minibuffer-p 1273,50995
-(defun hmouse-vertical-line-spacing 1285,51498
-(defun hmouse-window-at-absolute-pixel-position 1297,52006
-(defun hmouse-window-coordinates 1409,57290
-(defun hmouse-key-release-buffer 1451,59171
-(defun hmouse-key-release-window 1458,59469
-(defun hmouse-key-release-args-emacs 1463,59703
-(defun hmouse-use-region-p 1493,61129
-(defun hmouse-save-region 1498,61284
-(defun hmouse-set-point 1515,62083
-(defun hmouse-set-point-at 1525,62546
-(defun hmouse-release 1546,63474
-(defun hmouse-function 1568,64532
-(defun smart-scroll-down 1597,65864
-(defun smart-scroll-up 1622,66770
+(defun hkey-drag-to 515,20501
+(defun hkey-replace 547,21879
+(defun hkey-swap 557,22328
+(defun hkey-throw 586,23685
+(defun hkey-window-link 619,25162
+(defun hkey-insert-region 647,26330
+(defun hkey-buffer-to 682,27967
+(defun hkey-swap-buffers 693,28397
+(defun hmouse-click-to-drag 711,29179
+(defun hmouse-click-to-drag-stay 719,29464
+(defun hmouse-click-to-drag-item 727,29747
+(defun hmouse-click-to-drag-to 735,30035
+(defun hmouse-click-to-replace 743,30330
+(defun hmouse-click-to-swap 754,30732
+(defun hmouse-click-to-throw 762,30995
+(defun hmouse-choose-windows 769,31287
+(defun hkey-buffer-move-left 801,32538
+(defun hkey-buffer-move-right 807,32715
+(defun hkey-buffer-move-down 813,32894
+(defun hkey-buffer-move-up 819,33068
+(defun hkey-buffer-move 824,33226
+(defun mouse-drag-mode-line 866,35040
+(defun hkey-debug 896,36415
+(defun hkey-execute 917,37192
+(defun hkey-help 949,38529
+(defun hkey-assist-help 1094,43763
+(defun hkey-help-hide 1106,44195
+(defalias 'quit-window quit-window1121,44731
+(defun hkey-help-show 1132,45164
+(defun hkey-mouse-help 1182,47438
+(defun hkey-operate 1209,48455
+(defun hkey-summarize 1253,50267
+(defun hkey-toggle-debug 1274,51028
+(defun hmouse-depress-inactive-minibuffer-p 1287,51582
+(defun hmouse-vertical-line-spacing 1299,52085
+(defun hmouse-window-at-absolute-pixel-position 1311,52593
+(defun hmouse-window-coordinates 1423,57877
+(defun hmouse-key-release-buffer 1465,59758
+(defun hmouse-key-release-window 1472,60056
+(defun hmouse-key-release-args-emacs 1477,60290
+(defun hmouse-use-region-p 1507,61716
+(defun hmouse-save-region 1512,61871
+(defun hmouse-set-point 1529,62670
+(defun hmouse-set-point-at 1539,63133
+(defun hmouse-release 1560,64061
+(defun hmouse-function 1582,65119
+(defun smart-scroll-down 1611,66451
+(defun smart-scroll-up 1636,67357
 
 hmouse-key.el,393
 (defun hmouse-check-action-key 38,1286
@@ -938,7 +938,7 @@ hsmail.el,177
 (defun message--yank-original-internal 78,3024
 (defun mail-yank-original 141,5261
 
-hsys-org.el,1410
+hsys-org.el,1408
 (defun hsys-org-meta-return-shared-p 41,1262
 (defun hsys-org-meta-return 51,1710
 (defcustom hsys-org-enable-smart-keys 59,1972
@@ -958,20 +958,20 @@ hsys-org.el,1410
 (defun hsys-org-block-start-at-p 209,8564
 (defun hsys-org-src-block-start-at-p 217,8829
 (defun hsys-org-link-at-p 224,9074
-(defun hsys-org-heading-at-p 252,10258
-(defun hsys-org-target-at-p 258,10483
-(defun hsys-org-todo-at-p 266,10860
-(defun hsys-org-radio-target-link-at-p 272,11078
-(defun hsys-org-radio-target-def-at-p 280,11466
-(defun hsys-org-radio-target-at-p 292,12001
-(defun hsys-org-internal-target-link-at-p 299,12328
-(defun hsys-org-internal-target-def-at-p 307,12728
-(defun hsys-org-internal-target-at-p 319,13258
-(defun hsys-org-face-at-p 326,13596
-(defun hsys-org-search-internal-link-p 335,13958
-(defun hsys-org-search-radio-target-link-p 358,14895
-(defun hsys-org-set-ibut-label 379,15720
-(defun hsys-org-to-next-radio-target-link 388,16050
+(defun hsys-org-heading-at-p 232,9449
+(defun hsys-org-target-at-p 238,9674
+(defun hsys-org-todo-at-p 246,10051
+(defun hsys-org-radio-target-link-at-p 252,10269
+(defun hsys-org-radio-target-def-at-p 260,10657
+(defun hsys-org-radio-target-at-p 272,11192
+(defun hsys-org-internal-target-link-at-p 279,11519
+(defun hsys-org-internal-target-def-at-p 287,11919
+(defun hsys-org-internal-target-at-p 299,12449
+(defun hsys-org-face-at-p 306,12787
+(defun hsys-org-search-internal-link-p 315,13149
+(defun hsys-org-search-radio-target-link-p 338,14086
+(defun hsys-org-set-ibut-label 359,14911
+(defun hsys-org-to-next-radio-target-link 368,15241
 
 hsys-org-roam.el,43
 (defun hsys-org-roam-consult-grep 39,1257
@@ -998,10 +998,10 @@ hsys-youtube.el,765
 (defalias 'hsys-youtube-get-url hsys-youtube-get-url134,5644
 (defun hsys-youtube-get-url:help 137,5728
 (defconst hsys-youtube-url-prefix-regexp 146,6152
-(defun hsys-youtube-end-url 153,6476
-(defun hsys-youtube-start-url 178,7633
-(defun hsys-youtube-time-in-hms 195,8423
-(defun hsys-youtube-time-in-seconds 218,9396
+(defun hsys-youtube-end-url 154,6491
+(defun hsys-youtube-start-url 180,7663
+(defun hsys-youtube-time-in-hms 198,8468
+(defun hsys-youtube-time-in-seconds 222,9456
 
 htz.el,628
 (defun htz:date-arpa 41,1467
@@ -1413,85 +1413,85 @@ hui-treemacs.el,72
 (defun smart-treemacs 62,2340
 (defun smart-treemacs-modeline 103,4032
 
-hui-window.el,3322
-(defcustom action-key-minibuffer-function 90,4297
-(defcustom assist-key-minibuffer-function 96,4553
-(defcustom action-key-modeline-function 104,4926
-(defcustom assist-key-modeline-function 109,5116
-(defun hmouse-map-modes-to-form 114,5311
-(defvar hmouse-drag-item-mode-forms125,5730
-(defcustom hmouse-pulse-flag 151,6929
-(defvar hmouse-edge-sensitivity 160,7254
-(defvar hmouse-side-sensitivity 163,7373
-(defvar hmouse-x-drag-sensitivity 167,7539
-(defvar hmouse-y-drag-sensitivity 172,7774
-(defvar hmouse-x-diagonal-sensitivity 177,7997
-(defvar hmouse-y-diagonal-sensitivity 181,8235
-(defun hmouse-alist-add-window-handlers 197,8824
-(defun hmouse-at-item-p 277,12820
-(defun hmouse-context-menu 289,13268
-(defun hmouse-context-ibuffer-menu 308,13900
-(defun hmouse-prior-active-region 327,14540
-(defun hmouse-dired-readin-hook 339,15090
-(define-minor-mode hmouse-dired-display-here-mode344,15288
-(defun hmouse-drag-region-active 364,16324
-(defun hmouse-drag-thing 374,16724
-(defun hmouse-kill-region 428,19410
-(defun hmouse-kill-and-yank-region 441,20046
-(defun hmouse-yank-region 479,21979
-(defun hmouse-drag-between-frames 501,23045
-(defun hmouse-drag-between-windows 514,23645
-(defun hmouse-press-release-same-window 526,24183
-(defun hmouse-drag-outside-all-windows 537,24705
-(defun hmouse-drag-item-to-display 544,25076
-(defun hmouse-drag-same-window 566,25938
-(defun hmouse-drag-diagonally 571,26191
-(defun hmouse-drag-horizontally 603,27696
-(defun hmouse-drag-vertically-within-emacs 631,29126
-(defun hmouse-drag-vertically 660,30622
-(defun hmouse-drag-window-side 668,30984
-(defun hmouse-read-only-toggle-key 687,31929
-(defun hmouse-vertical-action-drag 691,32110
-(defun hmouse-vertical-assist-drag 701,32482
-(defun hmouse-horizontal-action-drag 709,32813
-(defun hmouse-horizontal-assist-drag 721,33247
-(defun smart-coords-in-window-p 729,33583
-(defun smart-point-of-coords 751,34296
-(defun smart-window-of-coords 759,34541
-(defun hmouse-split-window 782,35355
-(defun hmouse-buffer-to-window 790,35616
-(defun hmouse-drag-not-allowed 801,36136
-(defun hmouse-set-buffer-and-point 807,36488
-(defun hmouse-goto-region-prev-point 812,36615
-(defun hmouse-goto-depress-point 822,37065
-(defun hmouse-goto-release-point 828,37411
-(defun hmouse-inactive-minibuffer-p 834,37756
-(defun hmouse-insert-region 842,38122
-(defun hmouse-pulse-buffer 855,38624
-(defun hmouse-pulse-line 860,38821
-(defun hmouse-pulse-region 865,38998
-(defun hmouse-item-to-window 869,39171
-(defun action-key-modeline 928,41780
-(defun assist-key-modeline 963,43496
-(defun hmouse-drag-p 1002,45357
-(defun hmouse-modeline-click 1015,45884
-(defun hmouse-emacs-modeline-event-p 1024,46280
-(defun hmouse-modeline-event-p 1038,47112
-(defun hmouse-modeline-depress 1045,47370
-(defun hmouse-modeline-release 1053,47659
-(defun hmouse-emacs-at-modeline-buffer-id-p 1060,47886
-(defun hmouse-modeline-resize-window 1071,48468
-(defun hmouse-clone-window-to-frame 1087,49066
-(defun hmouse-move-window-to-frame 1092,49243
-(defun hmouse-release-left-edge 1125,50654
-(defun hmouse-release-right-edge 1143,51472
-(defun hmouse-resize-window-side 1156,52019
-(defun hmouse-swap-buffers 1192,53411
-(defun hmouse-swap-windows 1207,54037
-(defun hmouse-x-coord 1235,55129
-(defun hmouse-y-coord 1259,55926
+hui-window.el,3314
+(defcustom action-key-minibuffer-function 39,1323
+(defcustom assist-key-minibuffer-function 45,1579
+(defcustom action-key-modeline-function 53,1952
+(defcustom assist-key-modeline-function 58,2142
+(defun hmouse-map-modes-to-form 63,2337
+(defvar hmouse-drag-item-mode-forms74,2756
+(defcustom hmouse-pulse-flag 100,3959
+(defvar hmouse-edge-sensitivity 109,4284
+(defvar hmouse-side-sensitivity 112,4403
+(defvar hmouse-x-drag-sensitivity 116,4569
+(defvar hmouse-y-drag-sensitivity 121,4804
+(defvar hmouse-x-diagonal-sensitivity 126,5027
+(defvar hmouse-y-diagonal-sensitivity 130,5265
+(defun hmouse-alist-add-window-handlers 146,5854
+(defun hmouse-at-item-p 228,9849
+(defun hmouse-context-menu 242,10362
+(defun hmouse-context-ibuffer-menu 261,10994
+(defun hmouse-prior-active-region 280,11634
+(defun hmouse-dired-readin-hook 292,12184
+(define-minor-mode hmouse-dired-display-here-mode297,12382
+(defun hmouse-drag-region-active 317,13418
+(defun hmouse-drag-thing 327,13818
+(defun hmouse-kill-region 381,16504
+(defun hmouse-kill-and-yank-region 394,17140
+(defun hmouse-yank-region 432,19073
+(defun hmouse-drag-between-frames 454,20139
+(defun hmouse-drag-between-windows 467,20739
+(defun hmouse-press-release-same-window 479,21277
+(defun hmouse-drag-outside-all-windows 490,21799
+(defun hmouse-drag-item-to-display 497,22170
+(defun hmouse-drag-same-window 519,23047
+(defun hmouse-drag-diagonally 524,23300
+(defun hmouse-drag-horizontally 556,24805
+(defun hmouse-drag-vertically-within-emacs 584,26235
+(defun hmouse-drag-vertically 613,27731
+(defun hmouse-drag-window-side 621,28093
+(defun hmouse-read-only-toggle-key 640,29038
+(defun hmouse-vertical-action-drag 644,29219
+(defun hmouse-vertical-assist-drag 654,29591
+(defun hmouse-horizontal-action-drag 662,29922
+(defun hmouse-horizontal-assist-drag 674,30356
+(defun smart-coords-in-window-p 682,30692
+(defun smart-point-of-coords 704,31405
+(defun smart-window-of-coords 712,31650
+(defun hmouse-split-window 735,32464
+(defun hmouse-buffer-to-window 743,32725
+(defun hmouse-drag-not-allowed 754,33245
+(defun hmouse-set-buffer-and-point 760,33597
+(defun hmouse-goto-region-prev-point 765,33724
+(defun hmouse-goto-depress-point 775,34174
+(defun hmouse-goto-release-point 781,34520
+(defun hmouse-inactive-minibuffer-p 787,34865
+(defun hmouse-insert-region 795,35231
+(defun hmouse-pulse-buffer 808,35737
+(defun hmouse-pulse-line 813,35934
+(defun hmouse-pulse-region 818,36111
+(defun hmouse-item-to-window 822,36284
+(defun action-key-modeline 893,39288
+(defun assist-key-modeline 928,41004
+(defun hmouse-drag-p 967,42865
+(defun hmouse-modeline-click 980,43392
+(defun hmouse-emacs-modeline-event-p 989,43788
+(defun hmouse-modeline-event-p 1003,44620
+(defun hmouse-modeline-depress 1010,44878
+(defun hmouse-modeline-release 1018,45167
+(defun hmouse-emacs-at-modeline-buffer-id-p 1025,45394
+(defun hmouse-modeline-resize-window 1036,45976
+(defun hmouse-clone-window-to-frame 1052,46574
+(defun hmouse-move-window-to-frame 1057,46751
+(defun hmouse-release-left-edge 1090,48162
+(defun hmouse-release-right-edge 1108,48980
+(defun hmouse-resize-window-side 1121,49527
+(defun hmouse-swap-buffers 1157,50919
+(defun hmouse-swap-windows 1172,51545
+(defun hmouse-x-coord 1200,52637
+(defun hmouse-y-coord 1224,53434
 
-hui.el,2235
+hui.el,2327
 (defcustom hui:hbut-delete-confirm-flag 39,1219
 (defcustom hui:ebut-prompt-for-action 44,1382
 (defun hui-copy-to-register 55,1804
@@ -1528,30 +1528,32 @@ hui.el,2235
 (defun hui:ibut-label-create 981,38956
 (defun hui:ibut-rename 1019,40831
 (defun hui:link 1053,41988
-(defun hui:link-directly 1057,42148
-(defun hui:action 1131,45122
-(defun hui:actype 1184,46855
-(defun hui:buf-writable-err 1203,47848
-(defvar hui:ignore-buffers-regexp 1223,48711
-(defun hui:ebut-delete-op 1226,48881
-(defun hui:ebut-message 1257,50134
-(defun hui:ebut-unmark 1268,50538
-(defun hui:file-find 1328,53001
-(defun hui:hbut-operate 1335,53271
-(defun hui:hbut-term-highlight 1360,54386
-(defun hui:hbut-term-unhighlight 1374,54788
-(defun hui:help-ebut-highlight 1383,55074
-(defun hui:htype-delete 1389,55322
-(defun hui:htype-help 1400,55729
-(defun hui:htype-help-current-window 1451,57497
-(defun hui:ibut-delete-op 1458,57862
-(defun hui:ibut-message 1482,58965
-(defun hui:key-dir 1493,59369
-(defun hui:key-src 1502,59717
-(defun hui:link-create 1511,60088
-(defun hui:link-possible-types 1533,61237
-(defun hui:list-remove-text-properties 1666,66605
-(defvar hui:ebut-label-prev 1676,66995
+(defun hui:ebut-link-directly 1057,42148
+(defun hui:ibut-link-directly 1128,44983
+(defun hui:action 1206,48131
+(defun hui:actype 1259,49864
+(defun hui:buf-writable-err 1278,50857
+(defvar hui:ignore-buffers-regexp 1298,51720
+(defun hui:ebut-delete-op 1301,51890
+(defun hui:ebut-message 1332,53143
+(defun hui:ebut-unmark 1343,53547
+(defun hui:file-find 1403,56010
+(defun hui:hbut-operate 1410,56280
+(defun hui:hbut-term-highlight 1435,57395
+(defun hui:hbut-term-unhighlight 1449,57797
+(defun hui:help-ebut-highlight 1458,58083
+(defun hui:htype-delete 1464,58331
+(defun hui:htype-help 1475,58738
+(defun hui:htype-help-current-window 1526,60506
+(defun hui:ibut-delete-op 1533,60871
+(defun hui:ibut-message 1557,61974
+(defun hui:key-dir 1568,62378
+(defun hui:key-src 1577,62726
+(defun hui:ebut-link-create 1586,63097
+(defun hui:ibut-link-create 1608,64251
+(defun hui:link-possible-types 1630,65405
+(defun hui:list-remove-text-properties 1763,70773
+(defvar hui:ebut-label-prev 1773,71163
 
 hvar.el,272
 (defvar var::append-list 34,1095
@@ -1669,7 +1671,7 @@ hypb.el,2566
 (defun hypb:insert-hyperbole-banner 1003,41443
 (defun hypb:locate-pathnames 1034,42861
 (defun hypb:oct-to-int 1042,43166
-(define-button-type 'hyperbole-banner)hyperbole-banner1059,43754
+(define-button-type 'hyperbole-banner)hyperbole-banner1059,43750
 
 hyperbole.el,821
 (defconst hyperbole-loading 81,3564
@@ -1945,24 +1947,24 @@ hui-register.el,214
 (cl-defmethod register-val-insert 69,2228
 
 kotl/kexport.el,796
-(defvar kexport:input-filename 40,1318
-(defvar kexport:output-filename 43,1428
-(defcustom kexport:html-description46,1539
-(defcustom kexport:html-keywords 53,1830
-(defvar kexport:kcell-reference-regexp61,2050
-(defvar kexport:kcell-partial-reference-regexp64,2140
-(defvar kexport:html-replacement-alist67,2225
-(defconst kexport:font-awesome-css-url111,4012
-(defconst kexport:font-awesome-css-include116,4238
-(defconst kexport:font-awesome-css-include-with-menus184,5064
-(defconst kexport:font-awesome-collapsible-javascript-btn318,7644
-(defun kexport:koutline 362,8880
-(defun kexport:display 376,9483
-(defun kexport:html 390,10077
-(defun kexport:princ-cell 528,15128
-(defun kexport:html-file-klink 555,16422
-(defun kexport:html-markup 569,16971
-(defun kexport:html-url 577,17234
+(defvar kexport:input-filename 40,1317
+(defvar kexport:output-filename 43,1427
+(defcustom kexport:html-description46,1538
+(defcustom kexport:html-keywords 53,1829
+(defvar kexport:kcell-reference-regexp61,2049
+(defvar kexport:kcell-partial-reference-regexp64,2139
+(defvar kexport:html-replacement-alist67,2224
+(defconst kexport:font-awesome-css-url111,4011
+(defconst kexport:font-awesome-css-include116,4237
+(defconst kexport:font-awesome-css-include-with-menus190,5127
+(defconst kexport:font-awesome-collapsible-javascript-btn325,7726
+(defun kexport:koutline 369,8962
+(defun kexport:display 383,9565
+(defun kexport:html 397,10159
+(defun kexport:princ-cell 535,15210
+(defun kexport:html-file-klink 562,16504
+(defun kexport:html-markup 576,17053
+(defun kexport:html-url 584,17316
 
 kotl/kfile.el,623
 (defconst kfile:version 28,859
@@ -2752,7 +2754,7 @@ test/kimport-tests.el,327
 (ert-deftest kimport--star-outline-two-lines-per-star-heading 99,3521
 (ert-deftest kimport--star-outline-with-siblings 116,4192
 
-test/kotl-mode-tests.el,2048
+test/kotl-mode-tests.el,2094
 (defmacro setup-kotl-mode-example-test 27,688
 (ert-deftest smart-menu-loads-kotl-example 36,1016
 (ert-deftest kotl-mode-example-loads-kotl-example 45,1356
@@ -2774,20 +2776,21 @@ test/kotl-mode-tests.el,2048
 (ert-deftest kotl-mode-kill-tree-and-reopen 314,10285
 (ert-deftest kotl-mode-kill-tree-on-empty-file-creates-new-cell 334,11005
 (ert-deftest kotl-mode-split-cell 348,11538
-(ert-deftest kotl-mode-previous-cell-from-invalid-position 363,12068
-(ert-deftest kotl-mode-backward-cell-from-invalid-position 384,12761
-(ert-deftest kotl-mode-backward-cell-from-invalid-pos-leave-point-in-valid-pos 405,13459
-(ert-deftest kotl-mode-transpose-cell 432,14494
-(ert-deftest kotl-mode-transpose-cell-with-mark 451,15102
-(ert-deftest kotl-mode-transpose-cell-past-multiple-cells 474,15863
-(ert-deftest kotl-mode-copy-kotl-file-updates-root-id-attributes 502,16801
-(ert-deftest kotl-mode-hide-cell 520,17614
-(ert-deftest kotl-mode-move-tree-forward 537,18210
-(ert-deftest kotl-mode-move-tree-backward 562,19099
-(ert-deftest kotl-mode--add-cell-set-fill-attribute 587,19981
-(ert-deftest kotl-mode-cell-help-displays-help-in-temp-buffer 599,20400
-(ert-deftest kotl-mode-cell-help-displays-help-from-root 616,21042
-(ert-deftest kotl-mode-cell-help-displays-help-for-all-cells 634,21729
+(ert-deftest kotl-mode-append-cell 363,12068
+(ert-deftest kotl-mode-previous-cell-from-invalid-position 379,12675
+(ert-deftest kotl-mode-backward-cell-from-invalid-position 400,13368
+(ert-deftest kotl-mode-backward-cell-from-invalid-pos-leave-point-in-valid-pos 421,14066
+(ert-deftest kotl-mode-transpose-cell 448,15101
+(ert-deftest kotl-mode-transpose-cell-with-mark 467,15709
+(ert-deftest kotl-mode-transpose-cell-past-multiple-cells 490,16470
+(ert-deftest kotl-mode-copy-kotl-file-updates-root-id-attributes 518,17408
+(ert-deftest kotl-mode-hide-cell 536,18221
+(ert-deftest kotl-mode-move-tree-forward 553,18817
+(ert-deftest kotl-mode-move-tree-backward 578,19706
+(ert-deftest kotl-mode--add-cell-set-fill-attribute 603,20588
+(ert-deftest kotl-mode-cell-help-displays-help-in-temp-buffer 615,21007
+(ert-deftest kotl-mode-cell-help-displays-help-from-root 632,21649
+(ert-deftest kotl-mode-cell-help-displays-help-for-all-cells 650,22336
 
 test/kotl-orgtbl-tests.el,237
 (ert-deftest kotl-orgtbl-enabled-uses-kotl-mode-delete-char-outside-of-table 27,693

--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:     14-May-23 at 01:41:33 by Bob Weiner
+;; Last-Mod:     20-May-23 at 09:58:56 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -374,9 +374,11 @@ button is found in the current buffer."
 		    (setq end (point)))
 		   ((and (hmouse-use-region-p)
 			 (if (hyperb:stack-frame
-			      '(hui:ebut-create hui:ebut-edit hui:ebut-edit-region hui:gbut-create
+			      '(hui:ebut-create hui:ebut-edit hui:ebut-edit-region
+						hui:ebut-link-create hui:gbut-create
                        				hui:gbut-edit hui:link-create ebut:program
-						hui:ibut-create hui:ibut-edit ibut:program))
+						hui:ibut-create hui:ibut-edit
+						hui:ibut-link-create ibut:program))
 			     ;; Ignore action-key-depress-prev-point
 			     (progn (setq mark (marker-position (mark-marker))
 					  start (region-beginning)
@@ -970,15 +972,13 @@ Default is the symbol hbut:current."
 
 (defun    hbut:action (hbut)
   "Return appropriate action name/function for Hyperbole button symbol HBUT."
-  (let ((categ (hattr:get hbut 'categ)) (atype) (action))
-    (if (eq categ 'explicit)
-	(progn (setq action (car (hattr:get hbut 'action))
-		     atype  (hattr:get hbut 'actype))
-	       (if (= (length (symbol-name atype)) 2)
-		   atype
-		 (or action (actype:action atype))))
-      ;; Must be an implicit button.
-      (when (functionp atype) atype))))
+  (let (atype
+	action)
+    (setq action (car (hattr:get hbut 'action))
+	  atype  (hattr:get hbut 'actype))
+    (if (= (length (symbol-name atype)) 2)
+	atype
+      (or action (actype:action atype)))))
 
 (defun    hbut:at-p ()
   "Return symbol for explicit or implicit Hyperbole button at point or nil.
@@ -2008,8 +2008,8 @@ move to the first occurrence of the button."
 (defun    ibut:operate (curr-label new-label)
   "Create an in-buffer ibutton named CURR-LABEL.  Modify if NEW-LABEL is given.
 
-If CURR-LABEL is nil, the text in the active region is used as the
-button label, if any, otherwise, an error is signaled.
+If CURR-LABEL is nil, the active region text is used as the button
+label, if any; otherwise, an error is signaled.
 
 Return instance string appended to label to form a per-buffer unique
 label; nil if label is already unique.  Signal an error when no such
@@ -2052,17 +2052,25 @@ button is found in the current buffer."
 		    ((hypb:error "(ibut:operate): No button matching: %s" curr-label)))))
 
 	  (instance-flag
+	   ;; Above flag is 't when only one instance of the label
+	   ;;
 	   ;; Add a new button recording its start and end positions
 	   (let (start end mark prev-point buf-lbl)
-	     (cond ((not curr-label)
+	     (cond ((not (and curr-label new-label))
+		    ;; No label/name to insert, just insert ibutton
+		    ;; text below
+		    )
+		   ((not curr-label)
 		    (setq start (point))
 		    (insert new-label)
 		    (setq end (point)))
 		   ((and (hmouse-use-region-p)
 			 (if (hyperb:stack-frame
-			      '(hui:ebut-create hui:ebut-edit hui:ebut-edit-region hui:gbut-create
+			      '(hui:ebut-create hui:ebut-edit hui:ebut-edit-region
+						hui:ebut-link-create hui:gbut-create
                        				hui:gbut-edit hui:link-create ebut:program
-						hui:ibut-create hui:ibut-edit ibut:program))
+						hui:ibut-create hui:ibut-edit
+						hui:ibut-link-create ibut:program))
 			     ;; Ignore action-key-depress-prev-point
 			     (progn (setq mark (marker-position (mark-marker))
 					  start (region-beginning)
@@ -2089,9 +2097,11 @@ button is found in the current buffer."
 		   (t (setq start (point))
 		      (insert curr-label)
 		      (setq end (point))))
-	     (ibut:delimit start end instance-flag)
+	     (when (and start end)
+	       (ibut:delimit start end instance-flag))
 	     (ibut:insert-text 'hbut:current)
-	     (goto-char start)))
+	     (when start
+	       (goto-char start))))
 
 	  (t (hypb:error
 	      "(ibut:operate): Operation failed.  Check button attribute permissions: %s"
@@ -2119,29 +2129,46 @@ button is found in the current buffer."
 
 (defun    ibut:insert-text (ibut)
   "Space, delimit and insert the activatable text of IBUT."
-  (insert ibut:label-separator)
-  (let ((actype (hattr:get ibut 'actype))
-	(args   (hattr:get ibut 'args)))
+  (when (hattr:get ibut 'name)
+    (insert ibut:label-separator))
+  (let* ((actype (hattr:get ibut 'actype))
+	 (args   (hattr:get ibut 'args))
+	 (arg1   (nth 0 args))
+	 (arg2   (nth 1 args))
+	 (arg3   (nth 2 args)))
     (pcase actype
-      ('kbd-key (insert "{" (car args) "}" ))
-      ((or 'link-to-directory 'link-to-file
-	   'link-to-Info-node 'link-to-Info-index-item)
-       (insert "\"" (car args) "\""))
-      ('link-to-file-line (insert (apply #'format "\"%s:%d\"" args)))
-      ('link-to-file-line-and-column (insert (apply #'format "\"%s:%d:%d\"" args)))
-      ('annot-bib (insert "[" (car args) "]"))
-      ('exec-shell-cmd (insert "\"!" (car args) "\""))
-      ('exec-window-cmd (insert "\"&" (car args) "\""))
-      ('link-to-ebut (progn (insert "<elink:" (car args))
-			    (when (cadr args) (insert ": " (cadr args)))))
-      ('link-to-ibut (progn (insert "<ilink:" (car args))
-			    (when (cadr args) (insert ": " (cadr args)))))
-      ('link-to-gbut (insert "<elink:" (car args)))
-      ('link-to-kcell (progn (insert "<") (when (car args) (insert (car args)))
-			     (when (cadr args) (insert ", " (cadr args)))))
-      ('link-to-org-id (insert (format "\"id:%s\"" (car args))))
-      ('link-to-rfc (insert (format "rfc%d" (car args))))
-      ('man-show (insert (car args)))
+      ('actypes::kbd-key (insert "{" arg1 "}" ))
+      ((or 'actypes::link-to-directory 'actypes::link-to-Info-node 'actypes::link-to-Info-index-item)
+       (insert "\"" arg1 "\""))
+      ('actypes::annot-bib (insert "[" arg1 "]"))
+      ('actypes::exec-shell-cmd (insert "\"!" arg1 "\""))
+      ('actypes::exec-window-cmd (insert "\"&" arg1 "\""))
+      ('actypes::link-to-gbut (insert "<glink:" arg1 ">"))
+      ('actypes::link-to-ebut (progn (insert "<elink:" arg1)
+				     (when arg2 (insert ": " arg2)) ">"))
+      ('actypes::link-to-ibut (progn (insert "<ilink:" arg1)
+				     (when arg2 (insert ": " arg2)) ">"))
+      ('actypes::link-to-kcell (progn (insert "<") (when arg1 (insert arg1))
+				      (when arg2 (insert ", " arg2)) ">"))
+      ('actypes::link-to-org-id (insert (format "\"id:%s\"" arg1)))
+      ('actypes::link-to-rfc (insert (format "rfc%d" arg1)))
+      ('actypes::man-show (insert arg1))
+      ('actypes::link-to-file-line (insert (format "\"%s:%d\""
+						   (hpath:substitute-var arg1) arg2)))
+      ('actypes::link-to-file-line-and-column
+       (insert (format "\"%s:%d:%d\"" (hpath:substitute-var arg1) arg2 arg3)))
+      ('actypes::link-to-file (insert
+			       (if (/= (length args) 2)
+				   ;; filename only
+				   (format "\"%s\"" (hpath:substitute-var arg1))
+				 ;; includes buffer pos that we translate to line:col
+				 (with-current-buffer (find-file-noselect arg1)
+				   (save-excursion
+				     (goto-char arg2)
+				     (format "\"%s:%d:%d\""
+					     (hpath:substitute-var arg1)
+					     (line-number-at-pos (point) t)
+					     (current-column)))))))
       ;; Generic action button type						      
       (_ (insert (format "<%s%s%s>" actype (if args " " "")
 			 (if args (hypb:format-args args) "")))))))

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:     14-May-23 at 10:57:23 by Bob Weiner
+;; Last-Mod:     20-May-23 at 16:10:20 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -988,6 +988,7 @@ in grep and shell buffers."
 	     ;; Emacs native compiler file lines
 	     (looking-at "Compiling \\(\\S-+\\)\\.\\.\\.$")
 	     (looking-at "Loading \\(\\S-+\\) (\\S-+)\\.\\.\\.$")
+ 	     (looking-at "[a-zA-Z0-9]+ ([-a-zA-Z0-9]+): \\([^:\"'`]+\\):\\([0-9]+\\):")
              ;; Grep matches (allowing for Emacs Lisp vars with : in
 	     ;; name within the pathname), Ruby, UNIX C compiler and Introl 68HC11 C compiler errors
              (looking-at "\\([^ \t\n\r\"'`]*[^ \t\n\r:\"'`0-9]\\): ?\\([1-9][0-9]*\\)[ :]")

--- a/hsys-org.el
+++ b/hsys-org.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Jul-16 at 14:54:14
-;; Last-Mod:     14-May-23 at 01:43:07 by Bob Weiner
+;; Last-Mod:     15-May-23 at 00:32:17 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -225,28 +225,8 @@ Return the (start . end) buffer positions of the region."
   "Return non-nil iff point is on an Org mode link.
 Assume caller has already checked that the current buffer is in `org-mode'
 or are looking for an Org link in another buffer type."
-  ;; If any Org test fails, just return nil
   (unless (or (smart-eolp) (smart-eobp))
-    (ignore-errors
-      (let* ((context
-	      ;; Only consider supported types, even if they are not
-	      ;; the closest one.
-	      (org-element-lineage
-	       ;; Next line can trigger an error when `looking-at' is called
-	       ;; with a `nil' value of `org-complex-heading-regexp'.
-	       (ignore-errors (org-element-context))
-	       '(clock footnote-definition footnote-reference headline
-		       inlinetask link timestamp)
-	       t))
-	     (type (org-element-type context)))
-	(or (eq type 'link)
-	    (and (boundp 'org-link-bracket-re)
-		 (org-in-regexp org-link-bracket-re))
-	    (and (boundp 'org-bracket-link-regexp)
-		 (org-in-regexp org-bracket-link-regexp))
-	    (and (boundp 'org-target-link-regexp)
-		 (not (null org-target-link-regexp))
-		 (org-in-regexp org-target-link-regexp)))))))
+    (org-in-regexp org-link-any-re nil t)))
 
 ;; Assume caller has already checked that the current buffer is in org-mode.
 (defun hsys-org-heading-at-p (&optional _)

--- a/hsys-org.el
+++ b/hsys-org.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Jul-16 at 14:54:14
-;; Last-Mod:     15-May-23 at 00:32:17 by Bob Weiner
+;; Last-Mod:     20-May-23 at 16:28:08 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -226,7 +226,7 @@ Return the (start . end) buffer positions of the region."
 Assume caller has already checked that the current buffer is in `org-mode'
 or are looking for an Org link in another buffer type."
   (unless (or (smart-eolp) (smart-eobp))
-    (org-in-regexp org-link-any-re nil t)))
+    (eq (org-element-type (org-element-context)) 'link)))
 
 ;; Assume caller has already checked that the current buffer is in org-mode.
 (defun hsys-org-heading-at-p (&optional _)
@@ -312,8 +312,9 @@ The region is (start . end) and includes any delimiters, else nil."
 	      (and (listp face-prop) (memq org-face-type face-prop)))
       org-face-type)))
 
+;; Adapted from Org code
 (defun hsys-org-search-internal-link-p (target)
-  "Search buffer start for the first Org internal link to matching <<TARGET>>.
+  "Search buffer start for the first Org internal link matching <<TARGET>>.
 White spaces are insignificant.  Return t if a link is found, else nil."
   (when (string-match "<<.+>>" target)
     (setq target (substring target 2 -2)))
@@ -335,6 +336,7 @@ White spaces are insignificant.  Return t if a link is found, else nil."
       (goto-char origin)
       nil)))
 
+;; Adapted from Org code
 (defun hsys-org-search-radio-target-link-p (target)
   "Search from point for a radio target link matching TARGET.
 White spaces are insignificant.  Return t if a target link is found, else nil."

--- a/hui-mouse.el
+++ b/hui-mouse.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-89
-;; Last-Mod:     30-Apr-23 at 15:50:57 by Bob Weiner
+;; Last-Mod:     20-May-23 at 10:52:22 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1399,8 +1399,8 @@ sets `hkey-value' to (identifier . identifier-definition-buffer-position)."
        (not (and (smart-lisp-mode-p) (smart-lisp-at-definition-p)))
        ;; Ignore Lisp loading expressions
        (not (smart-lisp-at-load-expression-p))
-       (setq hkey-value (hargs:find-tag-default)
-	     hkey-value (cons hkey-value (smart-imenu-item-p hkey-value variable-flag)))
+       (setq hkey-value (smart-imenu-item-p hkey-value variable-flag))
+       (setq hkey-value (cons (hargs:find-tag-default) hkey-value))
        (cdr hkey-value)))
 
 ;; Derived from `imenu' function in the imenu library.

--- a/hui-window.el
+++ b/hui-window.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Sep-92
-;; Last-Mod:     14-May-23 at 02:03:27 by Bob Weiner
+;; Last-Mod:     19-May-23 at 06:53:58 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -18,59 +18,8 @@
 ;;
 ;;   Handles drags in same window or across windows and modeline presses.
 ;;
-;; What drags and modeline presses do.  (Note that a `thing' is a
-;; delimited expression, such as a string, list or markup language tag pair).
-;; ======================================================================================================
-;;                                              Smart Keys
-;; Context                         Action Key                  Assist Key
-;; ======================================================================================================
-;; Drag from thing start or end    Yank thing at release       Kill thing and yank at release
-;;
-;; Drag from bottom Modeline       Reposition frame as         <- same
-;; in frame with non-nil           drag happens
-;; drag-with-mode-line param
-
-;; Drag from shared window side
-;;   or from left of scroll bar    Resize window width         <- same
-;; Modeline vertical drag          Resize window height        <- same
-;;
-;; Other Modeline drag to          Replace dest. buffer with   Swap window buffers
-;;   another window                  source buffer
-;;
-;; Drag to a Modeline from:
-;;   buffer/file menu item         Display buffer/file in      Swap window buffers
-;;                                   new window by release
-;;   buffer/file menu 1st line     Move buffer/file menu to    Swap window buffers
-;;                                   new window by release
-;;   anywhere else                 Display buffer in           Swap window buffers
-;;                                   new window by release
-;;
-;; Drag between windows from:
-;;   buffer/file menu item         Display buffer/file in      Swap window buffers
-;;                                   window of button release
-;;   buffer/file menu 1st line     Move buffer/file menu       Swap window buffers
-;;   anywhere else                 Create/edit a link button   Swap window buffers
-;;
-;; Drag outside of Emacs from:
-;;   buffer/file menu item         Display buffer/file in      Move window to a new frame
-;;                                   a new frame
-;;   Modeline or other window      Clone window to a new frame Move window to a new frame
-;;
-;; Click in modeline
-;;     Left modeline edge          Bury buffer                 Unbury bottom buffer
-;;     Right modeline edge         Info                        Smart Key Summary
-;;     Buffer ID                   Dired on buffer's dir       Next buffer
-;;                                   or on parent when a dir
-;;     Other blank area            Action Key modeline hook    Assist Key modeline hook
-;;                                   Show/Hide Buffer Menu      Popup Jump & Manage Menu
-;;
-;; Drag in a window, region active Error, not allowed          Error, not allowed
-;; Drag horizontally in a window   Split window below          Delete window
-;; Drag vertically in a window     Split window side-by-side   Delete window
-;; Drag diagonally in a window     Save window-config          Restore window-config from ring
-;;
-;; Active region exists, click     Yank region at release      Kill region and yank at release
-;;   outside of the region
+;;   The Action and Assist Key specifics per context are summarized in
+;;   "man/hkey-help.txt".
 
 ;;; Code:
 ;;; ************************************************************************
@@ -138,9 +87,9 @@ Return items with a single `major-mode' in the car, (major-mode form-to-eval)."
 						  (hmouse-pulse-buffer)
 						  (bury-buffer))))
      (treemacs-mode (if (fboundp 'treemacs-node-buffer-and-position)
-			(treemacs-node-buffer-and-position))
-		    (error "(hmouse-item-to-window): %s the treemacs package for item dragging support"
-			   (if (fboundp 'treemacs) "Update" "Install")))))
+			(treemacs-node-buffer-and-position)
+		      (error "(hmouse-item-to-window): %s the treemacs package for item dragging support"
+			     (if (fboundp 'treemacs) "Update" "Install"))))))
   "List of (major-mode lisp-form) lists.
 The car of an item must be a `major-mode' symbol.  The cadr of an item
 is a Lisp form to evaluate to get the item name at point (typically a
@@ -199,10 +148,10 @@ and release to register a diagonal drag.")
     (setq hmouse-alist
 	  (append
 	   '(
-	     ((hmouse-drag-thing) .
-	      ((hmouse-yank-region) . (hmouse-kill-and-yank-region)))
-	     ((hmouse-drag-window-side) .
-	      ((hmouse-resize-window-side) . (hmouse-resize-window-side)))
+	     ((hmouse-drag-thing)
+	      . ((hmouse-yank-region) . (hmouse-kill-and-yank-region)))
+	     ((hmouse-drag-window-side)
+	      . ((hmouse-resize-window-side) . (hmouse-resize-window-side)))
 	     ;;
 	     ;; Although Hyperbole can distinguish whether inter-window
 	     ;; drags are between frames or not, having different behavior
@@ -215,47 +164,51 @@ and release to register a diagonal drag.")
 	     ;;
 	     ;; Drag from within a window (not a Modeline) with release on a Modeline
 	     ((and (not (hmouse-modeline-depress)) (hmouse-modeline-release)
-		   (not (hmouse-modeline-click))) .
-	      ((or (hmouse-drag-item-to-display t) (hmouse-buffer-to-window t)) .
-	       (hmouse-swap-buffers)))
+		   (not (hmouse-modeline-click)))
+	      . ((or (hmouse-drag-item-to-display t) (hmouse-buffer-to-window t))
+		 . (hmouse-swap-buffers)))
 	     ;; Non-vertical Modeline drag between windows
 	     ((and (hmouse-modeline-depress) (hmouse-drag-between-windows)
-		   (not (hmouse-drag-vertically-within-emacs))) .
-		   ((hmouse-buffer-to-window) . (hmouse-swap-buffers)))
+		   (not (hmouse-drag-vertically-within-emacs)))
+	      . ((hmouse-buffer-to-window) . (hmouse-swap-buffers)))
 	     ;; Modeline drag that ends outside of Emacs
-	     ((and (hmouse-modeline-depress) (hmouse-drag-outside-all-windows)) .
-	      ((hycontrol-clone-window-to-new-frame) . (hycontrol-window-to-new-frame)))
+	     ((and (hmouse-modeline-depress) (hmouse-drag-outside-all-windows))
+	      . ((hycontrol-clone-window-to-new-frame)
+		 . (hycontrol-window-to-new-frame)))
 	     ;; Other Modeline click or drag
-	     ((hmouse-modeline-depress) .
-	      ((action-key-modeline) . (assist-key-modeline)))
-	     ((hmouse-drag-between-windows) .
-	      ;; Note that `hui:link-directly' uses any active
+	     ((hmouse-modeline-depress)
+	      . ((action-key-modeline) . (assist-key-modeline)))
+	     ((hmouse-drag-between-windows)
+	      ;; Note that `hui:ebut-link-directly' uses any active
 	      ;; region as the label of the button to create.
-	      ((or (hmouse-drag-item-to-display) (hui:link-directly)) . (hmouse-swap-buffers)))
-	     ((hmouse-drag-region-active) .
-	      ((hmouse-drag-not-allowed) . (hmouse-drag-not-allowed)))
-	     ((setq hkey-value (hmouse-drag-horizontally)) .
-	      ((hmouse-horizontal-action-drag) . (hmouse-horizontal-assist-drag)))
-	     ((hmouse-drag-vertically) .
-	      ((hmouse-vertical-action-drag) . (hmouse-vertical-assist-drag)))
-	     ((setq hkey-value (hmouse-drag-diagonally)) .
-	      ((call-interactively #'hywconfig-ring-save) .
-	       (call-interactively #'hywconfig-yank-pop)))
+	      . ((or (hmouse-drag-item-to-display) (hui:ebut-link-directly))
+		 . (hmouse-swap-buffers)))
+	     ((hmouse-drag-region-active)
+	      . ((hmouse-drag-not-allowed) . (hmouse-drag-not-allowed)))
+	     ((setq hkey-value (hmouse-drag-horizontally))
+	      . ((hmouse-horizontal-action-drag) . (hmouse-horizontal-assist-drag)))
+	     ((hmouse-drag-vertically)
+	      . ((hmouse-vertical-action-drag) . (hmouse-vertical-assist-drag)))
+	     ((setq hkey-value (hmouse-drag-diagonally))
+	      . ((call-interactively #'hywconfig-ring-save)
+		 . (call-interactively #'hywconfig-yank-pop)))
 	     ;; Window drag that ends outside of Emacs
-	     ((hmouse-drag-outside-all-windows) .
-	      ((or (hmouse-drag-item-to-display)
-		   (hycontrol-clone-window-to-new-frame)) .
-		   (hycontrol-window-to-new-frame)))
+	     ((hmouse-drag-outside-all-windows)
+	      . ((or (hmouse-drag-item-to-display)
+		     (hycontrol-clone-window-to-new-frame))
+		     . (hycontrol-window-to-new-frame)))
 	     ;; If click in the minibuffer when it is not active (blank),
 	     ;; display the Hyperbole minibuffer menu or popup the jump menu.
-	     ((hmouse-inactive-minibuffer-p) .
-	      ((funcall action-key-minibuffer-function) .
-	       (funcall assist-key-minibuffer-function)))
-	     ((and (boundp 'ivy-mode) ivy-mode (minibuffer-window-active-p (selected-window))) .
-	      ((ivy-mouse-done action-key-release-args) . (ivy-mouse-dispatching-done assist-key-release-args)))
+	     ((hmouse-inactive-minibuffer-p)
+	      . ((funcall action-key-minibuffer-function)
+		 . (funcall assist-key-minibuffer-function)))
+	     ((and (boundp 'ivy-mode) ivy-mode
+		   (minibuffer-window-active-p (selected-window)))
+	      . ((ivy-mouse-done action-key-release-args)
+		 . (ivy-mouse-dispatching-done assist-key-release-args)))
 	     ;; Handle widgets in Custom-mode
-	     ((eq major-mode 'Custom-mode) .
-	      ((smart-custom) . (smart-custom-assist)))
+	     ((eq major-mode 'Custom-mode)
+	      . ((smart-custom) . (smart-custom-assist)))
 	     ;;
 	     ;; Now since this is not a drag and if there was an active
 	     ;; region prior to when the Action or Assist Key was
@@ -263,10 +216,8 @@ and release to register a diagonal drag.")
 	     ;; `hkey-value' and the string value of the region
 	     ;; into `hkey-region' which is either yanked, or
 	     ;; killed and yanked at the current point.
-	     ((hmouse-prior-active-region) .
-	      ((hmouse-yank-region) . (hmouse-kill-and-yank-region)))
-	     ;;
-	     )
+	     ((hmouse-prior-active-region)
+	      . ((hmouse-yank-region) . (hmouse-kill-and-yank-region))))
 	   hmouse-alist))))
 (with-eval-after-load 'hui-mouse (hmouse-alist-add-window-handlers))
 
@@ -280,10 +231,12 @@ and release to register a diagonal drag.")
 		(window-buffer start-window)))
 	 (mode (when buf
 		 (buffer-local-value 'major-mode buf))))
-    (and buf (with-current-buffer buf
+    (and buf (save-window-excursion
+	       (select-window start-window)
 	       ;; Point must be on an item, not after one
-	       (not (looking-at "\\s-*$")))
-	 (memq mode (mapcar #'car hmouse-drag-item-mode-forms))
+	       (and (not (looking-at "\\s-*$"))
+		    (or (memq mode (mapcar #'car hmouse-drag-item-mode-forms))
+			(hbut:at-p))))
 	 t)))
 
 (defun hmouse-context-menu ()
@@ -541,7 +494,7 @@ If free variable `assist-flag' is non-nil, uses Assist Key."
       (and (window-live-p assist-key-depress-window) (not assist-key-release-window))
     (and (window-live-p action-key-depress-window) (not action-key-release-window))))
 
-(defun hmouse-drag-item-to-display (&optional new-window)
+(defun hmouse-drag-item-to-display (&optional new-window-flag)
   "Drag an item and release where it is to be displayed.
 Depress on a buffer name in Buffer-menu/ibuffer mode or on a
 file/directory in dired mode and release where the item is to be
@@ -549,7 +502,7 @@ displayed.
 
 If depress is on an item and release is outside of Emacs, the
 item is displayed in a new frame with a single window.  If the
-release is inside Emacs and the optional NEW-WINDOW is non-nil,
+release is inside Emacs and the optional NEW-WINDOW-FLAG is non-nil,
 the release window is sensibly split before the buffer is
 displayed.  Otherwise, the buffer is simply displayed in the
 release window.
@@ -560,7 +513,7 @@ not on an item, then nil.
 See `hmouse-drag-item-mode-forms' for how to allow for draggable
 items in other modes."
   (when (hmouse-at-item-p action-key-depress-window)
-    (hmouse-item-to-window new-window)
+    (hmouse-item-to-window new-window-flag)
     t))
 
 (defun hmouse-drag-same-window ()
@@ -843,13 +796,13 @@ Return t if such a point is saved, else nil."
   "Save a mark, then insert at point the text from `hkey-region' and indent it."
   (indent-for-tab-command)
   (push-mark nil t)
-  (if (smart-eobp) (insert "\n"))
+  (when (smart-eobp) (insert "\n"))
   (insert hkey-region)
   (indent-region (point) (mark))
   (message "") ;; Clear any indenting message.
   ;; From par-align.el library; need to think about all the
   ;; possibilities before enabling filling of this region.
-  ;; (if (fboundp 'fill-region-and-align) (fill-region-and-align (mark) (point)))
+  ;; (when (fboundp 'fill-region-and-align) (fill-region-and-align (mark) (point)))
   )
 
 (defun hmouse-pulse-buffer ()
@@ -866,14 +819,18 @@ Return t if such a point is saved, else nil."
   (when (and hmouse-pulse-flag (featurep 'pulse) (pulse-available-p))
     (pulse-momentary-highlight-region start end 'next-error)))
 
-(defun hmouse-item-to-window (&optional new-window)
-  "Display item of Action Key depress at the location of Action Key release.
-Item is a buffer or file menu item.
+(defun hmouse-item-to-window (&optional new-window-flag)
+  "Display item/action of Action Key depress at the release location.
+Return non-nil if item is displayed or action is executed; nil
+otherwise.
+
+Item is a buffer, file menu item or a Hyperbole button (execute its
+action).
 
 Release location may be an Emacs window or outside of Emacs, in
 which case a new frame with a single window is created to display
 the item.  If the release is inside Emacs and the optional
-NEW-WINDOW is non-nil, the release window is sensibly split
+NEW-WINDOW-FLAG is non-nil, the release window is sensibly split
 before the buffer is displayed.  Otherwise, the buffer is simply
 displayed in the release window.
 
@@ -884,7 +841,8 @@ item, this moves the menu buffer itself to the release location."
 	 ;; create a new frame and window.
 	 (w2 (or action-key-release-window (frame-selected-window (hycontrol-make-frame))))
 	 (w1-ref)
-	 (pos))
+	 (pos)
+	 (at-button-flag))
     (when (and (window-live-p w1) (window-live-p w2))
       (unwind-protect
 	  (progn (select-window w1)
@@ -896,14 +854,18 @@ item, this moves the menu buffer itself to the release location."
 			    (sit-for 0.05)
 			    (bury-buffer))
 		   ;; Otherwise, move the current menu item to the release window.
-		   (setq w1-ref (eval (cadr (assq major-mode hmouse-drag-item-mode-forms))))
+		   (setq w1-ref (or (eval (cadr (assq major-mode hmouse-drag-item-mode-forms)))
+				    (when (setq at-button-flag (hbut:at-p))
+				      (hbut:action 'hbut:current))))
 		   (when w1-ref (hmouse-pulse-line) (sit-for 0.05))))
 	(hypb:select-window-frame w2)
-	(when (and new-window action-key-release-window)
+	(when (and new-window-flag action-key-release-window)
 	  (hmouse-split-window))))
     (unwind-protect
 	(progn
-	  (when (and w1-ref (not (stringp w1-ref)) (sequencep w1-ref))
+	  (when (and w1-ref (not (stringp w1-ref)) (sequencep w1-ref)
+		     (buffer-live-p (seq-elt w1-ref 0))
+		     (integerp (seq-elt w1-ref 1)))
 	    ;; w1-ref is a list or vector of `buffer' and `position' elements.
 	    (setq pos (seq-elt w1-ref 1)
 		  w1-ref (seq-elt w1-ref 0)))
@@ -911,6 +873,9 @@ item, this moves the menu buffer itself to the release location."
 		 (if (not (window-live-p w1))
 		     (error "(hmouse-item-to-window): Action Mouse Key item drag must start in a live window")
 		   (error "(hmouse-item-to-window): No item to display at start of Action Mouse Key drag")))
+		(at-button-flag
+		 (let ((hpath:display-where 'this-window))
+		   (hbut:act)))
 		((buffer-live-p w1-ref) ;; Must be a buffer, not a buffer name
 		 (set-window-buffer w2 w1-ref)
 		 (set-buffer w1-ref))

--- a/hui-window.el
+++ b/hui-window.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Sep-92
-;; Last-Mod:     19-May-23 at 06:53:58 by Bob Weiner
+;; Last-Mod:     20-May-23 at 10:37:04 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -182,7 +182,7 @@ and release to register a diagonal drag.")
 	      ;; Note that `hui:ebut-link-directly' uses any active
 	      ;; region as the label of the button to create.
 	      . ((or (hmouse-drag-item-to-display) (hui:ebut-link-directly))
-		 . (hmouse-swap-buffers)))
+		 . (hui:ibut-link-directly)))
 	     ((hmouse-drag-region-active)
 	      . ((hmouse-drag-not-allowed) . (hmouse-drag-not-allowed)))
 	     ((setq hkey-value (hmouse-drag-horizontally))

--- a/hui.el
+++ b/hui.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 21:42:03
-;; Last-Mod:     14-May-23 at 02:02:53 by Bob Weiner
+;; Last-Mod:     19-May-23 at 08:07:13 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1054,8 +1054,8 @@ Signal an error when no such button is found in the current buffer."
   "Return a list of the selected window (where depressed) and the RELEASE-WINDOW."
   (list (selected-window) release-window))
 
-(defun hui:link-directly (&optional depress-window release-window)
-  "Create a link button at Action Key depress point, linked to release point.
+(defun hui:ebut-link-directly (&optional depress-window release-window)
+  "Create a link ebutton at Action Key depress point, linked to release point.
 With optional DEPRESS-WINDOW and RELEASE-WINDOW, use the points
 from those instead.  See also documentation for
 `hui:link-possible-types'."
@@ -1097,7 +1097,7 @@ from those instead.  See also documentation for
 	   (error "(link-directly): No possible link type to create"))
 	  ((= num-types 1)
 	   (setq type-and-args (hui:list-remove-text-properties (car link-types)))
-	   (hui:link-create but-edit but-window lbl-key but-loc but-dir type-and-args))
+	   (hui:ebut-link-create but-edit but-window lbl-key but-loc but-dir type-and-args))
 	  (t ;; more than 1
 	   (let ((item)
 		 type)
@@ -1119,10 +1119,85 @@ from those instead.  See also documentation for
 			      (documentation (symtable:actype-p type))))
 			   link-types)))
 		   type-and-args (hui:list-remove-text-properties type-and-args))
-	     (hui:link-create
+	     (hui:ebut-link-create
 	      but-edit but-window
 	      lbl-key but-loc but-dir type-and-args))))
-    (hui:ebut-message but-edit)))
+    (when (called-interactively-p 'interactive)
+      (hui:ebut-message but-edit))))
+
+(defun hui:ibut-link-directly (&optional depress-window release-window)
+  "Create a link ibutton at Action Key depress point, linked to release point.
+With optional DEPRESS-WINDOW and RELEASE-WINDOW, use the points
+from those instead.  See also documentation for
+`hui:link-possible-types'."
+  (interactive (hmouse-choose-windows #'hui:link))
+  (let ((but-window (or depress-window action-key-depress-window))
+	(referent-window (or release-window action-key-release-window (selected-window)))
+	but-name but-edit link-types num-types type-and-args lbl-key but-loc but-dir)
+    (select-window but-window)
+    ;; It is rarely possible that a *Warnings* buffer popup might have
+    ;; displaced the button src buffer in the depress window, so switch
+    ;; to it to be safe.
+    (when (and action-key-depress-buffer
+	       (not (eq (current-buffer) action-key-depress-buffer))
+	       (buffer-live-p action-key-depress-buffer))
+      (switch-to-buffer action-key-depress-buffer))
+    (hui:buf-writable-err (current-buffer) "link-directly")
+    (if (ibut:at-p)
+	(setq but-edit t
+	      but-loc (hattr:get 'hbut:current 'loc)
+	      but-dir (hattr:get 'hbut:current 'dir)
+	      lbl-key (hattr:get 'hbut:current 'lbl-key))
+      (setq but-loc (hui:key-src (current-buffer))
+	    but-dir (hui:key-dir (current-buffer))
+	    ;; Don't prompt to name implicit button
+	    ;; but-name (hui:hbut-label
+	    ;; 	      (cond ((hmouse-prior-active-region)
+	    ;; 		     hkey-region)
+	    ;; 		    ((use-region-p)
+	    ;; 		     (hui:hbut-label-default
+	    ;; 		      (region-beginning) (region-end))))
+	    ;; 	      "link-directly"
+	    ;; 	      "Create button named: ")
+	    ;; lbl-key (hbut:label-to-key but-name)
+	    ))
+    (select-window referent-window)
+    (setq link-types (hui:link-possible-types)
+	  num-types (length link-types))
+
+    ;; num-types is the number of possible link types to choose among
+    (cond ((= num-types 0)
+	   (error "(link-directly): No possible link type to create"))
+	  ((= num-types 1)
+	   (setq type-and-args (hui:list-remove-text-properties (car link-types)))
+	   (hui:ibut-link-create but-edit but-window lbl-key but-loc but-dir type-and-args))
+	  (t ;; more than 1
+	   (let ((item)
+		 type)
+	     (setq type-and-args
+		   (hui:menu-choose
+		    (cons '("Link to>")
+			  (mapcar
+			   (lambda (type-and-args)
+			     (setq type (car type-and-args))
+			     (list
+			      (capitalize
+			       (if (string-match
+				    "^\\(link-to\\|eval\\)-"
+				    (setq item (symbol-name type)))
+				   (setq item (substring
+					       item (match-end 0)))
+				 item))
+			      type-and-args
+			      (documentation (symtable:actype-p type))))
+			   link-types)))
+		   type-and-args (hui:list-remove-text-properties type-and-args))
+	     (hui:ibut-link-create
+	      but-edit but-window
+	      lbl-key but-loc but-dir type-and-args))))
+    (when (called-interactively-p 'interactive)
+      (hui:ibut-message but-edit))))
+
 
 ;;; ************************************************************************
 ;;; Private functions - used only within Hyperbole
@@ -1508,7 +1583,7 @@ button's source file name when the button data is stored externally."
 	  ((hpath:symlink-referent (buffer-file-name but-buf)))
 	  (t but-buf))))
 
-(defun hui:link-create (edit-flag but-window lbl-key but-loc but-dir type-and-args)
+(defun hui:ebut-link-create (edit-flag but-window lbl-key but-loc but-dir type-and-args)
   "Create or edit a new Hyperbole explicit link button.
 If EDIT-FLAG is non-nil, edit button at point in BUT-WINDOW,
 otherwise, prompt for button label and create a button.
@@ -1527,8 +1602,30 @@ arguments."
   (unless (and but-loc (or (equal (buffer-name) but-loc)
 			   (eq (current-buffer) but-loc)))
     (hbut:key-src-set-buffer but-loc))
-  (let ((label (ebut:key-to-label lbl-key)))
+  (let ((label (hbut:key-to-label lbl-key)))
     (ebut:operate label (when edit-flag label))))
+
+(defun hui:ibut-link-create (edit-flag but-window lbl-key but-loc but-dir type-and-args)
+  "Create or edit a new Hyperbole implicit link button.
+If EDIT-FLAG is non-nil, edit button at point in BUT-WINDOW,
+otherwise, prompt for button label and create a button.
+LBL-KEY is internal form of button label.  BUT-LOC is the file or buffer
+in which to create button.  BUT-DIR is the directory of BUT-LOC.
+TYPE-AND-ARGS is the action type for the button followed by any
+arguments it requires.  Any text properties are removed from string
+arguments."
+  (hattr:set 'hbut:current 'loc but-loc)
+  (hattr:set 'hbut:current 'dir but-dir)
+  (hattr:set 'hbut:current 'actype (actype:elisp-symbol (car type-and-args)))
+  (hattr:set 'hbut:current 'args (cdr type-and-args))
+  (select-window but-window)
+  ;; It is rarely possible that a *Warnings* buffer popup might have
+  ;; displaced `but-loc' in the window, so switch to it to be safe.
+  (unless (and but-loc (or (equal (buffer-name) but-loc)
+			   (eq (current-buffer) but-loc)))
+    (hbut:key-src-set-buffer but-loc))
+  (let ((label (hbut:key-to-label lbl-key)))
+    (ibut:operate label (when edit-flag label))))
 
 (defun hui:link-possible-types ()
   "Return list of possible link action types during editing of a Hyperbole button.

--- a/hui.el
+++ b/hui.el
@@ -897,6 +897,7 @@ For programmatic creation, use `ibut:program' instead."
 	(setq but-buf (current-buffer))
 	(hui:buf-writable-err but-buf "ibut-create")
 
+	(hattr:set 'hbut:current 'name lbl)
 	(hattr:set 'hbut:current 'loc (hui:key-src but-buf))
 	(hattr:set 'hbut:current 'dir (hui:key-dir but-buf))
 	(setq actype (hui:actype))

--- a/man/hkey-help.txt
+++ b/man/hkey-help.txt
@@ -41,22 +41,22 @@ Mouse-only Control
     another window                with source buffer
 
   Drag to a Modeline from:
-    buffer/file menu item       Displays buffer/file in    Swaps window buffers
-                                  new window by release
+    but/buffer/file menu item   Displays ref/buffer/file   Swaps window buffers
+                                  in new window by release
     buffer/file menu 1st line   Moves buffer/file menu to  Swaps window buffers
                                   new window by release
     anywhere else               Displays buffer in         Swaps window buffers
                                   new window by release
 
   Drag between windows from:
-    buffer/file menu item       Displays buffer/file in    Swaps window buffers
-                                  window of button release 
+    but/buffer/file menu item   Displays ref/buffer/file   Swaps window buffers
+                                  in window of button release 
     buffer/file menu 1st line   Moves buffer/file menu     Swaps window buffers
     anywhere else               Creates/modifies a link    Swaps window buffers
 
   Drag outside of Emacs from:
-    buffer/file menu item       Displays buffer/file in    Moves window to new frame
-                                  a new frame
+    but/buffer/file menu item   Displays ref/buffer/file   Moves window to new frame
+                                  in a new frame
     Modeline or other window    Clones window to new frame Moves window to new frame
 
   Modeline Click

--- a/man/hyperbole.texi
+++ b/man/hyperbole.texi
@@ -7,7 +7,7 @@
 @c Author:       Bob Weiner
 @c
 @c Orig-Date:     6-Nov-91 at 11:18:03
-@c Last-Mod:     13-May-23 at 22:34:55 by Bob Weiner
+@c Last-Mod:     19-May-23 at 06:49:37 by Bob Weiner
 
 @c %**start of header (This is for running Texinfo on a region.)
 @setfilename hyperbole.info
@@ -156,7 +156,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.</P>
 
 <PRE>
 Edition 8.0.1pre
-Printed May 13, 2023.
+Printed May 16, 2023.
 
   Published by the Free Software Foundation, Inc.
   Author:    Bob Weiner
@@ -198,7 +198,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
 @example
 Edition 8.0.1pre
-May 13, 2023
+May 16, 2023
 
   Published by the Free Software Foundation, Inc.
   Author:    Bob Weiner
@@ -1789,10 +1789,12 @@ replace the selected (current) window's buffer with that of <window>
 @item M-o t <window>
 throw region, listing item at point, or current buffer to <window>
 
+@findex hui:ebut-link-directly
 @item M-o w <window>
 window link, create a new explicit button in the selected (current)
-window, linking to point in the referent <window>, with the link type
-determined by the referent context via @code{hui:link-directly}.
+window, linking to point in the referent <window>.
+@code{hui:ebut-link-directly} determines the link type by using the
+referent context.
 @end table
 
 @c -------


### PR DESCRIPTION
With Ace Window bound to M-o, {C-u M-o w <window>} inserts a ilink within the current buffer to the referent <window> file..