### PR TITLE
Align header fields consistently

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,7 @@
 
 * hyperbole.el: Preload `kotl-autoloads`.  Submitted by Stefan
     Monnier. Thanks Stefan.
+    Align header fields consistently with other files.
 
 2023-06-29  Mats Lidell  <matsl@gnu.org>
 

--- a/hyperbole.el
+++ b/hyperbole.el
@@ -4,16 +4,16 @@
 ;;
 ;; Copyright (C) 1992-2023  Free Software Foundation, Inc.
 
-;; Author:           Bob Weiner
-;; Maintainer:       Bob Weiner <rsw@gnu.org>, Mats Lidell <matsl@gnu.org>
-;; Created:          06-Oct-92 at 11:52:51
-;; Last-Mod:      1-Jul-23 at 10:33:45 by Mats Lidell
-;; Released:         03-Dec-22
-;; Version:          8.0.1pre
-;; Keywords:         comm, convenience, files, frames, hypermedia, languages, mail, matching, mouse, multimedia, outlines, tools, wp
-;; Package:          hyperbole
+;; Author:       Bob Weiner
+;; Maintainer:   Bob Weiner <rsw@gnu.org>, Mats Lidell <matsl@gnu.org>
+;; Created:      06-Oct-92 at 11:52:51
+;; Last-Mod:      1-Jul-23 at 23:42:43 by Mats Lidell
+;; Released:     03-Dec-22
+;; Version:      8.0.1pre
+;; Keywords:     comm, convenience, files, frames, hypermedia, languages, mail, matching, mouse, multimedia, outlines, tools, wp
+;; Package:      hyperbole
 ;; Package-Requires: ((emacs "27.0"))
-;; URL:              http://www.gnu.org/software/hyperbole
+;; URL:          http://www.gnu.org/software/hyperbole
 
 ;; See the "HY-COPY" file for license information.
 


### PR DESCRIPTION
## What

Align header fields consistently.

## Why

Our header field package inserts the fields further to the left so the Last-Mod field is not aligned with the rest of the fields. This PR moves all the other fields to the left similar to how they are set in the other files. Provides an example of how it would look for discussion. 

## Note

The date format for single digit dates looks a bit strange when compared to the dates for creation and release that contains a leading zero.
