### PR TITLE
Use invisible-p

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2023-05-28  Mats Lidell  <matsl@gnu.org>
+
+* kotl/kview.el (kview:char-invisible-p, kview:char-visible-p): Use
+    invisible-p.
+
 2023-05-27  Bob Weiner  <rsw@gnu.org>
 
 * kotl/kotl-mode.el (kotl-mode:setup-keymap): Create this function instead

--- a/kotl/kview.el
+++ b/kotl/kview.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:      5-Feb-23 at 22:36:46 by Mats Lidell
+;; Last-Mod:     28-May-23 at 11:21:42 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -630,20 +630,12 @@ level."
 ;;;###autoload
 (defun kview:char-invisible-p (&optional pos)
   "Return t if the character after point is invisible/hidden, else nil."
-  (or pos (setq pos (point)))
-  (when (or (kproperty:get pos 'invisible)
-	    (delq nil (mapcar (lambda (o) (overlay-get o 'invisible))
-			      (overlays-at (or pos (point))))))
-    t))
+  (invisible-p (or pos (point))))
 
 ;;;###autoload
 (defun kview:char-visible-p (&optional pos)
   "Return t if the character after point is visible, else nil."
-  (unless pos
-    (setq pos (point)))
-  (and (not (kproperty:get pos 'invisible))
-       (not (delq nil (mapcar (lambda (o) (overlay-get o 'invisible))
-			      (overlays-at (or pos (point))))))))
+  (not (invisible-p (or pos (point)))))
 
 (defun kview:create (buffer-name
 			 &optional id-counter top-cell-attributes


### PR DESCRIPTION
## What

Use invisible-p

## Why

Suggested by Stefan. See the scratch [PR](https://github.com/rswgnu/hyperbole/pull/322#discussion_r1186848934)

## Note

Not sure about how overlays comes in here and if this change is too aggressive. Does the check for overlay invisible need to be kept? `inivisible-p` seems to be using text properties only. Here is the Emacs [src for invisible-p](https://git.savannah.gnu.org/cgit/emacs.git/tree/src/xdisp.c#n28873) But I'm not sure how we use overlays in this context if it matters. If that is the case then maybe `get-char-property` could be an alternative since it checks both overlays and char properties!? 

Don't think we have much unit tests to stand on here I'm afraid.

If you can advice on a good use case that uses overlays and not character properties or a mix of these I could create test cases.
