### PR TITLE
Update CI to produce a summary page for the warnings during bin target

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,12 @@ jobs:
         run: make clean
 
       - name: Compile
-        run: make bin
+        run: |
+          make bin 2>&1 | tee MAKE_BIN_OUTPUT
+          echo "Number of warnings: $(grep "Warning:" MAKE_BIN_OUTPUT | wc -l)" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          grep "Warning:" MAKE_BIN_OUTPUT >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Test
         run: make test


### PR DESCRIPTION
## What

Add more verbose info about warning messages.

## Why

Getting started with using job summary information. Can potentially be used to fail builds if many warnings are introduced if we think that is a good idea.