### PR TITLE
remove warnings 2023-07-10 default-dir usage

### DIFF
--- a/hargs.el
+++ b/hargs.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    31-Oct-91 at 23:17:35
-;; Last-Mod:     10-Jul-23 at 18:26:29 by Mats Lidell
+;; Last-Mod:     10-Jul-23 at 23:07:12 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -33,6 +33,7 @@
 (require 'hypb)
 (require 'set)
 (require 'info)
+(require 'klink)
 
 ;;; ************************************************************************
 ;;; Public variables
@@ -391,7 +392,7 @@ Handles all of the interactive argument types that `hargs:iform-read' does."
 	      (not (looking-at "^$")))
 	 (if (eq major-mode 'kotl-mode)
 	     (kcell-view:reference
-	      nil (and (boundp 'default-dir) default-dir))
+	      nil (and (boundp 'hypb--klink-default-dir) hypb--klink-default-dir))
 	   (let ((hargs:reading-type 'file))
 	     (list (hargs:at-p)))))
 	((eq hargs:reading-type 'kvspec)

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Jun-89 at 22:08:29
-;; Last-Mod:     11-Jul-23 at 10:22:40 by Mats Lidell
+;; Last-Mod:     11-Jul-23 at 10:23:14 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Jun-89 at 22:08:29
-;; Last-Mod:     10-Jul-23 at 17:55:02 by Mats Lidell
+;; Last-Mod:     11-Jul-23 at 10:22:40 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;

--- a/kotl/klink.el
+++ b/kotl/klink.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Nov-93 at 12:15:16
-;; Last-Mod:     17-Jun-23 at 16:50:34 by Bob Weiner
+;; Last-Mod:     10-Jul-23 at 23:09:59 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -83,6 +83,9 @@
   :type '(list function)
   :group 'hyperbole-koutliner)
 
+(defvar hypb--klink-default-dir nil
+  "Default dir used in hargs.el for argument getting.")
+
 ;;; ************************************************************************
 ;;; Public functions
 ;;; ************************************************************************
@@ -107,9 +110,7 @@ return an absolute klink string.  Klink returned is of the form:
 REFERENCE should be a cell-ref or a string containing \"filename, cell-ref\".
 See documentation for `kcell:ref-to-id' for valid cell-ref formats."
   (interactive
-   ;; Don't change the name or delete default-dir used here.  It is referenced
-   ;; in "hargs.el" for argument getting.
-   (let ((default-dir default-directory))
+   (let ((hypb--klink-default-dir default-directory))
      (barf-if-buffer-read-only)
      (save-excursion
        (hargs:iform-read
@@ -121,7 +122,7 @@ See documentation for `kcell:ref-to-id' for valid cell-ref formats."
   (and (stringp reference) (> (length reference) 0)
        (eq (aref reference 0) ?\()
        (setq reference (replace-regexp-in-string "\\\"" "" reference nil t)))
-  (let ((default-dir default-directory)
+  (let ((hypb--klink-default-dir default-directory)
 	file-ref cell-ref)
     (setq reference (klink:parse reference)
 	  file-ref  (car reference)


### PR DESCRIPTION
## What

Use hypb--klink-default-dir (Based on earlier PR for convenience) See commit 5b3b674ad02c51d5fcacb77433d5c9beaa2cc962 for the actual code that is of interest.

## Why

I want to understand the `default-dir` usage and how we can implement
that in another way. Adding this PR for the discussion.
