### PR TITLE
Let git see el-files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,3 @@ TODO*
 
 # Video Demos
 videos
-*.el


### PR DESCRIPTION
## What

Do not ignore el-files.

## Why

 * Emacs lisp files are the core of the package so most likely what we want git to track. 
 * Tools that respect gitignore also fails to look at Emacs lips files. An example of that is `ripgrep` which makes the setting extra tedious to work with since all searches fail to find things in Emacs lisp files unless explicitly told to look there.   
 * (Possibly and oversight or error that this change was committed!?)