### PR TITLE
Add Emacs 29.1 to CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [27.2, 28.1, 28.2, master]
+        version: [27.2, 28.1, 28.2, 29.1, master]
     container: silex/emacs:${{ matrix.version }}-ci
 
     steps:

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-08-02  Mats Lidell  <matsl@gnu.org>
+
+* .github/workflows/main.yml (jobs): Add version 29.1 to CI workflow.
+
 2023-07-30  Bob Weiner  <rsw@gnu.org>
 
 * hyperbole.el (hyperb:init): Fix potential unbound use of vertico-mouse-mode.


### PR DESCRIPTION
## What

Add Emacs 29.1 to the CI workflow checks.

## Why

We want to verify all supported versions of Emacs can successfully build Hyperbole and run the test suite.