### PR TITLE
Delete file and buffer to clean up tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2023-05-28  Mats Lidell  <matsl@gnu.org>
 
+* test/hy-test-helpers.el (hy-delete-file-and-buffer): Add helper that
+    removes file and buffer even if in modified state.
+
 * hibtypes.el (hypb-mail-address-tld-regexp)
     (hypb-mail-address-regexp): Use hypb prefix.
 

--- a/test/demo-tests.el
+++ b/test/demo-tests.el
@@ -490,7 +490,7 @@ enough files with matching mode loaded."
       (hy-test-helpers:kill-buffer buff)
       (global-set-key (kbd "C-x C-b") old)
       (hy-test-helpers:kill-buffer (get-file-buffer tmp))
-      (delete-file tmp))))
+      (hy-delete-file-and-buffer tmp))))
 
 (ert-deftest fast-demo-key-series-keep-lines-slash ()
   "Action key opens Ibuffer and keep lines that contains a slash."

--- a/test/hargs-tests.el
+++ b/test/hargs-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    04-Feb-22 at 23:00:00
-;; Last-Mod:     04-Feb-22 at 23:00:00 by Mats Lidell
+;; Last-Mod:     28-May-23 at 23:14:18 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -21,6 +21,7 @@
 (require 'ert)
 (require 'with-simulated-input)
 (require 'hargs)
+(require 'hy-test-helpers "test/hy-test-helpers")
 
 (ert-deftest hargs-get-verify-extension-characters ()
   "Verify hyperbole extension characters are indentified."
@@ -39,7 +40,7 @@
           (with-simulated-input "xyz RET"
             (should (string= (hargs:get "+X: ") "(dir)xyz")))
           (should-error (hargs:get "+A: ") :type 'error))
-      (delete-file file))))
+      (hy-delete-file-and-buffer file))))
 
 (ert-deftest hargs-get-verify-extension-characters-+K ()
   "Verify hyperbole extension character +K is indentified."

--- a/test/hbut-tests.el
+++ b/test/hbut-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-may-21 at 09:33:00
-;; Last-Mod:     30-Apr-23 at 11:04:33 by Mats Lidell
+;; Last-Mod:     28-May-23 at 23:14:35 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -23,6 +23,7 @@
 (require 'hactypes)
 (require 'hpath)
 (require 'el-mock)
+(require 'hy-test-helpers "test/hy-test-helpers")
 
 (defun hbut-tests:should-match-tmp-folder (tmp)
   "Check that TMP matches either a list of a single element of \"/tmp\" or \"private/tmp\".
@@ -41,7 +42,7 @@ Needed since hyperbole expands all links to absolute paths and
           (hbut-tests:should-match-tmp-folder (hattr:get (hbut:at-p) 'args))
           (should (equal (hattr:get (hbut:at-p) 'loc) file))
           (should (equal (hattr:get (hbut:at-p) 'lbl-key) "label")))
-      (delete-file file))))
+      (hy-delete-file-and-buffer file))))
 
 (ert-deftest ebut-program-link-to-directory-2 ()
   "Programatically create ebut with link-to-directory using `temporary-file-directory`."
@@ -51,7 +52,7 @@ Needed since hyperbole expands all links to absolute paths and
           (find-file file)
           (ebut:program "label" 'link-to-directory temporary-file-directory)
           (hy-test-helpers-verify-hattr-at-p :actype 'actypes::link-to-directory :args (list temporary-file-directory) :loc file :lbl-key "label"))
-      (delete-file file))))
+      (hy-delete-file-and-buffer file))))
 
 (ert-deftest ebut-program-shell-cmd ()
   "Programatically create ebut running shell command."
@@ -61,7 +62,7 @@ Needed since hyperbole expands all links to absolute paths and
           (find-file file)
           (ebut:program "label" 'exec-shell-cmd "ls /tmp")
           (hy-test-helpers-verify-hattr-at-p :actype 'actypes::exec-shell-cmd :args '("ls /tmp") :loc file :lbl-key "label"))
-      (delete-file file))))
+      (hy-delete-file-and-buffer file))))
 
 (ert-deftest ebut-delete-removes-ebut-and-returns-button-data ()
   "Remove an ebut."
@@ -74,7 +75,7 @@ Needed since hyperbole expands all links to absolute paths and
           (let ((success-flag (hui:hbut-delete)))
             (should-not (hbut:at-p))
             (should (eq success-flag t))))
-      (delete-file file))))
+      (hy-delete-file-and-buffer file))))
 
 (ert-deftest gbut-program-calls-ebut-program ()
   "Programatically create gbut calls ebut:program."
@@ -85,7 +86,7 @@ Needed since hyperbole expands all links to absolute paths and
           (mock (hpath:find-noselect (expand-file-name hbmap:filename hbmap:dir-user)) => test-buffer)
           (mock (ebut:program "label" 'link-to-directory "/tmp") => t)
           (gbut:ebut-program "label" 'link-to-directory "/tmp"))
-      (delete-file test-file))))
+      (hy-delete-file-and-buffer test-file))))
 
 (ert-deftest gbut-program-link-to-directory ()
   "Programatically create gbut with link-to-directory."
@@ -101,7 +102,7 @@ Needed since hyperbole expands all links to absolute paths and
             (hbut-tests:should-match-tmp-folder (hattr:get (hbut:at-p) 'args))
             (should (equal (hattr:get (hbut:at-p) 'loc) test-file))
             (should (equal (hattr:get (hbut:at-p) 'lbl-key) "global"))))
-      (delete-file test-file))))
+      (hy-delete-file-and-buffer test-file))))
 
 (ert-deftest gbut-program-eval-elisp ()
   "Programatically create gbut with eval-elisp."
@@ -114,7 +115,7 @@ Needed since hyperbole expands all links to absolute paths and
             (gbut:ebut-program "global" 'eval-elisp '()))
 	  (with-current-buffer test-buffer
             (hy-test-helpers-verify-hattr-at-p :actype 'actypes::eval-elisp :args  '(()) :loc test-file :lbl-key "global")))
-      (delete-file test-file))))
+      (hy-delete-file-and-buffer test-file))))
 
 (ert-deftest gbut-program-link-to-file ()
   "Programatically create gbut with eval-elisp."
@@ -127,7 +128,7 @@ Needed since hyperbole expands all links to absolute paths and
             (gbut:ebut-program "global" 'link-to-file test-file))
 	  (with-current-buffer test-buffer
             (hy-test-helpers-verify-hattr-at-p :actype 'actypes::link-to-file :args (list test-file) :loc test-file :lbl-key "global")))
-      (delete-file test-file))))
+      (hy-delete-file-and-buffer test-file))))
 
 (ert-deftest gbut-program-link-to-file-line ()
   "Programatically create gbut with eval-elisp."
@@ -140,7 +141,7 @@ Needed since hyperbole expands all links to absolute paths and
             (gbut:ebut-program "global" 'link-to-file-line test-file 10))
 	  (with-current-buffer test-buffer
             (hy-test-helpers-verify-hattr-at-p :actype 'actypes::link-to-file-line :args (list test-file 10) :loc test-file :lbl-key "global")))
-      (delete-file test-file))))
+      (hy-delete-file-and-buffer test-file))))
 
 (ert-deftest gbut-program-link-to-file-line-and-column ()
   "Programatically create gbut with eval-elisp."
@@ -153,7 +154,7 @@ Needed since hyperbole expands all links to absolute paths and
             (gbut:ebut-program "global" 'link-to-file-line-and-column test-file 10 20))
 	  (with-current-buffer test-buffer
             (hy-test-helpers-verify-hattr-at-p :actype 'actypes::link-to-file-line-and-column :args (list test-file 10 20) :loc test-file :lbl-key"global")))
-      (delete-file test-file))))
+      (hy-delete-file-and-buffer test-file))))
 
 (ert-deftest hypb:program-create-ebut-in-buffer ()
   "Create button with hypb:program in buffer."
@@ -179,7 +180,7 @@ Needed since hyperbole expands all links to absolute paths and
           (find-file test-file)
           (ebut:program "label" 'link-to-file-line-and-column test-file 2 3)
           (hy-test-helpers-verify-hattr-at-p :actype 'actypes::link-to-file-line-and-column :args (list test-file 2 3) :loc test-file :lbl-key "label"))
-      (delete-file test-file))))
+      (hy-delete-file-and-buffer test-file))))
 
 (ert-deftest hypb--ebut-at-p-should-not-insert-hbdata-section-in-non-file-buffers ()
   "Verify that ebut:at-p does not insert a hbdata section in a non file buffer."

--- a/test/hmouse-drv-tests.el
+++ b/test/hmouse-drv-tests.el
@@ -520,7 +520,7 @@ Regression: Looked up path name '-narrow'."
           (with-mock
             (mock (smart-lisp-find-tag nil nil) => t)
             (action-key)))
-      (delete-file el-file))))
+      (hy-delete-file-and-buffer el-file))))
 
 ;; This file can't be byte-compiled without the `el-mock' and
 ;; `with-simulated-input' package (because of the use of the

--- a/test/hpath-tests.el
+++ b/test/hpath-tests.el
@@ -272,7 +272,7 @@
                   (goto-char 3)
                   (should (string= (hpath:at-p) fn))
                   (should (string= (hpath:is-p fn) fn)))
-              (delete-file filename))))
+              (hy-delete-file-and-buffer filename))))
       (delete-directory dir))))
 
 (ert-deftest hpath--at-p-checks-file-that-with-hash-that-does-not-exist-returns-nil ()

--- a/test/hui-register-tests.el
+++ b/test/hui-register-tests.el
@@ -35,7 +35,7 @@
             (should (markerp (hui-register-but-mpos content)))
             (should (equal (marker-buffer (hui-register-but-mpos content)) (current-buffer)))
             (should (equal (hui-register-but-file content) (buffer-file-name)))))
-      (delete-file file))))
+      (hy-delete-file-and-buffer file))))
 
 (ert-deftest hui-register-test--register-val-jump-to ()
   "Verify register val jumps to right file."
@@ -52,7 +52,7 @@
             (register-val-jump-to content nil)
             (should (equal (buffer-file-name) file))
             (should (equal pos (point)))))
-      (delete-file file))))
+      (hy-delete-file-and-buffer file))))
 
 ;; TODO - Problem with link to ebut
 ;; (ert-deftest hui-register-test--register-val-insert-ibut ()
@@ -73,8 +73,8 @@
 ;;             (should (ebut:at-p))
 ;;             (action-key)
 ;;             (should (equal (buffer-file-name) file1))))
-;;       (delete-file file1)
-;;       (delete-file file2))))
+;;       (hy-delete-file-and-buffer file1)
+;;       (hy-delete-file-and-buffer file2))))
 
 (ert-deftest hui-register-test--register-val-insert-ebut ()
   "Verify register val inserts link to ebut."
@@ -95,8 +95,8 @@
             (action-key)
             (should (equal major-mode 'dired-mode))
             (should (member default-directory '("/tmp/" "/private/tmp/")))))
-      (delete-file file1)
-      (delete-file file2))))
+      (hy-delete-file-and-buffer file1)
+      (hy-delete-file-and-buffer file2))))
 
 (provide 'hui-register-tests)
 ;;; hui-register-tests.el ends here

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -80,7 +80,7 @@
       (save-excursion
 	(set-buffer gbut-file-buffer)
 	(save-buffer))
-      (delete-file linked-file)
+      (hy-delete-file-and-buffer linked-file)
       (when (file-writable-p hbmap:dir-user)
 	(delete-directory hbmap:dir-user t)))))
 
@@ -116,7 +116,7 @@
           (should (hact 'kbd-key "C-h h e c label RET RET link-to-directory RET RET"))
           (hy-test-helpers:consume-input-events)
           (hy-test-helpers-verify-hattr-at-p :actype 'actypes::link-to-directory :args '("./") :loc file :lbl-key "label"))
-      (delete-file file))))
+      (hy-delete-file-and-buffer file))))
 
 (ert-deftest hui-ebut-create-link-to-www-url ()
   "Create an ebut with link to www-url."
@@ -126,7 +126,7 @@
         (with-simulated-input "label RET www-url RET www.hypb.org RET"
           (hui:ebut-create)
           (hy-test-helpers-verify-hattr-at-p :actype 'actypes::www-url :args '("www.hypb.org") :loc file :lbl-key "label"))
-      (delete-file file))))
+      (hy-delete-file-and-buffer file))))
 
 (ert-deftest hui-ebut-edit-link-to-www-url-keeping-all-values-should-not-modify-buffer-or-ebut ()
   "Edit an ebut keeping all initial values should not modify buffer or ebut.
@@ -141,7 +141,7 @@ Ensure modifying the button but keeping the label does not create a double label
           (hui:ebut-edit "label")
           (hy-test-helpers-verify-hattr-at-p :actype 'actypes::www-url :args '("www.hypb.org") :loc file :lbl-key "label")
           (should (string= "<(label)>" (buffer-string)))))
-    (delete-file file)))
+    (hy-delete-file-and-buffer file)))
 
 (ert-deftest hui-ebut-use-region-as-label ()
   "Create an ebut using region as label."
@@ -155,7 +155,7 @@ Ensure modifying the button but keeping the label does not create a double label
           (should (hact 'kbd-key "C-h h e c RET link-to-directory RET RET"))
           (hy-test-helpers:consume-input-events)
           (hy-test-helpers-verify-hattr-at-p :actype 'actypes::link-to-directory :args '("./") :loc file :lbl-key "label"))
-      (delete-file file))))
+      (hy-delete-file-and-buffer file))))
 
 (ert-deftest hui-ebut-www-link ()
   "Create an ebut with an url."
@@ -167,7 +167,7 @@ Ensure modifying the button but keeping the label does not create a double label
           (should (hact 'kbd-key "C-h h e c label RET RET www-url RET www.example.com RET"))
           (hy-test-helpers:consume-input-events)
           (hy-test-helpers-verify-hattr-at-p :actype 'actypes::www-url  :args '("www.example.com") :loc file :lbl-key "label"))
-      (delete-file file))))
+      (hy-delete-file-and-buffer file))))
 
 (ert-deftest hui-ebut-create-exec-shell-cmd ()
   "Create an ebut that executes a command."
@@ -179,7 +179,7 @@ Ensure modifying the button but keeping the label does not create a double label
           (should (hact 'kbd-key "C-h h e c label RET RET exec-shell-cmd RET ls SPC /tmp RET y n C-x C-s"))
           (hy-test-helpers:consume-input-events)
           (hy-test-helpers-verify-hattr-at-p :actype 'actypes::exec-shell-cmd :args '("ls /tmp" t nil) :loc file :lbl-key "label"))
-      (delete-file file))))
+      (hy-delete-file-and-buffer file))))
 
 (ert-deftest hui-ebut-create-link-to-info-index-using-completion ()
   "Create an ebut with link to Info index using completion for the index item."
@@ -193,7 +193,7 @@ Ensure modifying the button but keeping the label does not create a double label
           (hy-test-helpers-verify-hattr-at-p :actype 'actypes::link-to-Info-index-item :args '("(emacs)Package") :loc file :lbl-key "emacs-package-button"))
       (progn
         (kill-buffer "*info*")
-        (delete-file file)))))
+        (hy-delete-file-and-buffer file)))))
 
 (ert-deftest hui-gibut-create-link-to-file ()
   "Programatically create implicit button link to file."
@@ -206,7 +206,7 @@ Ensure modifying the button but keeping the label does not create a double label
             (hui:gibut-create "global" test-file))
 	  (with-current-buffer test-buffer
             (hy-test-helpers-verify-hattr-at-p :actype 'actypes::link-to-file :args (list test-file) :loc test-file :lbl-key "global")))
-      (delete-file test-file))))
+      (hy-delete-file-and-buffer test-file))))
 
 (ert-deftest hui-gibut-create-link-to-file-line ()
   "Programatically create implicit button link to file and line."
@@ -219,7 +219,7 @@ Ensure modifying the button but keeping the label does not create a double label
             (hui:gibut-create "global" (concat test-file ":10")))
 	  (with-current-buffer test-buffer
             (hy-test-helpers-verify-hattr-at-p :actype 'actypes::link-to-file-line :args (list test-file 10) :loc test-file :lbl-key "global")))
-      (delete-file test-file))))
+      (hy-delete-file-and-buffer test-file))))
 
 (ert-deftest hui-gibut-create-link-to-file-line-and-column ()
   "Programatically create implicit button link to file, line and column."
@@ -232,7 +232,7 @@ Ensure modifying the button but keeping the label does not create a double label
             (hui:gibut-create "global" (concat test-file ":10:20")))
 	  (with-current-buffer test-buffer
             (hy-test-helpers-verify-hattr-at-p :actype 'actypes::link-to-file-line-and-column :args (list test-file 10 20) :loc test-file :lbl-key "global")))
-      (delete-file test-file))))
+      (hy-delete-file-and-buffer test-file))))
 
 (ert-deftest hui-gibut-create-info-node ()
   "Programatically create implicit button link to info node."
@@ -246,7 +246,7 @@ Ensure modifying the button but keeping the label does not create a double label
             (hui:gibut-create "global" (concat "\"" info-node "\"")))
 	  (with-current-buffer test-buffer
             (hy-test-helpers-verify-hattr-at-p :actype 'actypes::link-to-Info-node :args (list info-node) :loc test-file :lbl-key "global")))
-      (delete-file test-file))))
+      (hy-delete-file-and-buffer test-file))))
 
 (ert-deftest hui--delimited-selectable-thing--in-cell-return-ref ()
   "In kotl cell return klink ref."
@@ -257,7 +257,7 @@ Ensure modifying the button but keeping the label does not create a double label
           (setq klink (klink:parse (hui:delimited-selectable-thing)))
           (should (string-match kotl-file (car klink)))
           (should (string= (cadr klink) "1=01")))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest hui--delimited-selectable-thing--in-ibut-return-ibut-text ()
   "In ibut return ibut text."
@@ -268,7 +268,7 @@ Ensure modifying the button but keeping the label does not create a double label
           (insert file)
           (goto-char 2)
           (should (equal (hui:delimited-selectable-thing) file)))
-      (delete-file file))))
+      (hy-delete-file-and-buffer file))))
 
 (ert-deftest hui--delimited-selectable-thing--ibut-label-return-ibut-text ()
   "In ibut label return ibut text without label."
@@ -279,7 +279,7 @@ Ensure modifying the button but keeping the label does not create a double label
           (insert "<[lnk]>: " file "\n")
           (beginning-of-buffer)
           (should (equal (hui:delimited-selectable-thing) file)))
-      (delete-file file))))
+      (hy-delete-file-and-buffer file))))
 
 (ert-deftest hui--delimited-selectable-thing--in-ebut-return-ebut-text ()
   "In ebut return ebut text."
@@ -290,7 +290,7 @@ Ensure modifying the button but keeping the label does not create a double label
           (ebut:program "label" 'exec-shell-cmd "echo abc")
           (beginning-of-buffer)
           (should (equal (hui:delimited-selectable-thing) "<(label)>")))
-      (delete-file file))))
+      (hy-delete-file-and-buffer file))))
 
 (ert-deftest hui--delimited-selectable-thing--start-of-paired-delimiter ()
   "At start of paired delimiter return text with delimiters."
@@ -302,7 +302,7 @@ Ensure modifying the button but keeping the label does not create a double label
           (beginning-of-buffer)
           (emacs-lisp-mode)
           (should (equal (hui:delimited-selectable-thing) "(xyz)")))
-      (delete-file file))))
+      (hy-delete-file-and-buffer file))))
 
 (ert-deftest hui--delimited-selectable-thing--in-kcell-link-return-link ()
   "In kcell link return link."
@@ -325,7 +325,7 @@ Ensure modifying the button but keeping the label does not create a double label
           (setq klink (klink:parse (hui:delimited-selectable-thing)))
           (should (string= (cadr klink) "1"))
           (should (string-match kotl-file (car klink))))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest hui--kill-ring-save--yank-in-same-kotl ()
   "Yank saved klink into same kotl file."
@@ -346,7 +346,7 @@ Ensure modifying the button but keeping the label does not create a double label
           (should (looking-at-p "<@ 1>"))
           (forward-char 1)
           (should (equal (hattr:get (hbut:at-p) 'actype) 'klink:act)))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest hui--kill-ring-save--yank-in-other-kotl ()
   "Yank saved klink into other kotl file."
@@ -368,8 +368,8 @@ Ensure modifying the button but keeping the label does not create a double label
           (should (looking-at-p (concat "<" (file-name-nondirectory kotl-file) ", 1>")))
           (forward-char 1)
           (should (equal (hattr:get (hbut:at-p) 'actype) 'klink:act)))
-      (delete-file kotl-file)
-      (delete-file other-file))))
+      (hy-delete-file-and-buffer kotl-file)
+      (hy-delete-file-and-buffer other-file))))
 
 (ert-deftest hui--kill-ring-save--yank-in-other-file ()
   "Yank saved klink into other file."
@@ -391,8 +391,8 @@ Ensure modifying the button but keeping the label does not create a double label
           (should (looking-at-p (concat "<" (file-name-nondirectory kotl-file) ", 1>")))
           (forward-char 1)
           (should (equal (hattr:get (hbut:at-p) 'actype) 'klink:act)))
-      (delete-file kotl-file)
-      (delete-file other-file))))
+      (hy-delete-file-and-buffer kotl-file)
+      (hy-delete-file-and-buffer other-file))))
 
 (ert-deftest hui--kill-ring-save--yank-in-other-file-other-dir ()
   "Yank saved klink into other file in other dir."
@@ -416,8 +416,8 @@ Ensure modifying the button but keeping the label does not create a double label
           (should (looking-at-p (concat "<" kotl-file ", 1>")))
           (forward-char 1)
           (should (equal (hattr:get (hbut:at-p) 'actype) 'klink:act)))
-      (delete-file kotl-file)
-      (delete-file other-file)
+      (hy-delete-file-and-buffer kotl-file)
+      (hy-delete-file-and-buffer other-file)
       (delete-directory other-dir))))
 
 (ert-deftest hui--copy-to-register--yank-in-same-kotl ()
@@ -441,7 +441,7 @@ Ensure modifying the button but keeping the label does not create a double label
           (should (looking-at-p "<@ 1>"))
           (forward-char 1)
           (should (equal (hattr:get (hbut:at-p) 'actype) 'klink:act)))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest hui--copy-to-register--yank-in-other-kotl ()
   "Yank klink in register into other kotl file."
@@ -466,8 +466,8 @@ Ensure modifying the button but keeping the label does not create a double label
           (should (looking-at-p (concat "<" (file-name-nondirectory kotl-file) ", 1>")))
           (forward-char 1)
           (should (equal (hattr:get (hbut:at-p) 'actype) 'klink:act)))
-      (delete-file kotl-file)
-      (delete-file other-file))))
+      (hy-delete-file-and-buffer kotl-file)
+      (hy-delete-file-and-buffer other-file))))
 
 (ert-deftest hui--copy-to-register--yank-in-other-file ()
   "Yank klink in regiuster into other file."
@@ -491,8 +491,8 @@ Ensure modifying the button but keeping the label does not create a double label
           (should (looking-at-p (concat "<" (file-name-nondirectory kotl-file) ", 1>")))
           (forward-char 1)
           (should (equal (hattr:get (hbut:at-p) 'actype) 'klink:act)))
-      (delete-file kotl-file)
-      (delete-file other-file))))
+      (hy-delete-file-and-buffer kotl-file)
+      (hy-delete-file-and-buffer other-file))))
 
 (ert-deftest hui--copy-to-register--yank-in-other-file-other-dir ()
   "Yank klink in register into other file in other dir."
@@ -518,8 +518,8 @@ Ensure modifying the button but keeping the label does not create a double label
           (should (looking-at-p (concat "<" kotl-file ", 1>")))
           (forward-char 1)
           (should (equal (hattr:get (hbut:at-p) 'actype) 'klink:act)))
-      (delete-file kotl-file)
-      (delete-file other-file)
+      (hy-delete-file-and-buffer kotl-file)
+      (hy-delete-file-and-buffer other-file)
       (delete-directory other-dir))))
 
 (ert-deftest hui--kill-ring-save-in-kotl-mode-copies-region ()
@@ -534,7 +534,7 @@ Ensure modifying the button but keeping the label does not create a double label
           (insert "b")
           (hui-kill-ring-save (region-beginning) (region-end))
           (should (string= (current-kill 0 t) "a\nb")))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest hui--kill-ring-save-in-kotl-mode-between-cells-fails ()
   "Copy region in kotl-mode between cells fails."
@@ -547,7 +547,7 @@ Ensure modifying the button but keeping the label does not create a double label
           (kotl-mode:add-cell)
           (insert "b")
           (should-error (hui-kill-ring-save (region-beginning) (region-end)) :type 'error))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest hui--ibut-create-interactive ()
   "Create an implicit button interactively."
@@ -558,7 +558,7 @@ Ensure modifying the button but keeping the label does not create a double label
 	  (with-simulated-input "ibut RET link-to-rfc RET 123 RET"
 	    (hact (lambda () (call-interactively 'hui:ibut-create))))
           (should (string= "<[ibut]> - rfc123" (buffer-string))))
-      (delete-file file))))
+      (hy-delete-file-and-buffer file))))
 
 (ert-deftest hui--ibut-create-interactive-label-using-region ()
   "Create an implicit button interactively with label from region."
@@ -572,7 +572,7 @@ Ensure modifying the button but keeping the label does not create a double label
 	  (with-simulated-input "RET link-to-rfc RET 123 RET"
 	    (hact (lambda () (call-interactively 'hui:ibut-create))))
           (should (string= "<[ibut]> - rfc123" (buffer-string))))
-      (delete-file file))))
+      (hy-delete-file-and-buffer file))))
 
 (ert-deftest hui--ibut-create-interactive-add-comment-char ()
   "Create an implicit button interactively in program mode adds comment char."
@@ -585,7 +585,7 @@ Ensure modifying the button but keeping the label does not create a double label
 	  (with-simulated-input "ibut RET link-to-rfc RET 123 RET"
 	    (hact (lambda () (call-interactively 'hui:ibut-create))))
           (should (string= "(sexp); <[ibut]> - rfc123" (buffer-string))))
-      (delete-file file))))
+      (hy-delete-file-and-buffer file))))
 
 (ert-deftest hui--ibut-create-interactive-create-label ()
   "Create a label for an implicit button interactively."
@@ -598,7 +598,7 @@ Ensure modifying the button but keeping the label does not create a double label
 	  (with-simulated-input "label RET"
 	    (hact (lambda () (call-interactively 'hui:ibut-label-create))))
           (should (string= "<[label]> - \"/tmp\"" (buffer-string))))
-      (delete-file file))))
+      (hy-delete-file-and-buffer file))))
 
 (ert-deftest hui--ibut-rename-label-at-point ()
   "Rename a label for an implicit button interactively.
@@ -612,7 +612,7 @@ With point on label suggest that ibut for rename."
 	  (with-simulated-input "M-DEL renamed RET"
 	    (hact (lambda () (call-interactively 'hui:ibut-rename))))
           (should (string= "<[renamed]> - rfc123" (buffer-string))))
-      (delete-file file))))
+      (hy-delete-file-and-buffer file))))
 
 (ert-deftest hui--ibut-rename-label ()
   "Rename a label for an implicit button interactively."
@@ -625,7 +625,7 @@ With point on label suggest that ibut for rename."
 	  (with-simulated-input "label RET M-DEL renamed RET"
 	    (hact (lambda () (call-interactively 'hui:ibut-rename))))
           (should (string= "<[renamed]> - rfc123" (buffer-string))))
-      (delete-file file))))
+      (hy-delete-file-and-buffer file))))
 
 (ert-deftest hui--ibut-rename-label-not-in-buffer-errors ()
   "Rename a label not in buffer should error."
@@ -637,7 +637,7 @@ With point on label suggest that ibut for rename."
           (goto-char (point-max))
           (with-simulated-input "RET"
 	    (should-error (hui:ibut-rename "notalabel") :type 'error)))
-      (delete-file file))))
+      (hy-delete-file-and-buffer file))))
 
 (ert-deftest hui--ebut-rename ()
   "Rename an ebut shall change the name."

--- a/test/hy-test-helpers.el
+++ b/test/hy-test-helpers.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     23-Jul-22 at 18:39:05 by Bob Weiner
+;; Last-Mod:     28-May-23 at 22:52:40 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -67,6 +67,15 @@ Checks ACTYPE, ARGS, LOC and LBL-KEY."
     (should (equal (hattr:get hbut-at-p 'args) args))
     (should (equal (hattr:get hbut-at-p 'loc) loc))
     (should (equal (hattr:get hbut-at-p 'lbl-key) lbl-key))))
+
+(defun hy-delete-file-and-buffer (file)
+  "Delete file and buffer vistinng file."
+  (delete-file file)
+  (let ((buf (find-buffer-visiting file)))
+    (when buf
+      (with-current-buffer buf
+        (set-buffer-modified-p nil)
+        (kill-buffer)))))
 
 (provide 'hy-test-helpers)
 ;;; hy-test-helpers.el ends here

--- a/test/hyrolo-tests.el
+++ b/test/hyrolo-tests.el
@@ -41,7 +41,7 @@
           (hyrolo-add "a/b/c")
           (beginning-of-line)
           (should (looking-at-p "\*\*\*   c")))
-      (delete-file hyrolo-file))))
+      (hy-delete-file-and-buffer hyrolo-file))))
 
 (ert-deftest hyrolo-demo-search-work ()
   "Use demo example and search for work should match work."
@@ -229,7 +229,7 @@ and {b} the previous same level cell."
           (dolist (sorted-order '("a" "b" "d" "c"))
             (goto-char (1+ (should (search-forward sorted-order))))
             (should (looking-at-p "^\t[0-9/]+$"))))
-      (delete-file hyrolo-file))))
+      (hy-delete-file-and-buffer hyrolo-file))))
 
 (ert-deftest hyrolo-sort-records-at-different-levels ()
   "HyRolo can sort records at different levels."
@@ -267,7 +267,7 @@ and {b} the previous same level cell."
           (find-file hyrolo-file)
           (hyrolo-sort)
           (should (string= (buffer-string) sorted-hyrolo-file)))
-      (delete-file hyrolo-file))))
+      (hy-delete-file-and-buffer hyrolo-file))))
 
 (provide 'hyrolo-tests)
 ;;; hyrolo-tests.el ends here

--- a/test/kcell-tests.el
+++ b/test/kcell-tests.el
@@ -7,7 +7,7 @@
 ;; e-mail:       matsl@gnu.org
 ;;
 ;; orig-date:    16-Feb-22 at 23:28:49
-;; last-mod:     13-May-23 at 10:06:42 by Bob Weiner
+;; last-mod:     28-May-23 at 23:15:30 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -26,6 +26,7 @@
 
 (require 'kcell)
 (require 'kotl-mode)
+(require 'hy-test-helpers "test/hy-test-helpers")
 
 (defconst kcell-tests--ref-to-id-tests
   ;  ref flag kvspec expected
@@ -88,7 +89,7 @@ Return t if is does else return the SPEC."
             (if failures
                 (ert-fail (cons "These refs were not correctly converted to ids:" failures))
               t)))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (provide 'kcell-tests)
 ;;; kcell-tests.el ends here

--- a/test/kexport-tests.el
+++ b/test/kexport-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    10-Oct-21 at 17:30:00
-;; Last-Mod:     13-May-23 at 12:38:06 by Bob Weiner
+;; Last-Mod:     28-May-23 at 23:15:39 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -21,6 +21,7 @@
 (require 'ert)
 (require 'el-mock)
 (require 'kexport "kotl/kexport")
+(require 'hy-test-helpers "test/hy-test-helpers")
 
 (ert-deftest kexport:html-creates-html-file ()
   "kexport:html creates an output html file."
@@ -36,8 +37,8 @@
             (kexport:html kotl-file html-file))
           (should (file-exists-p html-file)))
       (progn
-        (delete-file kotl-file)
-        (delete-file html-file)))))
+        (hy-delete-file-and-buffer kotl-file)
+        (hy-delete-file-and-buffer html-file)))))
 
 (ert-deftest kexport:html-sets-title-and-header ()
   "kexport:html set title and header from kotl filename without suffix."
@@ -57,8 +58,8 @@
           (re-search-forward (format "<title>%s</title>" title))
           (re-search-forward (format "<h1>%s</h1>" title)))
       (progn
-        (delete-file kotl-file)
-        (delete-file html-file)))))
+        (hy-delete-file-and-buffer kotl-file)
+        (hy-delete-file-and-buffer html-file)))))
 
 (ert-deftest kexport:html-contains-each-cell ()
   "kexport:html contains each cell."
@@ -77,8 +78,8 @@
           (re-search-forward "<pre>first</pre>")
           (re-search-forward "<pre>second</pre>"))
       (progn
-        (delete-file kotl-file)
-        (delete-file html-file)))))
+        (hy-delete-file-and-buffer kotl-file)
+        (hy-delete-file-and-buffer html-file)))))
 
 (ert-deftest kexport:html-creates-hierarchy ()
   "kexport:html exports cells in a hierachy."
@@ -103,8 +104,8 @@
           (re-search-forward "<pre.*1a1\\. .*</pre>")
           (re-search-forward "<pre>third</pre>"))
       (progn
-        (delete-file kotl-file)
-        (delete-file html-file)))))
+        (hy-delete-file-and-buffer kotl-file)
+        (hy-delete-file-and-buffer html-file)))))
 
 (ert-deftest kexport:html-creates-list-hierarchy ()
   "kexport:html exports cells in a hierachy using lists."
@@ -126,8 +127,8 @@
                      (count-matches "</ul\\b" (point-min) (point-max))))
           (should (= (count-matches "<li\\b" (point-min) (point-max))
                      (count-matches "</li\\b" (point-min) (point-max)))))
-      (delete-file kotl-file)
-      (delete-file html-file))))
+      (hy-delete-file-and-buffer kotl-file)
+      (hy-delete-file-and-buffer html-file))))
 
 (ert-deftest kexport:display-creates-html-file-and-displays-it ()
   "kexport:display creates html file and displays it in external browser."
@@ -145,8 +146,8 @@
           (insert "second")
           (should (string= (kexport:display) html-file)))
       (progn
-        (delete-file kotl-file)
-        (delete-file html-file)))))
+        (hy-delete-file-and-buffer kotl-file)
+        (hy-delete-file-and-buffer html-file)))))
 
 (ert-deftest kexport:koutline-calls-kexport:html ()
   "kexport:koutline calls kexport:html and returns html buffer name."
@@ -162,7 +163,7 @@
           (find-file kotl-file)
           (should (string= (kexport:koutline) html-file)))
       (progn
-        (delete-file kotl-file)))))
+        (hy-delete-file-and-buffer kotl-file)))))
 
 ;; This file can't be byte-compiled without the `el-mock' package (because of
 ;; the use of the `with-mock' macro), which is not a dependency of Hyperbole.

--- a/test/kimport-tests.el
+++ b/test/kimport-tests.el
@@ -37,8 +37,8 @@
 	    (unless (kotl-mode:last-cell-p)
               (kotl-mode:next-cell 1)))
 	  (should (kotl-mode:last-cell-p)))
-      (delete-file file)
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer file)
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kimport--text-file ()
   "Import .txt text file into a Koutline, as one cell per paragraph."
@@ -54,8 +54,8 @@
 	    (unless (kotl-mode:last-cell-p)
               (kotl-mode:forward-cell 1)))
 	  (should (kotl-mode:last-cell-p)))
-      (delete-file file)
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer file)
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kimport--text-file-two-lines-per-paragraph ()
   "Import .txt text file into a Koutline, as one cell per paragraph.
@@ -75,8 +75,8 @@ Each paragraph is two lines."
 	    (unless (kotl-mode:last-cell-p)
               (kotl-mode:forward-cell 1)))
 	  (should (kotl-mode:last-cell-p)))
-      (delete-file file)
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer file)
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kimport--star-outline ()
   "Import .otl star outline as one cell per entry beginning with one or more stars."
@@ -93,8 +93,8 @@ Each paragraph is two lines."
 	    (unless (kotl-mode:last-cell-p)
               (kotl-mode:next-cell 1)))
 	  (should (kotl-mode:last-cell-p)))
-      (delete-file file)
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer file)
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kimport--star-outline-two-lines-per-star-heading ()
   "Import .org star outline as one cell per paragraph, each two lines."
@@ -110,8 +110,8 @@ Each paragraph is two lines."
 	    (unless (kotl-mode:last-cell-p)
               (kotl-mode:forward-cell 1)))
 	  (should (kotl-mode:last-cell-p)))
-      (delete-file file)
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer file)
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kimport--star-outline-with-siblings ()
   "Import .org star outline as one cell per entry beginning with one or more stars."
@@ -130,8 +130,8 @@ Each paragraph is two lines."
 	  (should (kotl-mode:last-cell-p))
           (kotl-mode:end-of-buffer)
           (should (= (kcell-view:level) 3)))
-      (delete-file file)
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer file)
+      (hy-delete-file-and-buffer kotl-file))))
 
 (provide 'kimport-tests)
 ;;; kimport-tests.el ends here

--- a/test/kotl-mode-tests.el
+++ b/test/kotl-mode-tests.el
@@ -90,7 +90,7 @@
         (progn
           (find-file kotl-file)
           (should (equal major-mode 'kotl-mode)))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kotl-mode-set-view-with-kbd ()
   "When the view mode is changed the label is changed too."
@@ -104,7 +104,7 @@
           (hy-test-helpers:consume-input-events)
           (should (eq (kview:label-type kview) 'id))
           (should (string= (kcell-view:label (point)) "01")))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kotl-mode-idstamp-saved-with-file ()
   "The active view mode is saved with the buffer."
@@ -130,7 +130,7 @@
           (should (eq (kview:label-type kview) 'id))
           (should (string= (kcell-view:idstamp) "01"))
           (should (string= (kcell-view:label (point)) "01")))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kotl-mode-demote-keeps-idstamp ()
   "When tree is demoted the idstamp label is not changed."
@@ -153,7 +153,7 @@
           (kotl-mode:demote-tree 0)
           (should (string= (kcell-view:idstamp) "02"))
           (should (string= (kcell-view:label (point)) "02")))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kotl-mode-demote-change-label ()
   "When tree is demoted the label is changed."
@@ -169,7 +169,7 @@
           ;; Verify demote change label
           (kotl-mode:demote-tree 0)
           (should (string= (kcell-view:label (point)) "1a")))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kotl-mode-label-type-activation ()
   "Kotl-mode test label type activation."
@@ -187,7 +187,7 @@
 
           (kvspec:activate "ben0")
           (should (string= (kcell-view:label (point)) "02")))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kotl-mode-move-cell-before-cell ()
   "Move cell before cell."
@@ -204,7 +204,7 @@
 
           (should (string= (kcell-view:label (point)) "1"))
           (should (looking-at-p "second")))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kotl-mode-move-cell-after-cell ()
   "Move cell after cell."
@@ -221,7 +221,7 @@
 
           (should (string= (kcell-view:label (point)) "2"))
           (should (looking-at-p "first")))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kotl-mode-copy-cell-after-cell ()
   "Copy cell after cell."
@@ -238,7 +238,7 @@
 
           (should (string= (kcell-view:label (point)) "3"))
           (should (looking-at-p "first")))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kotl-mode-copy-cell-before-cell ()
   "Copy cell after cell."
@@ -254,7 +254,7 @@
 
           (should (string= (kcell-view:label (point)) "1"))
           (should (looking-at-p "second")))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kotl-mode-jump-to-cell ()
   "Kotl-mode jump to cell."
@@ -269,7 +269,7 @@
 
           (kotl-mode:goto-cell "2")
           (should (string= (kcell-view:label (point)) "2")))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kotl-mode-goto-child-and-parent ()
   "Kotl-mode goto child and goto parent."
@@ -286,7 +286,7 @@
 
           (kotl-mode:down-level 1)
           (should (string= (kcell-view:label (point)) "1a")))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kotl-mode-kill-cell ()
   "Kotl-mode kill a cell test."
@@ -309,7 +309,7 @@
           (kotl-mode:beginning-of-cell)
           (should (string= (kcell-view:idstamp) "04"))
           (should (looking-at-p "$")))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kotl-mode-kill-tree-and-reopen ()
   "Remove first cell, reopen file, verify idstamp of first cell."
@@ -329,7 +329,7 @@
           (find-file kotl-file)
           (should (looking-at-p "second"))
           (should (string= (kcell-view:idstamp) "02")))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kotl-mode-kill-tree-on-empty-file-creates-new-cell ()
   "Kill tree on empty kotl file creates new cell."
@@ -343,7 +343,7 @@
           (should (string= (kcell-view:idstamp) "02"))
           (kotl-mode:kill-tree)
           (should (string= (kcell-view:idstamp) "03")))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kotl-mode-split-cell ()
   "Kotl-mode split cell."
@@ -358,7 +358,7 @@
           (kotl-mode:demote-tree 0)
           (should (string= (kcell-view:label (point)) "1a"))
           (should (string= (kcell-view:idstamp) "02")))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kotl-mode-append-cell ()
   "Kotl-mode append cell to cell."
@@ -374,7 +374,7 @@
             (insert "2")
             (kotl-mode:append-cell ids (kcell-view:idstamp))
             (should (string= "21\n1" (substring-no-properties (kcell-view:contents))))))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kotl-mode-previous-cell-from-invalid-position ()
   "When in an invalid position previous cell should move back to first valid cell."
@@ -395,7 +395,7 @@
 
           (kotl-mode:previous-cell 1)
           (should (string= (kcell-view:label (point)) "2")))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kotl-mode-backward-cell-from-invalid-position ()
   "When in an invalid position backward cell should move back to first valid cell."
@@ -416,7 +416,7 @@
 
           (kotl-mode:backward-cell 1)
           (should (string= (kcell-view:label (point)) "1a")))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kotl-mode-backward-cell-from-invalid-pos-leave-point-in-valid-pos ()
   "From invalid pos backward cell leaves point in valid pos on error."
@@ -443,7 +443,7 @@
                (should (string-match "(kotl-mode:backward-cell): No prior cell at same level" (cadr err))))))
           (should (kotl-mode:bocp)) ;; Point is moved to begining of cell
           (should (string= (kcell-view:label (point)) "1a")))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kotl-mode-transpose-cell ()
   "Transpose cells and leave point in cell."
@@ -462,7 +462,7 @@
 
           (should (string= (kcell-view:idstamp) "01"))
           (should (looking-at-p "first"))))
-      (delete-file kotl-file)))
+      (hy-delete-file-and-buffer kotl-file)))
 
 (ert-deftest kotl-mode-transpose-cell-with-mark ()
   "Transpose cell with cell with mark and change point to mark."
@@ -485,7 +485,7 @@
           (should (string= (kcell-view:idstamp) "03"))
           (should (looking-at-p "third"))
           (should (kotl-mode:first-cell-p)))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kotl-mode-transpose-cell-past-multiple-cells ()
   "Transpose cell past multiple cells."
@@ -513,7 +513,7 @@
           (should (string= (kcell-view:idstamp) "01"))
           (kotl-mode:beginning-of-cell)
           (should (looking-at-p "first")))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kotl-mode-copy-kotl-file-updates-root-id-attributes ()
   "Verify root id-attribute is updated when kotl mode is copied."
@@ -530,8 +530,8 @@
           (copy-file kotl-file new-name)
           (find-file new-name)
           (should (string= (kcell:get-attr (kcell-view:cell-from-ref 0) 'level-indent) indent)))
-      (delete-file kotl-file)
-      (delete-file new-name))))
+      (hy-delete-file-and-buffer kotl-file)
+      (hy-delete-file-and-buffer new-name))))
 
 (ert-deftest kotl-mode-hide-cell ()
   "Verify cell is hidden and unhidden on `action-key' press."
@@ -548,7 +548,7 @@
           (should (outline-invisible-p))
           (action-key)                  ; Unhide cell
           (should-not (outline-invisible-p)))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kotl-mode-move-tree-forward ()
   "Should move tree forward."
@@ -573,7 +573,7 @@
           (should (string= (kcell-view:idstamp) "02"))
           (should (string= (kcell-view:label (point)) "1"))
           (should (looking-at "2")))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kotl-mode-move-tree-backward ()
   "Should move tree backward."
@@ -598,7 +598,7 @@
           (should (string= (kcell-view:idstamp) "01"))
           (should (string= (kcell-view:label (point)) "2"))
           (should (looking-at "1")))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kotl-mode--add-cell-set-fill-attribute ()
   "Add cell shall set the fill attribute."
@@ -610,7 +610,7 @@
           (should-not (kcell-view:get-attr 'no-fill))
           (kotl-mode:add-cell)
           (should-not (kcell-view:get-attr 'no-fill)))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kotl-mode-cell-help-displays-help-in-temp-buffer ()
   "Verify that kotl-mode:cell-help shows help in a temp buffer."
@@ -627,7 +627,7 @@
           (kotl-mode:cell-help "1" nil)
           (with-current-buffer "*Help: Hyperbole Koutliner*"
             (should (looking-at-p (concat "\\W+1\\. " kotl-file)))))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kotl-mode-cell-help-displays-help-from-root ()
   "Verify that kotl-mode:cell-help shows help from root cell."
@@ -645,7 +645,7 @@
           (with-current-buffer "*Help: Hyperbole Koutliner*"
             (should (looking-at-p (concat "\\W+1a\\. " kotl-file)))
             (should (= (count-matches "idstamp") 2))))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kotl-mode-cell-help-displays-help-for-all-cells ()
   "Verify that kotl-mode:cell-help shows help for all cells."
@@ -665,7 +665,7 @@
             (should (= (count-matches "idstamp") 4))
             (forward-line 5)
             (should (looking-at-p (concat "\\W+1\\. " kotl-file)))))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (provide 'kotl-mode-tests)
 ;;; kotl-mode-tests.el ends here

--- a/test/kotl-orgtbl-tests.el
+++ b/test/kotl-orgtbl-tests.el
@@ -47,7 +47,7 @@
                (should (equal (car err) 'error))
                (should (string-match "(kotl-mode:delete-char): End of cell" (cadr err)))))
             (:success (ert-fail "C-d shall fail when deleting at the end of a cell."))))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kotl-orgtbl-action-key-on-vertical-bar-toggles-orgtbl-mode ()
   "Action key on vertical bar toggles orgtbl-mode."
@@ -66,7 +66,7 @@
           (should-not orgtbl-mode)
           (action-key)
           (should orgtbl-mode))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kotl-orgtbl-shift-tab-demotes-tree-outside-table ()
   "Shift tab demotes tree outside of org table."
@@ -84,7 +84,7 @@
 
           (should (equal (kcell-view:level) 1))
           (should (string= (kcell-view:label (point)) "2")))
-      (delete-file kotl-file))))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (provide 'kotl-orgtbl-tests)
 ;;; kotl-orgtbl-tests.el ends here


### PR DESCRIPTION
## What 

Delete file and buffer to clean up tests.

## Why

Unsaved temp buffers is a pain when running tests interactively in your development Emacs. This helper removed both the temp file uses in the test and the buffer that could be associated with it. All delete-file calls has been replace with using the new helper. 

## Note

Some tests do already clean up both the buffer and the file. Those can be changed to use this helper for both tasks but I have left that optimization for later.