### PR TITLE
Remove some byte compilation warnings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-2023-06-30  Mats Lidell  <matsl@gnu.org>
+2023-07-01  Mats Lidell  <matsl@gnu.org>
 
 * hui.el:
   hpath.el:
@@ -10,7 +10,7 @@
 
 * hactypes.el (require): Load hsys-org for org-fold-show-context.
     (link-to-org-id-marker): Use org-fold-show-context.
-    (link-to-org-id): Silence byte compile warnings when org-roam not loaded.
+    (org-roam-id-find): declare-function.
 
 2023-06-29  Mats Lidell  <matsl@gnu.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,17 @@
+2023-06-30  Mats Lidell  <matsl@gnu.org>
+
+* hui.el:
+  hpath.el:
+  hbut.el:
+  hbdata.el: Fix single quotes in docstrings.
+
+* kotl/kview.el (kcell-view:to-label-end): Add missing point to error
+    message.
+
+* hactypes.el (require): Load hsys-org for org-fold-show-context.
+    (link-to-org-id-marker): Use org-fold-show-context.
+    (link-to-org-id): Silence byte compile warnings when org-roam not loaded.
+
 2023-06-29  Mats Lidell  <matsl@gnu.org>
 
 * hbut.el (defib): Remove redundant indent property. Change by Stefan

--- a/hactypes.el
+++ b/hactypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    23-Sep-91 at 20:34:36
-;; Last-Mod:     25-Jun-23 at 13:48:01 by Bob Weiner
+;; Last-Mod:     30-Jun-23 at 22:44:36 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -18,7 +18,7 @@
 ;;; Other required Elisp libraries
 ;;; ************************************************************************
 
-(eval-and-compile (mapc #'require '(bookmark hvar hsettings comint hbut hpath hargs hmail man)))
+(eval-and-compile (mapc #'require '(bookmark hvar hsettings comint hbut hpath hargs hmail man hsys-org)))
 
 ;;; ************************************************************************
 ;;; Public declarations
@@ -503,7 +503,7 @@ available.  Filename may be given without the .info suffix."
     (hypb:error "(link-to-Info-node): Invalid Info node: `%s'" string)))
 
 (defact link-to-ibut (name-key &optional but-src point)
-  "Perform implicit button action specified by NAME-KEY, optional BUT-SRC and POINT.
+  "Do implicit button action specified by NAME-KEY, optional BUT-SRC and POINT.
 NAME-KEY must be a normalized key for an ibut <[name]>.
 BUT-SRC defaults to the current buffer's file or if there is no
 attached file, then to its buffer name.  POINT defaults to the
@@ -600,7 +600,9 @@ information on how to specify a mail reader to use."
   (when (stringp id)
     (let (m
 	  (inhibit-message t)) ;; Inhibit org-id-find status msgs
-      (when (setq m (or (and (featurep 'org-roam) (org-roam-id-find id 'marker))
+      (when (setq m (or (and (featurep 'org-roam)
+                             (with-no-warnings
+                               (org-roam-id-find id 'marker)))
 			(org-id-find id 'marker)))
 	(hact #'link-to-org-id-marker m)))))
 
@@ -612,7 +614,7 @@ See doc of `ibtypes::org-id' for usage."
     (org-mark-ring-push)
     (hact #'link-to-buffer-tmp (marker-buffer marker) marker)
     (move-marker marker nil)
-    (org-show-context))
+    (org-fold-show-context))
 
 (defact link-to-regexp-match (regexp n source &optional buffer-p)
   "Find REGEXP's Nth occurrence in SOURCE and display location at window top.

--- a/hactypes.el
+++ b/hactypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    23-Sep-91 at 20:34:36
-;; Last-Mod:     30-Jun-23 at 22:44:36 by Mats Lidell
+;; Last-Mod:      1-Jul-23 at 23:06:38 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -27,6 +27,7 @@
 (declare-function kotl-mode:goto-cell "kotl-mode")
 (declare-function kotl-mode:beginning-of-buffer "kotl-mode")
 (declare-function rmail:msg-to-p "hrmail")
+(declare-function org-roam-id-find "‎ext:org-roam-id")
 
 ;;; ************************************************************************
 ;;; Standard Hyperbole action types
@@ -503,7 +504,7 @@ available.  Filename may be given without the .info suffix."
     (hypb:error "(link-to-Info-node): Invalid Info node: `%s'" string)))
 
 (defact link-to-ibut (name-key &optional but-src point)
-  "Do implicit button action specified by NAME-KEY, optional BUT-SRC and POINT.
+  "Activate implicit button given by NAME-KEY, optional BUT-SRC and POINT.
 NAME-KEY must be a normalized key for an ibut <[name]>.
 BUT-SRC defaults to the current buffer's file or if there is no
 attached file, then to its buffer name.  POINT defaults to the
@@ -600,9 +601,7 @@ information on how to specify a mail reader to use."
   (when (stringp id)
     (let (m
 	  (inhibit-message t)) ;; Inhibit org-id-find status msgs
-      (when (setq m (or (and (featurep 'org-roam)
-                             (with-no-warnings
-                               (org-roam-id-find id 'marker)))
+      (when (setq m (or (and (featurep 'org-roam) (org-roam-id-find id 'marker))
 			(org-id-find id 'marker)))
 	(hact #'link-to-org-id-marker m)))))
 
@@ -741,4 +740,3 @@ Optional SECTIONS-START limits toc entries to those after that point."
 (provide 'hactypes)
 
 ;;; hactypes.el ends here
-

--- a/hbdata.el
+++ b/hbdata.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Apr-91
-;; Last-Mod:     13-Jun-23 at 01:27:25 by Bob Weiner
+;; Last-Mod:     30-Jun-23 at 22:36:04 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -288,9 +288,9 @@ class `hbdata' to operate on the entry."
   "Given NAME-KEY, return next ibutton instance number string for current buffer.
 If there is no existing ibutton with NAME-KEY, return t.
 
-With NAME-KEY nil or NAME-KEY 'name' and no existing in-buffer ibutton
+With NAME-KEY nil or NAME-KEY `name' and no existing in-buffer ibutton
 with that name, return t.
-With NAME-KEY 'name' and highest in-buffer ibutton 'name:3',
+With NAME-KEY `name' and highest in-buffer ibutton `name:3',
 return ':4'."
   (if (null name-key)
       t
@@ -305,8 +305,8 @@ Instance number is returned as an integer.  Return 1 if NAME-KEY exists
 in the buffer but no other instances do; nil if no instance.
 
 With no match, return nil.
-With only 'name' found, return 1.
-With 'name' and 'name:2' found, return 2."
+With only `name' found, return 1.
+With `name' and `name:2' found, return 2."
   (let ((key (car (ibut:label-sort-keys (ibut:label-key-match name-key)))))
     (cond ((null key) nil)
 	  ((string-match (concat (regexp-quote hbut:instance-sep)
@@ -319,7 +319,7 @@ With 'name' and 'name:2' found, return 2."
   "Return string for the next higher button instance number after NAME-KEY's.
 Return nil if NAME-KEY is nil.
 
-Given 'name', return ':2'.  Given 'name:2', return ':3'.
+Given `name', return ':2'.  Given `name:2', return ':3'.
 
 This does not search any buffer for other instances; it uses the
 NAME-KEY string literally, so it must include any instance number

--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:     29-Jun-23 at 17:12:36 by Mats Lidell
+;; Last-Mod:     30-Jun-23 at 22:39:57 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1631,7 +1631,7 @@ associated arguments from the button."
 	  (funcall ibut-type-symbol))))))
 
 (defun    ibut:set-name-and-label-key-p (&optional start-delim end-delim)
-  "Set ibut name, lbl-key, lbl-start/end attributes in 'hbut:current.
+  "Set ibut name, lbl-key, lbl-start/end attributes in \\='hbut:current.
 Point may be on the implicit button text or its optional preceding
 name.  Return t if on a named or delimited text implicit button;
 return nil otherwise.
@@ -1641,8 +1641,8 @@ button text (not name); without these, try a series of matching
 delimiters (double quotes, angle brackets, braces and square
 brackets).
 
-This will not set the 'name attribute unless there is a <[name]>
-prefix.  This will not set the 'lbl-key or the 'lbl-end location
+This will not set the \\='name attribute unless there is a <[name]>
+prefix.  This will not set the \\='lbl-key or the \\='lbl-end location
 attribute unless the button text is delimited.
 
 Any implicit button name must contain at least two characters,
@@ -1721,7 +1721,7 @@ if CATEG and following arguments are not given, create the button
 object from the implicit button at point, if any; in which case,
 return nil if no implicit button is found at point.
 
-Store new button attributes in the symbol, 'hbut:current."
+Store new button attributes in the symbol, \\='hbut:current."
   ;; :args is ignored unless :categ or :action is also given.
 
   ;; `lbl-key' attribute will be set from `but-sym' if any, the button

--- a/hpath.el
+++ b/hpath.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Nov-91 at 00:44:23
-;; Last-Mod:     19-Jun-23 at 14:29:44 by Bob Weiner
+;; Last-Mod:     30-Jun-23 at 22:38:18 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -2520,7 +2520,7 @@ that returns a replacement string."
   "Replace with VAR-SYMBOL any occurrences of VAR-DIR-VAL in PATH.
 Replacement is done iff VAR-DIR-VAL is an absolute path.
 
-If VAR-SYMBOL is 'hyperb:dir or 'load-path, remove the matching PATH
+If VAR-SYMBOL is \\='hyperb:dir or \\='load-path, remove the matching PATH
 part rather than replacing it with the variable since it can be
 resolved without attaching the variable name.
 

--- a/hui.el
+++ b/hui.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 21:42:03
-;; Last-Mod:     25-Jun-23 at 09:41:45 by Bob Weiner
+;; Last-Mod:     30-Jun-23 at 22:50:57 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -664,7 +664,7 @@ When in the global button buffer, the default is the button at point."
 
 (defun hui:gibut-create (name text)
   "Create a Hyperbole global implicit button with NAME and button TEXT at point.
-Button is stored as the properties of the symbol, 'hbut:current.
+Button is stored as the properties of the symbol, \\='hbut:current.
 
 Use `hui:gbut-create' to create a global explicit button."
   (interactive "sCreate global implicit button named: \nsButton text (with any delimiters): ")

--- a/kotl/kview.el
+++ b/kotl/kview.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:     21-Jun-23 at 21:00:17 by Bob Weiner
+;; Last-Mod:     30-Jun-23 at 21:43:29 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -507,7 +507,7 @@ If between kcells, move to the previous one.  The current cell may be hidden."
 	   ;; only in cases where no 'kcell property is found in cells,
 	   ;; e.g. before in-memory representation is created.
 	   (goto-char (- (match-end 0) 2)))
-	  (t (error "(kcell-view:to-label-end): In cell at pos %d, can't find end of cell's label")))))
+	  (t (error "(kcell-view:to-label-end): In cell at pos %d, can't find end of cell's label" (or pos (point)))))))
 
 (defun kcell-view:absolute-reference (&optional pos)
   "Return a klink to kcell at optional POS or point; return nil if not in a kcell.


### PR DESCRIPTION
## What

Remove some byte compilation warnings

## Details

* hui.el:
  hpath.el:
  hbut.el:
  hbdata.el: Fix single quotes in docstrings.

* kotl/kview.el (kcell-view:to-label-end): Add missing point to error
    message.

* hactypes.el (require): Load hsys-org for org-fold-show-context.
    (link-to-org-id-marker): Use org-fold-show-context.
    (link-to-org-id): Silence byte compile warnings when org-roam not loaded.
