### PR TITLE
Remove redundant :group args and obsolete * in defcustom docstrings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,9 @@
 
 2023-06-29  Mats Lidell  <matsl@gnu.org>
 
+* hyrolo.e: Remove redundant `:group` args.  Remove obsolete `*` in
+    `defcustom` docstrings. Contribution from Stefan Monnier. Thanks Stefan.
+
 * hbut.el (defib): Remove redundant indent property. Change by Stefan
     Monnier.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -17,7 +17,7 @@
 
 2023-06-29  Mats Lidell  <matsl@gnu.org>
 
-* hyrolo.e: Remove redundant `:group` args.  Remove obsolete `*` in
+* hyrolo.el: Remove redundant `:group` args.  Remove obsolete `*` in
     `defcustom` docstrings. Contribution from Stefan Monnier. Thanks Stefan.
 
 * hbut.el (defib): Remove redundant indent property. Change by Stefan

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -71,11 +71,10 @@
   :group 'hyperbole)
 
 (defcustom hyrolo-date-format "%m/%d/%Y"
-  "*Format of date string used in Rolo automatic date stamps.
+  "Format of date string used in Rolo automatic date stamps.
 Default is American style.  See documentation of the function
 `format-time-string' for format options."
-  :type 'string
-  :group 'hyperbole-rolo)
+  :type 'string)
 
 (defvar hyrolo-display-format-function
   (lambda (entry)
@@ -84,37 +83,32 @@ Default is American style.  See documentation of the function
 The argument is a rolo entry string.")
 
 (defcustom hyrolo-email-format "%s\t\t<%s>"
-  "*Format string to use when adding an entry with e-mail addr from a mail msg.
+  "Format string to use when adding an entry with e-mail addr from a mail msg.
 It must contain a %s indicating where to put the entry name and a second
 %s indicating where to put the e-mail address."
-  :type 'string
-  :group 'hyperbole-rolo)
+  :type 'string)
 
 (defvar hyrolo-entry-name-regexp "[-_a-zA-Z0-9@.]+\\( ?, ?[-_a-zA-Z0-9@.]+\\)?"
   "*Regexp matching a hyrolo entry name after matching to `hyrolo-entry-regexp'.")
 
 (defcustom hyrolo-file-suffix-regexp "\\.\\(kotl\\|md\\|org\\|otl\\)$"
   "File suffix regexp used to select files to search with HyRolo."
-  :type 'string
-  :group 'hyperbole-rolo)
+  :type 'string)
 
 (defcustom hyrolo-find-file-function #'find-file
-  "*Function to interactively display a `hyrolo-file-list' file for editing.
+  "Function to interactively display a `hyrolo-file-list' file for editing.
 Use the `hyrolo-edit' function instead to edit a new or existing entry."
-  :type 'function
-  :group 'hyperbole-rolo)
+  :type 'function)
 
 (defcustom hyrolo-find-file-noselect-function #'find-file-noselect
-  "*Function used by HyRolo to read `hyrolo-file-list' files into Emacs."
-  :type 'function
-  :group 'hyperbole-rolo)
+  "Function used by HyRolo to read `hyrolo-file-list' files into Emacs."
+  :type 'function)
 
 (defcustom hyrolo-google-contacts-flag t
-  "*Non-nil means search Google Contacts on each hyrolo query.
+  "Non-nil means search Google Contacts on each hyrolo query.
 The google-contact package must be loaded and a gpg encryption
 executable must be found as well (for Oauth security)."
-  :type 'boolean
-  :group 'hyperbole-rolo)
+  :type 'boolean)
 
 (defvar hyrolo-next-match-function #'hyrolo-next-regexp-match
   "Value is the function to find next match within a HyRolo file.
@@ -185,34 +179,30 @@ A hyrolo-file consists of:
        hyrolo-hdr-regexp;
    (2) one or more rolo entries which each begin with
        hyrolo-entry-regexp and may be nested."
-  :group 'hyperbole-rolo
   :type '(repeat file))
 
 (defcustom hyrolo-highlight-face 'match
-  "*Face used to highlight rolo search matches."
+  "Face used to highlight rolo search matches."
   :type 'face
-  :initialize #'custom-initialize-default
-  :group 'hyperbole-rolo)
+  :initialize #'custom-initialize-default)
 
 (defcustom hyrolo-kill-buffers-after-use nil
-  "*Non-nil means kill rolo file buffers after searching them for entries.
+  "Non-nil means kill rolo file buffers after searching them for entries.
 Only unmodified buffers are killed."
-  :type 'boolean
-  :group 'hyperbole-rolo)
+  :type 'boolean)
 
 (defcustom hyrolo-save-buffers-after-use t
-  "*Non-nil means save rolo file after an entry is killed."
-  :type 'boolean
-  :group 'hyperbole-rolo)
+  "Non-nil means save rolo file after an entry is killed."
+  :type 'boolean)
 
 ;; Insert or update the entry date each time an entry is added or edited.
 (add-hook 'hyrolo-add-hook  #'hyrolo-set-date)
 (add-hook 'hyrolo-edit-hook #'hyrolo-set-date)
 
-(defvar hyrolo-yank-reformat-function nil
-  "*A function of two arguments, START and END, invoked after a hyrolo-yank.
+(defvar hyrolo-yank-reformat-function #'ignore
+  "*A function of two arguments, START and END, invoked after a `hyrolo-yank'.
 It should reformat the region given by the arguments to some preferred style.
-Default value is nil, meaning no reformmating is done.")
+Default value is to perform no reformatting.")
 
 ;;; ************************************************************************
 ;;; Commands


### PR DESCRIPTION
## What

`:group` args are redundant and `*` is obsolete in `defcustom` docstrings.

Contribution from Stefan Monnier. Thanks Stefan.

See: https://github.com/rswgnu/hyperbole/pull/343/files#r1244628372

cc: @monnier 
