### PR TITLE
Use hypb prefix

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2023-05-28  Mats Lidell  <matsl@gnu.org>
+
+* hibtypes.el (hypb-mail-address-tld-regexp)
+    (hypb-mail-address-regexp): Use hypb prefix.
+
 2023-05-27  Bob Weiner  <rsw@gnu.org>
 
 * kotl/kotl-mode.el (kotl-mode:setup-keymap): Create this function instead

--- a/hib-social.el
+++ b/hib-social.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    20-Jul-16 at 22:41:34
-;; Last-Mod:     24-Jul-22 at 10:08:17 by Mats Lidell
+;; Last-Mod:     28-May-23 at 10:06:20 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -302,9 +302,9 @@ listed in `hibtypes-social-inhibit-modes'."
 					      (mapcar #'car hibtypes-social-hashtag-alist))))))
 		    ;; Heuristic to ensure this is not an email address
 		    (save-match-data
-		      (not (and (looking-at mail-address-regexp)
+		      (not (and (looking-at hypb-mail-address-regexp)
 				(let ((case-fold-search t))
-				  (string-match mail-address-tld-regexp
+				  (string-match hypb-mail-address-tld-regexp
 						(match-string-no-properties 1)))))))))
 
     (save-match-data

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:     20-May-23 at 16:10:20 by Bob Weiner
+;; Last-Mod:     28-May-23 at 10:45:16 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -46,7 +46,7 @@
 ;;; Public variables
 ;;; ************************************************************************
 
-(defconst mail-address-tld-regexp
+(defconst hypb-mail-address-tld-regexp
   (format "\\.%s\\'"
           (regexp-opt
            '("aero" "arpa" "asia" "biz" "cat" "com" "coop" "edu" "gov" "info"
@@ -74,7 +74,7 @@
            t))
   "Regular expression of most common Internet top level domain names.")
 
-(defconst mail-address-regexp
+(defconst hypb-mail-address-regexp
   "\\([_a-zA-Z0-9][-_a-zA-Z0-9.!@+%]*@[-_a-zA-Z0-9.!@+%]+\\.[a-zA-Z0-9][-_a-zA-Z0-9]+\\)\\($\\|[^a-zA-Z0-9@%]\\)"
   "Regexp with group 1 matching an Internet email address.")
 
@@ -314,10 +314,10 @@ display options."
   (let ((case-fold-search t))
     (save-excursion
       (skip-chars-backward "^ \t\n\r\f\"\'(){}[];:<>|")
-      (and (or (looking-at mail-address-regexp)
-               (looking-at (concat "mailto:" mail-address-regexp)))
+      (and (or (looking-at hypb-mail-address-regexp)
+               (looking-at (concat "mailto:" hypb-mail-address-regexp)))
            (save-match-data
-             (string-match mail-address-tld-regexp (match-string-no-properties 1)))
+             (string-match hypb-mail-address-tld-regexp (match-string-no-properties 1)))
            (match-string-no-properties 1)))))
 
 (defib mail-address ()

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Jun-89 at 22:08:29
-;; Last-Mod:     23-Apr-23 at 22:20:14 by Mats Lidell
+;; Last-Mod:     28-May-23 at 10:06:20 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -734,7 +734,7 @@ Return t if entry is killed, nil otherwise."
   (interactive)
   (let ((opoint (point)) button)
     (skip-chars-backward "^ \t\n\r<>")
-    (if (and (re-search-forward mail-address-regexp nil t)
+    (if (and (re-search-forward hypb-mail-address-regexp nil t)
 	     (goto-char (match-beginning 1))
 	     (setq button (ibut:at-p)))
 	(hui:hbut-act button)

--- a/kotl/kexport.el
+++ b/kotl/kexport.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    26-Feb-98
-;; Last-Mod:     14-May-23 at 10:29:11 by Bob Weiner
+;; Last-Mod:     28-May-23 at 10:06:20 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -84,7 +84,7 @@ If nil, use no keywords."
     'kexport:html-url)
    ;;
    ;; make mail addresses into hyperbuttons
-   (cons mail-address-regexp "<a href=\"mailto:\\1\"><i>\\1</i></a>\\2")
+   (cons hypb-mail-address-regexp "<a href=\"mailto:\\1\"><i>\\1</i></a>\\2")
    ;;
    ;; make klinks into hyperlinks
    (cons (concat "&lt;\\s-*@\\s-*" kexport:kcell-reference-regexp


### PR DESCRIPTION
## What

Use hypb prefix for vars with current mail prefix.

## Why

Global vars should use hyperbole prefix. Suggested by Stefan. See [scratch patch](https://github.com/rswgnu/hyperbole/pull/322#discussion_r1186846494)