### PR TITLE
First stab at compiling files separately - and remove warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,3 @@ TODO*
 
 # Video Demos
 videos
-*.el

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:     28-Sep-23 at 23:57:18 by Mats Lidell
+# Last-Mod:     29-Sep-23 at 16:43:34 by Mats Lidell
 #
 # Copyright (C) 1994-2023  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -294,7 +294,7 @@ $(data_dir)/hkey-help.txt: $(man_dir)/hkey-help.txt
 
 curr_dir = $(shell pwd)
 .el.elc:
-	@ echo Compile $< 
+	@ echo [[[  Compile $@  ]]] 
 	@ $(EMACS) --batch --quick \
 	--eval "(progn (add-to-list 'load-path \"$(curr_dir)\") (add-to-list 'load-path \"$(curr_dir)/kotl\"))" \
 	-f batch-native-compile $<

--- a/Makefile
+++ b/Makefile
@@ -276,20 +276,29 @@ $(html_dir)/hyperbole.html: $(man_dir)/hyperbole.html $(man_dir)/hyperbole.css
 $(data_dir)/hkey-help.txt: $(man_dir)/hkey-help.txt
 	$(INSTALL) hkey-help.txt $(data_dir)
 
-# Record any .el files that need to be compiled.
+# TODO: Seems to be unused - commented out to allow for .el.elc
+# # Record any .el files that need to be compiled.
+# .el.elc:
+# 	@ echo $< >> $(ELISP_TO_COMPILE)
+
+# # Compile all recorded .el files.
+# elc: elc-init $(ELC_KOTL) $(ELC_COMPILE)
+# 	@- \test ! -f $(ELISP_TO_COMPILE) \
+#             || (echo "These files will be compiled: " \
+#                  && echo "`cat $(ELISP_TO_COMPILE)`" \
+#                  && $(EMACS_BATCH) -f batch-byte-compile `cat $(ELISP_TO_COMPILE)`)
+# 	@ $(RM) $(ELISP_TO_COMPILE)
+
+# elc-init:
+# 	@ $(RM) $(ELISP_TO_COMPILE)
+
+curr_dir = $(shell pwd)
 .el.elc:
-	@ echo $< >> $(ELISP_TO_COMPILE)
+	$(EMACS) --batch --quick \
+	--eval "(progn (add-to-list 'load-path \"$(curr_dir)\") (add-to-list 'load-path \"$(curr_dir)/kotl\"))" \
+	-f batch-byte-compile $<
 
-# Compile all recorded .el files.
-elc: elc-init $(ELC_KOTL) $(ELC_COMPILE)
-	@- \test ! -f $(ELISP_TO_COMPILE) \
-            || (echo "These files will be compiled: " \
-                 && echo "`cat $(ELISP_TO_COMPILE)`" \
-                 && $(EMACS_BATCH) -f batch-byte-compile `cat $(ELISP_TO_COMPILE)`)
-	@ $(RM) $(ELISP_TO_COMPILE)
-
-elc-init:
-	@ $(RM) $(ELISP_TO_COMPILE)
+new-bin: autoloads $(ELC_KOTL) $(ELC_COMPILE)
 
 # Setup to run Hyperbole from .el source files
 src: autoloads tags

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:     27-Aug-23 at 15:19:50 by Bob Weiner
+# Last-Mod:     28-Sep-23 at 23:57:18 by Mats Lidell
 #
 # Copyright (C) 1994-2023  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -294,9 +294,10 @@ $(data_dir)/hkey-help.txt: $(man_dir)/hkey-help.txt
 
 curr_dir = $(shell pwd)
 .el.elc:
-	$(EMACS) --batch --quick \
+	@ echo Compile $< 
+	@ $(EMACS) --batch --quick \
 	--eval "(progn (add-to-list 'load-path \"$(curr_dir)\") (add-to-list 'load-path \"$(curr_dir)/kotl\"))" \
-	-f batch-byte-compile $<
+	-f batch-native-compile $<
 
 new-bin: autoloads $(ELC_KOTL) $(ELC_COMPILE)
 

--- a/hact.el
+++ b/hact.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:     27-Aug-23 at 19:46:10 by Bob Weiner
+;; Last-Mod:     27-Sep-23 at 22:35:06 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -20,6 +20,14 @@
 ;;; ************************************************************************
 
 (eval-and-compile (mapc #'require '(hhist set)))
+
+;;; FIXME: Circular dependencies
+(declare-function hattr:get "hypb")
+(declare-function hattr:list "hypb")
+(declare-function hattr:set "hypb")
+(declare-function hbut:is-p "hypb")
+(declare-function hpath:absolute-arguments "hpath")
+(declare-function hypb:indirect-function "hypb")
 
 ;;; ************************************************************************
 ;;; Public variables

--- a/hargs.el
+++ b/hargs.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    31-Oct-91 at 23:17:35
-;; Last-Mod:     28-Aug-23 at 17:59:39 by Bob Weiner
+;; Last-Mod:     27-Sep-23 at 23:14:10 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -24,6 +24,37 @@
 ;;   types are also provided, see `hargs:iforms-extensions' for details.
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies -- BEGIN
+
+;; Move local variables up before first use
+
+;;; ************************************************************************
+;;; Private variables
+;;; ************************************************************************
+
+(defvar hargs:reading-symbol nil
+  "Remember what symbol is being read.")
+
+(defvar hargs:string-to-complete nil
+  "Minibuffer content the last time a completions buffer was generated, or nil.")
+
+;; Declare package internal functions
+(declare-function ebut:label-p "hbut")
+(declare-function gbut:file "hbut")
+(declare-function hattr:get "hbut")
+(declare-function hbut:label-p "hbut")
+(declare-function hbut:label-to-key "hbut")
+(declare-function hmail:reader-p "hmail")
+(declare-function hui:menu-enter "hui")
+(declare-function ibut:label-p "hbut")
+(declare-function kbd-key:normalize "hib-kbd")
+(declare-function kcell-view:label "kview")
+(declare-function kcell-view:reference "kview")
+(declare-function rmail:msg-id-get "hmail")
+
+;;; FIXME: Circular dependencies -- END
+
 ;;; ************************************************************************
 ;;; Other required Elisp libraries
 ;;; ************************************************************************
@@ -214,6 +245,188 @@ included; any string that matches this regexp is ignored."
 		     (list string start end)
 		   string))))))))
 
+(defmacro hargs:make-iform-vector (&rest iform-alist)
+  "Return a vector of interactive command code characters.
+IFORM-ALIST is a list of elements of the form
+    (INTERACTIVE-CMD-CHR  (ARGUMENT-TYPE . GET-ARGUMENT-FORM))
+GET-ARGUMENT-FORM is executed in a context where it has access to
+two variables `prompt' and `default'."
+  ;; Vector needs to have 1 more elts than the highest char code for
+  ;; interactive commands.
+  (let ((size (1+ (car (sort (mapcar #'car iform-alist) #'>))))
+        (vecsym (make-symbol "vec")))
+    `(let ((,vecsym (make-vector ',size nil)))
+       ,@(mapcar (lambda (elt)
+		   `(aset ,vecsym ',(car elt)
+		          (lambda (prompt default)
+		            (ignore prompt default) ;; Don't warn if not used.
+			    (let ((prev-reading-p hargs:reading-type))
+			      (unwind-protect
+				  (progn
+				    ;; Use setq here to ensure change is
+				    ;; visible in lexical subcontexts that are
+				    ;; part of 'elt' body.
+				    (setq hargs:reading-type ',(cadr elt))
+				    ,(cddr elt))
+				(setq hargs:reading-type prev-reading-p))))))
+		 iform-alist)
+       ,vecsym)))
+
+;;; FIXME: Circular dependencies
+;; Define this after hargs:make-iform-vector macro but before first use.
+(defconst hargs:iform-extensions-vector
+  (hargs:make-iform-vector
+   ;; Get existing Info node name, possibly prefixed with its (filename).
+   (?I . (Info-node . (progn (require 'info)
+			     ;; Prevent empty completions list from
+			     ;; triggering an error in Info-read-node-name.
+			     (unless (and Info-current-file-completions
+					  (not (equal Info-current-file-completions '(("None")))))
+			       (condition-case nil
+				   (Info-build-node-completions)
+				 (error (setq Info-current-file-completions '(("None"))))))
+			     (Info-read-node-name prompt))))
+
+   ;; Get kcell from some koutline.
+   (?K . (kcell . (hargs:read prompt nil default nil 'kcell)))
+   ;; Get kcell or path reference for use in a link.
+   (?L . (klink . (hargs:read prompt nil default nil 'klink)))
+   ;; Get existing mail msg date and file.
+   (?M . (mail . (progn
+		   (while
+		       (or (not (listp
+				 (setq default
+				       (read-minibuffer
+					(hargs:prompt
+					 prompt ""
+					 "list of (date mail-file)")
+					default))))
+			   (/= (length default) 2)
+			   (not (and (stringp (car (cdr default)))
+				     (file-exists-p
+				      (car (cdr default))))))
+		     (beep))
+		   default)))
+   ;; Get a Koutline viewspec.
+   (?V . (kvspec . (hargs:read prompt nil nil nil 'kvspec)))
+   ;; Get existing Info index item name, possibly prefixed with its (filename).
+   (?X . (Info-index-item . (let (file item)
+			      (require 'info)
+			      (setq item (Info-read-index-item-name prompt))
+			      (if (string-match "^(\\([^\)]+\\))\\(.*\\)" item)
+			          item
+			        (if (setq file (Info-current-filename-sans-extension))
+			            (format "(%s)%s" file item)
+			          item))))))
+  "Vector of forms for each interactive command character code.")
+
+(defconst hargs:iform-vector
+  (hargs:make-iform-vector
+   ;; Get function symbol.
+   (?a . (symbol .
+		 (intern (completing-read prompt obarray #'fboundp t default))))
+   ;; Get name of existing buffer.
+   (?b . (buffer .
+		 (progn
+		   (or default (setq default (other-buffer (current-buffer))))
+		   (read-buffer prompt default t))))
+   ;; Get name of possibly nonexistent buffer.
+   (?B . (buffer .
+		 (progn
+		   (or default (setq default (other-buffer (current-buffer))))
+		   (read-buffer prompt default nil))))
+   ;; Get character.
+   (?c . (character .
+		    (progn (message
+			    (if default
+			        (hargs:prompt prompt
+					      (if (integerp default)
+					          (char-to-string default)
+					        default)
+					      "Curr:")
+			      prompt))
+			   (char-to-string (read-char)))))
+   ;; Get symbol for interactive function, a command.
+   (?C . (symbol .
+		 (intern
+		  (completing-read prompt obarray #'commandp t default))))
+   ;; Get value of point; does not do I/O.
+   (?d . (integer . (point)))
+   ;; Get directory name.
+   (?D . (directory .
+		    (progn
+		      (or default (setq default default-directory))
+		      (read-directory-name prompt default default t))))
+   ;; Get existing file name.
+   (?f . (file .
+	       (read-file-name prompt default default
+			       (if (eq system-type 'vax-vms)
+				   nil 'existing))))
+   ;; Get possibly nonexistent file name.
+   (?F . (file . (read-file-name prompt default default nil)))
+   ;; Ignore this argument
+   (?i . nil)
+   ;; Get key sequence.
+   (?k . (key .
+	      (key-description (read-key-sequence
+				(if default
+				    (hargs:prompt prompt default "Curr:")
+				  prompt)))))
+   ;; Get key sequence without converting uppercase or shifted
+   ;; function keys to their unshifted equivalents.
+   (?K . (key .
+	      (key-description (read-key-sequence
+				(if default
+				    (hargs:prompt prompt default "Curr:")
+				  prompt)
+				nil t))))
+   ;; Get value of mark.  Does not do I/O.
+   (?m . (integer . (marker-position (mark-marker))))
+   ;; Get numeric prefix argument or a number from the minibuffer.
+   (?N . (integer .
+		  (if prefix-arg
+		      (prefix-numeric-value prefix-arg)
+		    (let ((arg))
+		      (while (not (integerp
+				   (setq arg (read-minibuffer prompt default))))
+		        (beep))
+		      arg))))
+   ;; Get number from minibuffer.
+   (?n . (integer .
+		  (let ((arg))
+		    (while (not (integerp
+				 (setq arg (read-minibuffer prompt default))))
+		      (beep))
+		    arg)))
+   ;; Get numeric prefix argument.  No I/O.
+   (?p . (prefix-arg .
+		     (prefix-numeric-value prefix-arg)))
+   ;; Get prefix argument in raw form.  No I/O.
+   (?P . (prefix-arg . prefix-arg))
+   ;; Get region, point and mark as 2 args.  No I/O
+   (?r . (region .
+		 (if (marker-position (mark-marker))
+		     (list 'args (min (point) (mark t))
+			   (max (point) (mark t)))
+		   (list 'args nil nil))))
+   ;; Get string.
+   (?s . (string . (read-string prompt default)))
+   ;; Get symbol.
+   (?S . (symbol .
+		 (read-from-minibuffer
+		  prompt default minibuffer-local-ns-map 'sym)))
+   ;; Get variable name: symbol that is user-variable-p.
+   (?v . (symbol . (read-variable
+		    (if default
+			(hargs:prompt prompt default "Curr:")
+		      prompt))))
+   ;; Get Lisp expression but don't evaluate.
+   (?x . (sexpression . (read-minibuffer prompt default)))
+   ;; Get Lisp expression and evaluate.
+   (?X . (sexpression . (eval-minibuffer prompt default))))
+  "Vector of forms for each interactive command character code.")
+;;; FIXME: Circular dependencies -- END
+
 (defun hargs:get (interactive-entry &optional default prior-arg)
   "Prompt for an argument, if need be, from INTERACTIVE-ENTRY, a string.
 Optional DEFAULT is inserted after prompt.
@@ -250,33 +463,6 @@ element of the list is always the symbol \\='args."
 	       (error
 		"(hargs:get): Bad interactive-entry command character: `%c'"
 		cmd))))))
-
-(defmacro hargs:make-iform-vector (&rest iform-alist)
-  "Return a vector of interactive command code characters.
-IFORM-ALIST is a list of elements of the form
-    (INTERACTIVE-CMD-CHR  (ARGUMENT-TYPE . GET-ARGUMENT-FORM))
-GET-ARGUMENT-FORM is executed in a context where it has access to
-two variables `prompt' and `default'."
-  ;; Vector needs to have 1 more elts than the highest char code for
-  ;; interactive commands.
-  (let ((size (1+ (car (sort (mapcar #'car iform-alist) #'>))))
-        (vecsym (make-symbol "vec")))
-    `(let ((,vecsym (make-vector ',size nil)))
-       ,@(mapcar (lambda (elt)
-		   `(aset ,vecsym ',(car elt)
-		          (lambda (prompt default)
-		            (ignore prompt default) ;; Don't warn if not used.
-			    (let ((prev-reading-p hargs:reading-type))
-			      (unwind-protect
-				  (progn
-				    ;; Use setq here to ensure change is
-				    ;; visible in lexical subcontexts that are
-				    ;; part of 'elt' body.
-				    (setq hargs:reading-type ',(cadr elt))
-				    ,(cddr elt))
-				(setq hargs:reading-type prev-reading-p))))))
-		 iform-alist)
-       ,vecsym)))
 
 ;; Replicated from `vertico--match-p' in "vertico.el"
 (defun hargs:match-p (str)
@@ -858,168 +1044,6 @@ Hyperbole menu item help when appropriate."
 	      value)))
 	(when (and back-to (window-live-p owind))
 	  (select-window owind))))))
-
-;;; ************************************************************************
-;;; Private variables
-;;; ************************************************************************
-
-(defvar hargs:reading-symbol nil
-  "Remember what symbol is being read.")
-
-(defconst hargs:iform-vector
-  (hargs:make-iform-vector
-   ;; Get function symbol.
-   (?a . (symbol .
-		 (intern (completing-read prompt obarray #'fboundp t default))))
-   ;; Get name of existing buffer.
-   (?b . (buffer .
-		 (progn
-		   (or default (setq default (other-buffer (current-buffer))))
-		   (read-buffer prompt default t))))
-   ;; Get name of possibly nonexistent buffer.
-   (?B . (buffer .
-		 (progn
-		   (or default (setq default (other-buffer (current-buffer))))
-		   (read-buffer prompt default nil))))
-   ;; Get character.
-   (?c . (character .
-		    (progn (message
-			    (if default
-			        (hargs:prompt prompt
-					      (if (integerp default)
-					          (char-to-string default)
-					        default)
-					      "Curr:")
-			      prompt))
-			   (char-to-string (read-char)))))
-   ;; Get symbol for interactive function, a command.
-   (?C . (symbol .
-		 (intern
-		  (completing-read prompt obarray #'commandp t default))))
-   ;; Get value of point; does not do I/O.
-   (?d . (integer . (point)))
-   ;; Get directory name.
-   (?D . (directory .
-		    (progn
-		      (or default (setq default default-directory))
-		      (read-directory-name prompt default default t))))
-   ;; Get existing file name.
-   (?f . (file .
-	       (read-file-name prompt default default
-			       (if (eq system-type 'vax-vms)
-				   nil 'existing))))
-   ;; Get possibly nonexistent file name.
-   (?F . (file . (read-file-name prompt default default nil)))
-   ;; Ignore this argument
-   (?i . nil)
-   ;; Get key sequence.
-   (?k . (key .
-	      (key-description (read-key-sequence
-				(if default
-				    (hargs:prompt prompt default "Curr:")
-				  prompt)))))
-   ;; Get key sequence without converting uppercase or shifted
-   ;; function keys to their unshifted equivalents.
-   (?K . (key .
-	      (key-description (read-key-sequence
-				(if default
-				    (hargs:prompt prompt default "Curr:")
-				  prompt)
-				nil t))))
-   ;; Get value of mark.  Does not do I/O.
-   (?m . (integer . (marker-position (mark-marker))))
-   ;; Get numeric prefix argument or a number from the minibuffer.
-   (?N . (integer .
-		  (if prefix-arg
-		      (prefix-numeric-value prefix-arg)
-		    (let ((arg))
-		      (while (not (integerp
-				   (setq arg (read-minibuffer prompt default))))
-		        (beep))
-		      arg))))
-   ;; Get number from minibuffer.
-   (?n . (integer .
-		  (let ((arg))
-		    (while (not (integerp
-				 (setq arg (read-minibuffer prompt default))))
-		      (beep))
-		    arg)))
-   ;; Get numeric prefix argument.  No I/O.
-   (?p . (prefix-arg .
-		     (prefix-numeric-value prefix-arg)))
-   ;; Get prefix argument in raw form.  No I/O.
-   (?P . (prefix-arg . prefix-arg))
-   ;; Get region, point and mark as 2 args.  No I/O
-   (?r . (region .
-		 (if (marker-position (mark-marker))
-		     (list 'args (min (point) (mark t))
-			   (max (point) (mark t)))
-		   (list 'args nil nil))))
-   ;; Get string.
-   (?s . (string . (read-string prompt default)))
-   ;; Get symbol.
-   (?S . (symbol .
-		 (read-from-minibuffer
-		  prompt default minibuffer-local-ns-map 'sym)))
-   ;; Get variable name: symbol that is user-variable-p.
-   (?v . (symbol . (read-variable
-		    (if default
-			(hargs:prompt prompt default "Curr:")
-		      prompt))))
-   ;; Get Lisp expression but don't evaluate.
-   (?x . (sexpression . (read-minibuffer prompt default)))
-   ;; Get Lisp expression and evaluate.
-   (?X . (sexpression . (eval-minibuffer prompt default))))
-  "Vector of forms for each interactive command character code.")
-
-(defconst hargs:iform-extensions-vector
-  (hargs:make-iform-vector
-   ;; Get existing Info node name, possibly prefixed with its (filename).
-   (?I . (Info-node . (progn (require 'info)
-			     ;; Prevent empty completions list from
-			     ;; triggering an error in Info-read-node-name.
-			     (unless (and Info-current-file-completions
-					  (not (equal Info-current-file-completions '(("None")))))
-			       (condition-case nil
-				   (Info-build-node-completions)
-				 (error (setq Info-current-file-completions '(("None"))))))
-			     (Info-read-node-name prompt))))
-
-   ;; Get kcell from some koutline.
-   (?K . (kcell . (hargs:read prompt nil default nil 'kcell)))
-   ;; Get kcell or path reference for use in a link.
-   (?L . (klink . (hargs:read prompt nil default nil 'klink)))
-   ;; Get existing mail msg date and file.
-   (?M . (mail . (progn
-		   (while
-		       (or (not (listp
-				 (setq default
-				       (read-minibuffer
-					(hargs:prompt
-					 prompt ""
-					 "list of (date mail-file)")
-					default))))
-			   (/= (length default) 2)
-			   (not (and (stringp (car (cdr default)))
-				     (file-exists-p
-				      (car (cdr default))))))
-		     (beep))
-		   default)))
-   ;; Get a Koutline viewspec.
-   (?V . (kvspec . (hargs:read prompt nil nil nil 'kvspec)))
-   ;; Get existing Info index item name, possibly prefixed with its (filename).
-   (?X . (Info-index-item . (let (file item)
-			      (require 'info)
-			      (setq item (Info-read-index-item-name prompt))
-			      (if (string-match "^(\\([^\)]+\\))\\(.*\\)" item)
-			          item
-			        (if (setq file (Info-current-filename-sans-extension))
-			            (format "(%s)%s" file item)
-			          item))))))
-  "Vector of forms for each interactive command character code.")
-
-(defvar hargs:string-to-complete nil
-  "Minibuffer content the last time a completions buffer was generated, or nil.")
 
 (provide 'hargs)
 

--- a/hbdata.el
+++ b/hbdata.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Apr-91
-;; Last-Mod:     28-Aug-23 at 02:03:25 by Bob Weiner
+;; Last-Mod:     28-Sep-23 at 00:05:15 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -48,6 +48,24 @@
 ;;  source files within it.
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies -- BEGIN
+
+(defvar hbut:instance-sep) ;; defconst in hbut
+(defvar hattr:filename)
+
+(declare-function ibut:label-key-match "hbut")
+(declare-function ibut:label-sort-keys "hbut")
+(declare-function hpath:absolute-arguments "hpath")
+(declare-function hpath:substitute-var "hpath")
+(declare-function hattr:set "hbut")
+(declare-function htz:date-sortable-gmt "htz")
+(declare-function hattr:get "hbut")
+(declare-function hattr:copy "hbut")
+(declare-function ebut:label-to-key "hbut")
+
+;;; FIXME: Circular dependencies -- END
+
 ;;; ************************************************************************
 ;;; Other required Elisp libraries
 ;;; ************************************************************************

--- a/hbmap.el
+++ b/hbmap.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     6-Oct-91 at 06:34:05
-;; Last-Mod:      7-Oct-22 at 23:18:45 by Mats Lidell
+;; Last-Mod:     28-Sep-23 at 00:09:00 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -15,6 +15,32 @@
 ;;; Commentary:
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies -- BEGIN
+
+;;; ************************************************************************
+;;; Private variables
+;;; ************************************************************************
+
+(defvar hyperb:microsoft-os-p) ;; Defined in hload-path.
+
+(defvar hbmap:dir-user
+  (if (and hyperb:microsoft-os-p
+	   (not (getenv "HOME")))
+      "c:/_hyperb/" "~/.hyperb/")
+  "Per user directory in which to store top level Hyperbole map data.
+Must end with a directory separator.
+Hyperbole will try to create it whenever `hyperb:init' is called.")
+
+(defvar hbmap:dir-filename
+  (expand-file-name  "HBMAP" hbmap:dir-user)
+  "Name of a file that lists all dirs to which a user has written buttons.
+See also `hbmap:dir-user'.
+If you change its value, you will be unable to search for buttons created by
+others who use a different value!")
+
+;;; FIXME: Circular dependencies -- END
+
 ;;; ************************************************************************
 ;;; Public variables
 ;;; ************************************************************************
@@ -104,25 +130,6 @@ the error.  Optional NO-SAVE disables saving of the map after operation."
 			  t)
 			 (t 'hbmap-not-writable))))
 	'hbmap-not-readable))))
-
-;;; ************************************************************************
-;;; Private variables
-;;; ************************************************************************
-
-(defvar hbmap:dir-user
-  (if (and hyperb:microsoft-os-p
-	   (not (getenv "HOME")))
-      "c:/_hyperb/" "~/.hyperb/")
-  "Per user directory in which to store top level Hyperbole map data.
-Must end with a directory separator.
-Hyperbole will try to create it whenever `hyperb:init' is called.")
-
-(defvar hbmap:dir-filename
-  (expand-file-name  "HBMAP" hbmap:dir-user)
-  "Name of a file that lists all dirs to which a user has written buttons.
-See also `hbmap:dir-user'.
-If you change its value, you will be unable to search for buttons created by
-others who use a different value!")
 
 (provide 'hbmap)
 

--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:     29-Aug-23 at 01:38:44 by Bob Weiner
+;; Last-Mod:     28-Sep-23 at 00:23:44 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -15,6 +15,59 @@
 ;;; Commentary:
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies -- BEGIN
+
+(defvar hyperb:microsoft-os-p)
+
+;; Move up internal defconst to appear before their use
+(defconst ebut:label-start "<("
+  "String matching the start of a Hyperbole explicit hyper-button.")
+
+(defconst ebut:label-end   ")>"
+  "String matching the end of a Hyperbole explicit hyper-button.")
+
+(defconst hbut:instance-sep ":"
+  "String of one character, separates an ebut label from its instance num.")
+
+;; Move up internal defvar
+(defvar   hattr:filename
+  (if hyperb:microsoft-os-p "_hypb" ".hypb")
+  "Per directory file name in which explicit button attributes are stored.
+If you change its value, you will be unable to use buttons created by
+others who use a different value!")
+
+(defvar   ibut:label-separator-regexp "\\s-*[-:=|]*\\s-+"
+  "Regular expression that separates an implicit button name from its button text.")
+
+(defvar   ibut:label-separator " - "
+  "Default separator string inserted between implicit button name and its text.
+
+This separates it from the implicit button text.  See also
+`ibut:label-separator-regexp' for all valid characters that may be
+manually inserted to separate an implicit button label from its
+text.")
+
+(declare-function hargs:delimited "hargs")
+(declare-function hargs:read-match "hargs")
+(declare-function hpath:find-noselect "hpath")
+(declare-function hpath:find "hpath")
+(declare-function hpath:substitute-var "hpath")
+(declare-function hpath:symlink-referent "hpath")
+(declare-function hpath:www-p "hpath")
+(declare-function hsys-org-block-start-at-p "hsys-org")
+(declare-function hsys-org-src-block-start-at-p "hsys-org")
+(declare-function hui:buf-writable-err "hui")
+(declare-function hui:ebut-rename "hui")
+(declare-function hui:ibut-rename "hui")
+(declare-function hui:key-dir "hui")
+(declare-function hui:key-src "hui")
+(declare-function kbd-key:act "hib-kbd")
+(declare-function kbd-key:is-p "hib-kbd")
+(declare-function org-context "org")
+
+;;; FIXME: Circular dependencies -- END
+
 ;;; ************************************************************************
 ;;; Other required Elisp libraries
 ;;; ************************************************************************
@@ -23,6 +76,16 @@
 				    hmoccur hbmap htz hbdata hact
 				    hui-select view)))
 (require 'hmouse-drv) ; For `hui--ignore-action-key-depress-prev-point'.
+
+;;; FIXME: Circular dependencies -- BEGIN
+;; After require hmoccur
+(defconst hbut:source-prefix moccur-source-prefix
+  "String found at start of a buffer containing only a hyper-button menu.
+This expression should be followed immediately by a file-name indicating the
+source file for the buttons in the menu, if any.")
+
+;;; FIXME: Circular dependencies -- END
+
 
 ;;; ************************************************************************
 ;;; Public declarations
@@ -631,13 +694,6 @@ Insert INSTANCE-FLAG after END, before ending delimiter."
 		    match-keys "\\|")
    "\\)" match-part (regexp-quote ebut:label-end)))
 
-(defconst ebut:label-start "<("
-  "String matching the start of a Hyperbole explicit hyper-button.")
-(defconst ebut:label-end   ")>"
-  "String matching the end of a Hyperbole explicit hyper-button.")
-(defconst hbut:instance-sep ":"
-  "String of one character, separates an ebut label from its instance num.")
-
 ;;; ========================================================================
 ;;; gbut class - Global Hyperbole buttons - activated by typing label name
 ;;; ========================================================================
@@ -904,12 +960,6 @@ Suitable for use as part of `write-file-functions'."
   (put obj-symbol attr-symbol attr-value))
 
 (defalias 'hattr:summarize #'hattr:report)
-
-(defvar   hattr:filename
-  (if hyperb:microsoft-os-p "_hypb" ".hypb")
-  "Per directory file name in which explicit button attributes are stored.
-If you change its value, you will be unable to use buttons created by
-others who use a different value!")
 
 ;;; ========================================================================
 ;;; hbut class - abstract
@@ -1545,11 +1595,6 @@ button label.  Return the symbol for the button, else nil."
 
 (defvar   hbut:current nil
   "The currently selected Hyperbole button.  Available to action routines.")
-
-(defconst hbut:source-prefix moccur-source-prefix
-  "String found at start of a buffer containing only a hyper-button menu.
-This expression should be followed immediately by a file-name indicating the
-source file for the buttons in the menu, if any.")
 
 ;;; ------------------------------------------------------------------------
 
@@ -2767,17 +2812,6 @@ Return the symbol for the button if found, else nil."
   "String matching the start of a Hyperbole implicit button label.")
 (defconst ibut:label-end   "]>"
   "String matching the end of a Hyperbole implicit button label.")
-
-(defvar   ibut:label-separator " - "
-  "Default separator string inserted between implicit button name and its text.
-
-This separates it from the implicit button text.  See also
-`ibut:label-separator-regexp' for all valid characters that may be
-manually inserted to separate an implicit button label from its
-text.")
-
-(defvar   ibut:label-separator-regexp "\\s-*[-:=|]*\\s-+"
-  "Regular expression that separates an implicit button name from its button text.")
 
 ;;; ========================================================================
 ;;; ibtype class - Implicit button types

--- a/hhist.el
+++ b/hhist.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    24-Apr-91 at 03:36:23
-;; Last-Mod:      6-Nov-22 at 12:22:44 by Bob Weiner
+;; Last-Mod:     28-Sep-23 at 00:25:08 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -22,6 +22,20 @@
 ;;   Frames which have been deleted are not restored.
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies -- BEGIN
+;; Move before use
+
+;;; ************************************************************************
+;;; Private variables
+;;; ************************************************************************
+
+(defconst *hhist* nil
+  "List of previously visited Hyperbole button source locations.
+Car of list is most recent.")
+
+;;; FIXME: Circular dependencies -- END
+
 ;;; ************************************************************************
 ;;; Public functions
 ;;; ************************************************************************
@@ -73,14 +87,6 @@ The command is ignored with ARG < 1."
   "Reset history list."
   (interactive)
   (setq *hhist* nil))
-
-;;; ************************************************************************
-;;; Private variables
-;;; ************************************************************************
-
-(defconst *hhist* nil
-  "List of previously visited Hyperbole button source locations.
-Car of list is most recent.")
 
 (provide 'hhist)
 

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:     28-Aug-23 at 16:02:32 by Bob Weiner
+;; Last-Mod:     28-Sep-23 at 00:31:00 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -32,6 +32,22 @@
 ;;      (symset:get 'actypes 'symbols)
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies -- BEGIN
+
+(declare-function actype:eval "hact")
+(declare-function actype:identity "hact")
+(declare-function hact "hact")
+(declare-function hpath:display-buffer "hpath")
+(declare-function htype:def-symbol "hact")
+(declare-function hui:help-ebut-highlight "hui")
+(declare-function hyperb:stack-frame "hversion")
+(declare-function set:member "set")
+(declare-function symset:add "hact")
+(declare-function symtable:add "hact")
+
+;;; FIXME: Circular dependencies -- END
+
 ;;; ************************************************************************
 ;;; Other required Elisp libraries
 ;;; ************************************************************************

--- a/hmail.el
+++ b/hmail.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     9-Oct-91 at 18:38:05
-;; Last-Mod:     23-Apr-23 at 20:08:38 by Mats Lidell
+;; Last-Mod:     28-Sep-23 at 00:33:09 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -31,6 +31,21 @@
 ;;   with Hyperbole.
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies -- BEGIN
+
+;; Move up before first use
+;;; ************************************************************************
+;;; Private variables
+;;; ************************************************************************
+
+(defvar hmail:hbdata-sep "\^Lbd"
+  "Text separating e-mail msg from any trailing Hyperbole button data.")
+
+(declare-function hypb:insert-region "hypb")
+
+;;; FIXME: Circular dependencies -- END
+
 ;;; ************************************************************************
 ;;; Public variables
 ;;; ************************************************************************
@@ -273,13 +288,6 @@ Signals error when current mail reader is not supported."
 ;;; See "hrmail.el" for examples.
 ;;;
 ;;; rmail:get-new, rmail:msg-forward, rmail:summ-msg-to, rmail:summ-new
-
-;;; ************************************************************************
-;;; Private variables
-;;; ************************************************************************
-
-(defvar hmail:hbdata-sep "\^Lbd"
-  "Text separating e-mail msg from any trailing Hyperbole button data.")
 
 (provide 'hmail)
 

--- a/hmh.el
+++ b/hmh.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-May-91 at 17:06:36
-;; Last-Mod:      9-May-22 at 22:36:31 by Bob Weiner
+;; Last-Mod:     28-Sep-23 at 00:34:11 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -29,6 +29,13 @@
 ;;
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies -- BEGIN
+
+(declare-function hypb:window-list "hypb")
+
+;;; FIXME: Circular dependencies -- END
+
 ;;; ************************************************************************
 ;;; Other required Elisp libraries
 ;;; ************************************************************************

--- a/hmoccur.el
+++ b/hmoccur.el
@@ -3,7 +3,7 @@
 ;; Author:       Markus Freericks <Mfx@cs.tu-berlin.de> / Bob Weiner
 ;;
 ;; Orig-Date:     1-Aug-91
-;; Last-Mod:     25-Jul-22 at 20:00:01 by Mats Lidell
+;; Last-Mod:     28-Sep-23 at 00:36:26 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -48,6 +48,13 @@
 ;; C-c C-c gets you to the occurence
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies -- BEGIN
+
+(declare-function hpath:display-buffer "hpath")
+
+;;; FIXME: Circular dependencies -- END
+
 ;;; ************************************************************************
 ;;; Public variables
 ;;; ************************************************************************

--- a/hmouse-drv.el
+++ b/hmouse-drv.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-90
-;; Last-Mod:     12-Aug-23 at 13:19:18 by Bob Weiner
+;; Last-Mod:     28-Sep-23 at 21:30:23 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -15,6 +15,33 @@
 ;;; Commentary:
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies -- BEGIN
+
+(defvar hkey-value) ;; "hui-mouse.el"
+(defvar hmouse-alist) ;; "hui-mouse.el"
+(defvar hkey-alist) ;; "hui-mouse.el"
+(defvar hmouse-set-point-command) ;; "hui-mouse.el"
+
+(defvar hyperbole-mode-map) ;; "hyperbole.el"
+
+(defvar action-key-default-function) ;; defcustom hui-mouse
+(defvar assist-key-default-function) ;; defcustom hui-mouse
+
+(declare-function hkey-quit-window "hmouse-drv") ;; Alias defined in this file!?
+
+(declare-function hattr:report "hbut")
+(declare-function hattr:list "hbut")
+(declare-function br-in-browser "hpath")
+(declare-function hbut:label "hbut")
+(declare-function hattr:get "hbut")
+(declare-function hui:ebut-link-directly "hui")
+(declare-function hui:ibut-link-directly "hui")
+(declare-function hkey-set-key "hyperbole")
+(declare-function org-todo "org")
+
+;;; FIXME: Circular dependencies -- END
+
 ;;; ************************************************************************
 ;;; Other required Elisp libraries
 ;;; ************************************************************************

--- a/hmouse-info.el
+++ b/hmouse-info.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Apr-89
-;; Last-Mod:     20-Jan-23 at 22:19:33 by Mats Lidell
+;; Last-Mod:     28-Sep-23 at 19:55:49 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -19,6 +19,18 @@
 ;;  To install see "hui-mouse.el".
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies -- BEGIN
+(defvar action-key-release-args) ;; hmouse-drv.el
+(defvar assist-key-release-args) ;; hmouse-drv.el
+
+(declare-function first-line-p "hui-mouse")
+(declare-function last-line-p "hui-mouse")
+(declare-function smart-scroll-down "hmouse-drv")
+(declare-function smart-scroll-up "hmouse-drv")
+
+;;; FIXME: Circular dependencies -- END
+
 ;;; ************************************************************************
 ;;; Other required Elisp libraries
 ;;; ************************************************************************

--- a/hmouse-key.el
+++ b/hmouse-key.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    30-May-94 at 00:11:57
-;; Last-Mod:      6-Aug-23 at 12:31:42 by Bob Weiner
+;; Last-Mod:     28-Sep-23 at 21:35:03 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -25,6 +25,35 @@
 ;;   `hmouse-install' has been called.
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies -- BEGIN
+
+(defvar hyperbole-mode-map) ;; "hyperbole.el"
+
+;; Move private vars to top before first use
+
+;;; ************************************************************************
+;;; Private variables
+;;; ************************************************************************
+
+(defvar hmouse-bindings nil
+  "List of (key . binding) pairs for Hyperbole mouse keys.")
+
+(defvar hmouse-bindings-flag nil
+  "True if Hyperbole mouse bindings are in use, else nil.")
+
+(defvar hmouse-previous-bindings nil
+  "List of prior (key . binding) pairs for mouse keys rebound by Hyperbole.")
+
+
+(declare-function hkey-initialize "hbut")
+(declare-function hmouse-get-bindings "hmouse-sh")
+(declare-function hmouse-unshifted-setup "hmouse-sh")
+(declare-function hmouse-shifted-setup "hmouse-sh")
+(declare-function hkey-set-key "hyperbole")
+
+;;; FIXME: Circular dependencies -- END
+
 ;;; ************************************************************************
 ;;; Other required Elisp libraries
 ;;; ************************************************************************
@@ -134,20 +163,6 @@ Use after any programmatic change is made."
   (let ((load-prefer-newer t))
     (mapc #'load '("hui-mouse" "hui-window" "hibtypes" "hactypes")))
   (message "Hyperbole Smart Key and Smart Mouse Key actions have been updated."))
-
-
-;;; ************************************************************************
-;;; Private variables
-;;; ************************************************************************
-
-(defvar hmouse-bindings nil
-  "List of (key . binding) pairs for Hyperbole mouse keys.")
-
-(defvar hmouse-bindings-flag nil
-  "True if Hyperbole mouse bindings are in use, else nil.")
-
-(defvar hmouse-previous-bindings nil
-  "List of prior (key . binding) pairs for mouse keys rebound by Hyperbole.")
 
 (provide 'hmouse-key)
 

--- a/hmouse-sh.el
+++ b/hmouse-sh.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     3-Sep-91 at 21:40:58
-;; Last-Mod:      4-Jul-23 at 12:26:37 by Bob Weiner
+;; Last-Mod:     28-Sep-23 at 20:33:52 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -17,6 +17,26 @@
 ;;   See description in "hmouse-key.el".
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies -- BEGIN
+
+(defvar hmouse-bindings-flag) ; "hmouse-key.el"
+(defvar hmouse-previous-bindings) ; "hmouse-key.el"
+(defvar hmouse-set-point-command) ; "hui-mouse.el"
+(defvar hmouse-bindings) ; "hmouse-key.el"
+(defvar hmouse-bindings-flag) ; "hmouse-key.el"
+
+(defvar Info-mode-map)
+
+(declare-function assist-mouse-key-emacs "hmouse-drv")
+(declare-function assist-key-depress-emacs "hmouse-drv")
+(declare-function action-mouse-key-emacs "hmouse-drv")
+(declare-function action-key-depress-emacs "hmouse-drv")
+(declare-function hkey-set-key "hyperbole")
+(declare-function action-key-depress "hmouse-drv")
+
+;;; FIXME: Circular dependencies -- END
+
 ;;; ************************************************************************
 ;;; Other required Elisp libraries
 ;;; ************************************************************************

--- a/hmouse-tag.el
+++ b/hmouse-tag.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    24-Aug-91
-;; Last-Mod:     28-Aug-23 at 16:19:42 by Bob Weiner
+;; Last-Mod:     28-Sep-23 at 20:41:22 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -15,6 +15,19 @@
 ;;; Commentary:
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies -- BEGIN
+
+(defvar hkey-value) ; "hui-mouse.el"
+
+(declare-function hsys-org-get-value "hsys-org")
+(declare-function org-in-src-block-p "org")
+
+(declare-function xref-item-position "hmouse-tag") ; Forward declare needed? Because of optional defined!?
+(declare-function xref-item-buffer "hmouse-tag") ; Forward declare needed? Because of optional defined!?
+
+;;; FIXME: Circular dependencies -- END
+
 ;;; ************************************************************************
 ;;; Other required Elisp libraries
 ;;; ************************************************************************

--- a/hpath.el
+++ b/hpath.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Nov-91 at 00:44:23
-;; Last-Mod:     28-Aug-23 at 16:48:31 by Bob Weiner
+;; Last-Mod:     28-Sep-23 at 20:56:02 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -15,6 +15,21 @@
 ;;; Commentary:
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies -- BEGIN
+
+(declare-function mm-mailcap-command "mm-decode")
+(declare-function hypb:decode-url "hypb")
+(declare-function hattr:get "hbut")
+(declare-function kbd-key:key-series-to-events "hib-kbd")
+(declare-function hbut:label-to-key "hbut")
+(declare-function hbut:key-to-label "hbut")
+(declare-function hargs:delimited "hargs")
+(declare-function hypb:object-p "hypb")
+(declare-function Info-find-node "info")
+
+;;; FIXME: Circular dependencies -- END
+
 ;;; ************************************************************************
 ;;; Other required Elisp libraries
 ;;; ************************************************************************

--- a/hrmail.el
+++ b/hrmail.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     9-May-91 at 04:22:02
-;; Last-Mod:     23-Apr-23 at 22:16:50 by Mats Lidell
+;; Last-Mod:     28-Sep-23 at 20:59:31 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -23,6 +23,13 @@
 ;;
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies -- BEGIN
+
+(defvar message-setup-hook) ; "message.el"
+
+;;; FIXME: Circular dependencies -- END
+
 ;;; ************************************************************************
 ;;; Other required Elisp libraries
 ;;; ************************************************************************

--- a/hsettings.el
+++ b/hsettings.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Apr-91 at 00:48:49
-;; Last-Mod:     23-Apr-23 at 10:21:31 by Bob Weiner
+;; Last-Mod:     28-Sep-23 at 21:01:09 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -22,6 +22,16 @@
 ;;   support features work as desired.
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies -- BEGIN
+
+(defvar htz:local) ; "htz.el"
+
+(declare-function hyperbole-minibuffer-menu "hui-mini")
+(declare-function hyperbole-menubar-menu "hui-menu")
+
+;;; FIXME: Circular dependencies -- END
+
 ;;; ************************************************************************
 ;;; Other required Elisp libraries
 ;;; ************************************************************************

--- a/hsys-org.el
+++ b/hsys-org.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Jul-16 at 14:54:14
-;; Last-Mod:     27-Aug-23 at 14:29:35 by Bob Weiner
+;; Last-Mod:     28-Sep-23 at 21:05:47 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -26,6 +26,21 @@
 ;;     https://orgmode.org/worg/org-tutorials/orgtutorial_dto.html
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies -- BEGIN
+
+(defvar hyperbole-mode-map) ; "hyperbole.el"
+
+(declare-function smart-eobp "hui-mouse")
+(declare-function smart-eolp "hui-mouse")
+(declare-function hargs:read-match "hargs")
+(declare-function symset:add "hact")
+(declare-function symtable:add "hact")
+(declare-function action-key "hmouse-drv")
+(declare-function hkey-either "hmouse-drv")
+
+;;; FIXME: Circular dependencies -- END
+
 ;;; ************************************************************************
 ;;; Other required Elisp libraries
 ;;; ************************************************************************

--- a/hsys-www.el
+++ b/hsys-www.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Apr-94 at 17:17:39 by Bob Weiner
-;; Last-Mod:     27-Aug-23 at 20:34:24 by Bob Weiner
+;; Last-Mod:     28-Sep-23 at 21:28:20 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -26,6 +26,24 @@
 ;;   generates new ones.
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies -- BEGIN
+
+(defvar hpath:display-where-alist) ; "hpath.el"
+
+(declare-function hpath:remote-available-p "hpath")
+(declare-function hpath:remote-p "hpath")
+(declare-function hpath:remote-at-p "hpath")
+(declare-function hpath:www-at-p "hpath")
+
+;; Forward declare conditionally defined functions to avoid warnings!?
+(declare-function eww-history-property "hsys-www")
+(declare-function eww-bookmark-property "hsys-www")
+(declare-function eww-link-at-point "hsys-www")
+(declare-function shr-link-at-point "hsys-www")
+
+;;; FIXME: Circular dependencies -- END
+
 ;;; ************************************************************************
 ;;; Other required Elisp libraries
 ;;; ************************************************************************

--- a/htz.el
+++ b/htz.el
@@ -3,7 +3,7 @@
 ;; Author:       Masanobu Umeda             / Bob Weiner
 ;;
 ;; Orig-Date:    14-Oct-91 at 07:22:08
-;; Last-Mod:      2-Aug-22 at 15:02:15 by Mats Lidell
+;; Last-Mod:     28-Sep-23 at 21:34:59 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -27,6 +27,72 @@
 ;; created by users in different timezones will sort by time properly.
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies -- BEGIN
+
+;; Move private vars to top before first use
+
+;;; ************************************************************************
+;;; Private variables
+;;; ************************************************************************
+
+(defvar htz:local
+  (let ((local-tz (or (getenv "TZ") (getenv "TIMEZONE")
+		      (if (fboundp 'current-time-zone)
+			  (car (cdr (current-time-zone))))
+		      (progn
+			(require 'hypb)
+			(hypb:call-process-p
+			 "date" nil '(if (re-search-backward
+					  " \\([-+a-zA-Z0-9]+\\) [0-9]+$" nil t)
+					 (buffer-substring (match-beginning 1)
+							   (match-end 1))))))))
+    (if (and (stringp local-tz) (string-match " " local-tz))
+	;; Windows returns things like "Eastern Daylight Time", so
+	;; abbreviate to the first letter of each word.
+	(concat (mapcar (lambda (s) (aref s 0)) (split-string local-tz)))
+      local-tz))
+  "Holds string giving the timezone for the local machine.")
+
+(defvar htz:world-timezones
+  '(("PST" .  -800)
+    ("PDT" .  -700)
+    ("MST" .  -700)
+    ("MDT" .  -600)
+    ("CST" .  -600)
+    ("CDT" .  -500)
+    ("EST" .  -500)
+    ("EDT" .  -400)
+    ("AST" .  -400)
+    ("NST" .  -330)
+    ("UT"  .  +000)
+    ("GMT" .  +000)
+    ("BST" .  +100)
+    ("MET" .  +100)
+    ("EET" .  +200)
+    ("JST" .  +900)
+    ("GMT+1"  .  +100) ("GMT+2"  .  +200) ("GMT+3"  .  +300)
+    ("GMT+4"  .  +400) ("GMT+5"  .  +500) ("GMT+6"  .  +600)
+    ("GMT+7"  .  +700) ("GMT+8"  .  +800) ("GMT+9"  .  +900)
+    ("GMT+10" . +1000) ("GMT+11" . +1100) ("GMT+12" . +1200) ("GMT+13" . +1300)
+    ("GMT-1"  .  -100) ("GMT-2"  .  -200) ("GMT-3"  .  -300)
+    ("GMT-4"  .  -400) ("GMT-5"  .  -500) ("GMT-6"  .  -600)
+    ("GMT-7"  .  -700) ("GMT-8"  .  -800) ("GMT-9"  .  -900)
+    ("GMT-10" . -1000) ("GMT-11" . -1100) ("GMT-12" . -1200))
+  "Time differentials of timezone from GMT in +-HHMM form.
+Use `current-time-zone' instead where possible.")
+
+(defvar htz:months-assoc
+  '(("JAN" .  1)("FEB" .  2)("MAR" .  3)
+    ("APR" .  4)("MAY" .  5)("JUN" .  6)
+    ("JUL" .  7)("AUG" .  8)("SEP" .  9)
+    ("OCT" . 10)("NOV" . 11)("DEC" . 12))
+  "Alist of first three letters of a month and its numerical representation.")
+
+(declare-function hypb:call-process-p "hypb")
+
+;;; FIXME: Circular dependencies -- END
+
 ;;; ************************************************************************
 ;;; Other required Elisp libraries
 ;;; ************************************************************************
@@ -347,65 +413,6 @@ Optional argument TIMEZONE specifies a time zone."
 	    (setq timezone (string-to-number timezone)))
 	(/ timezone 100))
     (error "(htz:zone-to-hour): Nil timezone sent as argument")))
-
-
-;;; ************************************************************************
-;;; Private variables
-;;; ************************************************************************
-
-(defvar htz:local
-  (let ((local-tz (or (getenv "TZ") (getenv "TIMEZONE")
-		      (if (fboundp 'current-time-zone)
-			  (car (cdr (current-time-zone))))
-		      (progn
-			(require 'hypb)
-			(hypb:call-process-p
-			 "date" nil '(if (re-search-backward
-					  " \\([-+a-zA-Z0-9]+\\) [0-9]+$" nil t)
-					 (buffer-substring (match-beginning 1)
-							   (match-end 1))))))))
-    (if (and (stringp local-tz) (string-match " " local-tz))
-	;; Windows returns things like "Eastern Daylight Time", so
-	;; abbreviate to the first letter of each word.
-	(concat (mapcar (lambda (s) (aref s 0)) (split-string local-tz)))
-      local-tz))
-  "Holds string giving the timezone for the local machine.")
-
-(defvar htz:world-timezones
-  '(("PST" .  -800)
-    ("PDT" .  -700)
-    ("MST" .  -700)
-    ("MDT" .  -600)
-    ("CST" .  -600)
-    ("CDT" .  -500)
-    ("EST" .  -500)
-    ("EDT" .  -400)
-    ("AST" .  -400)
-    ("NST" .  -330)
-    ("UT"  .  +000)
-    ("GMT" .  +000)
-    ("BST" .  +100)
-    ("MET" .  +100)
-    ("EET" .  +200)
-    ("JST" .  +900)
-    ("GMT+1"  .  +100) ("GMT+2"  .  +200) ("GMT+3"  .  +300)
-    ("GMT+4"  .  +400) ("GMT+5"  .  +500) ("GMT+6"  .  +600)
-    ("GMT+7"  .  +700) ("GMT+8"  .  +800) ("GMT+9"  .  +900)
-    ("GMT+10" . +1000) ("GMT+11" . +1100) ("GMT+12" . +1200) ("GMT+13" . +1300)
-    ("GMT-1"  .  -100) ("GMT-2"  .  -200) ("GMT-3"  .  -300)
-    ("GMT-4"  .  -400) ("GMT-5"  .  -500) ("GMT-6"  .  -600)
-    ("GMT-7"  .  -700) ("GMT-8"  .  -800) ("GMT-9"  .  -900)
-    ("GMT-10" . -1000) ("GMT-11" . -1100) ("GMT-12" . -1200))
-  "Time differentials of timezone from GMT in +-HHMM form.
-Use `current-time-zone' instead where possible.")
-
-(defvar htz:months-assoc
-  '(("JAN" .  1)("FEB" .  2)("MAR" .  3)
-    ("APR" .  4)("MAY" .  5)("JUN" .  6)
-    ("JUL" .  7)("AUG" .  8)("SEP" .  9)
-    ("OCT" . 10)("NOV" . 11)("DEC" . 12))
-  "Alist of first three letters of a month and its numerical representation.")
-
 
 (provide 'htz)
 

--- a/hui-dired-sidebar.el
+++ b/hui-dired-sidebar.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    25-Jul-20
-;; Last-Mod:     24-Jan-22 at 00:18:47 by Bob Weiner
+;; Last-Mod:     28-Sep-23 at 20:51:37 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -15,6 +15,20 @@
 ;;; Commentary:
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies -- BEGIN
+
+(defvar assist-flag) "hmouse-drv.el"
+(defvar action-key-eol-function) "hmouse-drv.el"
+(defvar assist-key-eol-function) "hmouse-drv.el"
+
+(declare-function dired-get-file-for-visit "dired")
+(declare-function hact "hact")
+(declare-function first-line-p "hui-mouse")
+(declare-function last-line-p "hui-mouse")
+
+;;; FIXME: Circular dependencies -- END
+
 ;;; ************************************************************************
 ;;; Other required Elisp libraries
 ;;; ************************************************************************

--- a/hui-jmenu.el
+++ b/hui-jmenu.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     9-Mar-94 at 23:37:28
-;; Last-Mod:      2-Aug-22 at 19:50:39 by Mats Lidell
+;; Last-Mod:     28-Sep-23 at 21:41:51 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -38,6 +38,25 @@
 ;;   `hui-menu-screen-commands'.
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies -- BEGIN
+
+;; Move private vars to top before first use
+
+;;; ************************************************************************
+;;; Private variables
+;;; ************************************************************************
+
+(defvar hui-menu-buffer-and-mode-list-cache nil
+  "Last set of buffer and mode names used in hui-menu-of-buffers or nil.")
+
+(defvar hui-menu-of-buffers-cache nil
+  "Last menu of `mode-name' ordered buffers from hui-menu-of-buffers or nil.")
+
+(declare-function hui-menu-cutoff-list "hui-menu")
+
+;;; FIXME: Circular dependencies -- END
+
 ;;; ************************************************************************
 ;;; Public functions
 ;;; ************************************************************************
@@ -326,16 +345,6 @@ frame.  The current buffer is buried in the old frame's buffer list."
 	(if (buffer-live-p buf) (kill-buffer buf))
 	t)))
 
-
-;;; ************************************************************************
-;;; Private variables
-;;; ************************************************************************
-
-(defvar hui-menu-buffer-and-mode-list-cache nil
-  "Last set of buffer and mode names used in hui-menu-of-buffers or nil.")
-
-(defvar hui-menu-of-buffers-cache nil
-  "Last menu of `mode-name' ordered buffers from hui-menu-of-buffers or nil.")
 
 ;;; ************************************************************************
 ;;; Public variables

--- a/hui-menu.el
+++ b/hui-menu.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    28-Oct-94 at 10:59:44
-;; Last-Mod:      2-Jul-23 at 04:01:16 by Bob Weiner
+;; Last-Mod:     28-Sep-23 at 21:44:27 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -15,6 +15,28 @@
 ;;; Commentary:
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies -- BEGIN
+
+;; Move private vars to top before first use
+
+;;; ************************************************************************
+;;; Private variables
+;;; ************************************************************************
+
+(defvar hui-menu-max-list-length 24
+  "Positive integer that caps the length of a Hyperbole dynamic menu lists.")
+
+(defvar hui-menu-order-explicit-buttons t
+  "When non-nil (default), explicit button menu list is lexicographically ordered.
+Otherwise, explicit buttons are listed in their order of appearance within
+the current buffer.")
+
+(declare-function gbut:label-list "hbut")
+(declare-function ebut:list "hbut")
+
+;;; FIXME: Circular dependencies -- END
+
 ;;; ************************************************************************
 ;;; Other required Elisp libraries
 ;;; ************************************************************************
@@ -476,18 +498,6 @@ REBUILD-FLAG is non-nil, in which case the menu is rebuilt."
 		 infodock-hyrolo-menu
 		 '("Screen (HyControl)" :filter hui-menu-screen)
 		 hui-menu-hywconfig)))))
-
-;;; ************************************************************************
-;;; Private variables
-;;; ************************************************************************
-
-(defvar hui-menu-max-list-length 24
-  "Positive integer that caps the length of a Hyperbole dynamic menu lists.")
-
-(defvar hui-menu-order-explicit-buttons t
-  "When non-nil (default), explicit button menu list is lexicographically ordered.
-Otherwise, explicit buttons are listed in their order of appearance within
-the current buffer.")
 
 (provide 'hui-menu)
 

--- a/hui-mini.el
+++ b/hui-mini.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Oct-91 at 20:13:17
-;; Last-Mod:      9-Aug-23 at 00:21:49 by Bob Weiner
+;; Last-Mod:     28-Sep-23 at 21:55:10 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -15,6 +15,28 @@
 ;;; Commentary:
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies -- BEGIN
+
+(defvar hargs:reading-type) ; "hargs.el"
+(defvar hui:menu-mode-map) ; "hui.el"
+(defvar hbmap:dir-user) ; "hbmap.el"
+(defvar hbmap:filename) ; "hbmap.el"
+(defvar hui:menu-rolo) ; "hui.el"
+(defvar hyperbole-mode-map) ; "hyperbole.el"
+(defvar hyrolo-add-hook) ; "hyrolo.el"
+(defvar hyrolo-edit-hook) ; "hyrolo.el"
+(defvar hyrolo-file-list) ; "hyrolo.el"
+(defvar org-mode-map) ; "org.el"
+
+(declare-function hpath:find "hpath")
+(declare-function hmouse-update-smart-keys "hmouse-key")
+(declare-function hargs:at-p "hargs")
+(declare-function kbd-key:hyperbole-mini-menu-key-p "hib-kbd")
+
+;;; FIXME: Circular dependencies -- END
+
+
 ;;; ************************************************************************
 ;;; Other required Elisp libraries
 ;;; ************************************************************************

--- a/hui-mouse.el
+++ b/hui-mouse.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-89
-;; Last-Mod:     28-Aug-23 at 01:58:05 by Bob Weiner
+;; Last-Mod:     28-Sep-23 at 22:00:28 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -36,6 +36,20 @@
 ;; Dired listings is exceptionally nice, just as it is when reading mail.
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies -- BEGIN
+
+(declare-function tar-flag-deleted "tar")
+(declare-function tar-unflag "tar")
+(declare-function tar-extract-other-window "tar")
+(declare-function tar-expunge "tar")
+(declare-function outline-invisible-in-p "hyperbole") ; Conditionally defined!?
+(declare-function hyrolo-edit-entry "hyrolo")
+(declare-function Custom-newline "cus-edit")
+(declare-function Custom-buffer-done "cus-edit")
+
+;;; FIXME: Circular dependencies -- END
+
 ;;; ************************************************************************
 ;;; Other required Elisp libraries
 ;;; ************************************************************************

--- a/hui-register.el
+++ b/hui-register.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:     6-Oct-91 at 03:42:38
-;; Last-Mod:     18-Sep-22 at 00:40:52 by Mats Lidell
+;; Last-Mod:     28-Sep-23 at 00:51:29 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -21,6 +21,9 @@
 ;;
 
 (eval-when-compile (require 'cl-lib))
+
+;;; FIXME: Circular dependencies -- BEGIN
+(require 'hload-path) ;; For defining hyperb:microsoft-os-p that us defvar'ed in hbut!?
 
 (require 'hbut)
 

--- a/hui-select.el
+++ b/hui-select.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Oct-96 at 02:25:27
-;; Last-Mod:     21-Jun-23 at 00:25:45 by Bob Weiner
+;; Last-Mod:     28-Sep-23 at 22:10:44 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -103,6 +103,23 @@
 ;;
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies -- BEGIN
+
+(defvar help-mode-syntax-table) ; "help-mode.el"
+(defvar hkey-init) ; "hyperbole.el"
+(defvar hkey-value) ; "hui-mouse.el"
+(defvar hyperbole-mode-map) ; "hyperbole.el"
+(defvar keymap-sym)  ; "???"
+(defvar org-mode-map) ; "org.el"
+(defvar syntax-table-sym) ; "???"
+
+(declare-function kview:valid-position-p "kotl/kview")
+(declare-function hkey-set-key "hyperbole")
+(declare-function hypb:cmd-key-vector "hypb")
+
+;;; FIXME: Circular dependencies -- END
+
 ;;; ************************************************************************
 ;;; Other required Elisp libraries
 ;;; ************************************************************************

--- a/hui-treemacs.el
+++ b/hui-treemacs.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Nov-17
-;; Last-Mod:     19-Jun-22 at 13:58:47 by Bob Weiner
+;; Last-Mod:     28-Sep-23 at 22:17:42 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -25,6 +25,20 @@
 	  (and (require 'package)
 	       (package-installed-p 'treemacs)
 	       (package-activate 'treemacs)))
+
+;;; FIXME: Circular dependencies -- BEGIN
+
+(defvar assist-flag) "hmouse-drv.el"
+(defvar action-key-eol-function) "hmouse-drv.el"
+(defvar assist-key-eol-function) "hmouse-drv.el"
+(defvar action-key-depress-window) "hmouse-drv.el"
+
+(declare-function first-line-p "hui-mouse")
+(declare-function last-line-p "hui-mouse")
+(declare-function hact "hact")
+(declare-function package-activate "package")
+
+;;; FIXME: Circular dependencies -- END
 
 (require 'treemacs)
 

--- a/hui-window.el
+++ b/hui-window.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Sep-92
-;; Last-Mod:     20-Jun-23 at 23:08:18 by Bob Weiner
+;; Last-Mod:     28-Sep-23 at 22:37:03 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -22,6 +22,42 @@
 ;;   "man/hkey-help.txt".
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies -- BEGIN
+
+(defvar action-key-depress-args) ; "hmouse-drv.el"
+(defvar assist-key-depress-args) ; "hmouse-drv.el"
+(defvar action-key-depress-prev-point) ; "hmouse-drv.el"
+(defvar assist-key-depress-prev-point) ; "hmouse-drv.el"
+(defvar action-key-release-prev-point) ; "hmouse-drv.el"
+(defvar assist-key-release-prev-point) ; "hmouse-drv.el"
+(defvar assist-key-depress-window) ; "hmouse-drv.el"
+(defvar action-key-depress-window) ; "hmouse-drv.el"
+(defvar assist-key-release-window) ; "hmouse-drv.el"
+(defvar action-key-release-window) ; "hmouse-drv.el"
+(defvar assist-key-release-args) ; "hmouse-drv.el"
+(defvar action-key-release-args) ; "hmouse-drv.el"
+(defvar hkey-value) ; "hui-mouse.el"
+(defvar hkey-region) ; "hmouse-drv.el"
+(defvar hpath:display-where-alist) ; "hpath.el"
+(defvar hpath:display-where) ; "hpath.el"
+(defvar action-key-modeline-buffer-id-function) ; "hui-mouse.el"
+
+(declare-function hbut:act "hbut")
+(declare-function hbut:action "hbut")
+(declare-function hbut:at-p "hbut")
+(declare-function hkey-summarize "hmouse-drv")
+(declare-function hmouse-save-region "hmouse-drv")
+(declare-function hmouse-use-region-p "hmouse-drv")
+(declare-function hmouse-window-coordinates "hmouse-drv")
+(declare-function smart-helm-alive-p "hui-mouse")
+(declare-function smart-helm-line-has-action "hui-mouse")
+(declare-function smart-helm-to-minibuffer "hui-mouse")
+ 
+;;; FIXME: Circular dependencies -- END
+
+
+
 ;;; ************************************************************************
 ;;; Other required Elisp libraries
 ;;; ************************************************************************

--- a/hui.el
+++ b/hui.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 21:42:03
-;; Last-Mod:     29-Aug-23 at 01:11:29 by Bob Weiner
+;; Last-Mod:     28-Sep-23 at 22:44:35 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -15,6 +15,32 @@
 ;;; Commentary:
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies -- BEGIN
+
+;; Move private vars to top before first use
+
+;;; ************************************************************************
+;;; Private variables
+;;; ************************************************************************
+
+(defvar hui:ebut-label-prev nil
+  "String value of previous button name during an explicit button rename.
+At other times, value must be nil.")
+
+(defvar hui:ignore-buffers-regexp "\\`\\( \\|BLANK\\'\\|\\*Pp \\|TAGS\\|*quelpa\\)"
+  "When prompting for a buffer name, ignore any buffers whose names match to this.")
+
+(defvar hyperbole-mode-map) ; "hyperbole.el"
+
+(declare-function kcell-view:idstamp "kotl/kview")
+(declare-function bookmark-bmenu-bookmark "bookmark")
+(declare-function hui:menu-choose "hui-mini")
+(declare-function kcell-view:absolute-reference "kotl/kview")
+(declare-function klink:absolute "kotl/klink")
+
+;;; FIXME: Circular dependencies -- END
+
 ;;; ************************************************************************
 ;;; Other required Elisp libraries
 ;;; ************************************************************************
@@ -1406,9 +1432,6 @@ Trigger an error if DEFAULT-ACTYPE is invalid."
       (pop-to-buffer but-buf)
       (hypb:error err))))
 
-(defvar hui:ignore-buffers-regexp "\\`\\( \\|BLANK\\'\\|\\*Pp \\|TAGS\\|*quelpa\\)"
-  "When prompting for a buffer name, ignore any buffers whose names match to this.")
-
 (defun hui:ebut-delete-op (interactive but-key key-src)
   "INTERACTIVEly or not, delete explicit button given by BUT-KEY in KEY-SRC.
 KEY-SRC may be a buffer or a pathname; when nil, the current
@@ -1914,15 +1937,6 @@ Buffer without File      link-to-buffer-tmp"
   "Return LST, a list, with text properties removed from any string elements."
   (mapcar (lambda (elt) (if (stringp elt) (substring-no-properties elt) elt))
 	  lst))
-
-;;; ************************************************************************
-;;; Private variables
-;;; ************************************************************************
-
-
-(defvar hui:ebut-label-prev nil
-  "String value of previous button name during an explicit button rename.
-At other times, value must be nil.")
 
 (provide 'hui)
 

--- a/hversion.el
+++ b/hversion.el
@@ -4,7 +4,7 @@
 ;; Maintainer:   Bob Weiner, Mats Lidell
 ;;
 ;; Orig-Date:     1-Jan-94
-;; Last-Mod:     27-Aug-23 at 15:26:39 by Bob Weiner
+;; Last-Mod:     28-Sep-23 at 23:02:16 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -16,6 +16,15 @@
 ;;; Commentary:
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies -- BEGIN
+
+(declare-function hpath:substitute-value "hpath")
+(declare-function id-info-item "hversion") ;; Forward declared - rearrange order will fix this
+(declare-function br-in-browser "hpath")
+
+;;; FIXME: Circular dependencies -- END
+
 ;;; ************************************************************************
 ;;; Other required Elisp libraries
 ;;; ************************************************************************

--- a/hycontrol.el
+++ b/hycontrol.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Jun-16 at 15:35:36
-;; Last-Mod:     23-Aug-23 at 15:09:00 by Bob Weiner
+;; Last-Mod:     28-Sep-23 at 21:37:52 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -120,6 +120,16 @@
 ;;   text face.
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies -- BEGIN
+
+(defvar hyperbole-mode-map) ; "hyperbole.el"
+(defvar org-mode-map) ; "org.el"
+(defvar outline-mode-map) ; "outline.el"
+(defvar outline-minor-mode-map) ; "outline.el"
+
+;;; FIXME: Circular dependencies -- END
+
 ;;; ************************************************************************
 ;;; Other required Elisp libraries
 ;;; ************************************************************************

--- a/hypb.el
+++ b/hypb.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     6-Oct-91 at 03:42:38
-;; Last-Mod:     27-Aug-23 at 17:15:52 by Bob Weiner
+;; Last-Mod:     28-Sep-23 at 23:04:51 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -15,6 +15,16 @@
 ;;; Commentary:
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies -- BEGIN
+
+(defvar hyperb:user-email) ; "hinit.el"
+
+(declare-function hkey-either "hmouse-drv")
+(declare-function hycontrol-frame-to-right-center "hycontrol")
+
+;;; FIXME: Circular dependencies -- END
+
 ;;; ************************************************************************
 ;;; Other required Elisp libraries
 ;;; ************************************************************************

--- a/hyperbole.el
+++ b/hyperbole.el
@@ -7,7 +7,7 @@
 ;; Author:       Bob Weiner
 ;; Maintainer:   Bob Weiner <rsw@gnu.org>, Mats Lidell <matsl@gnu.org>
 ;; Created:      06-Oct-92 at 11:52:51
-;; Last-Mod:     27-Aug-23 at 13:04:09 by Bob Weiner
+;; Last-Mod:     28-Sep-23 at 23:11:06 by Mats Lidell
 ;; Released:     03-Dec-22
 ;; Version:      8.0.1pre
 ;; Keywords:     comm, convenience, files, frames, hypermedia, languages, mail, matching, mouse, multimedia, outlines, tools, wp
@@ -74,6 +74,21 @@
 ;; Other site-specific customizations belong in "hsettings.el".
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies -- BEGIN
+
+(defvar Info-directory-list) ; "info.el"
+
+(declare-function info-initialize "info")
+(declare-function hmouse-install "hmouse-key")
+(declare-function hui-search-web "hui-mini")
+(declare-function hkey-operate "hmouse-drv")
+(declare-function facemenu-keymap "???")
+(declare-function hkey-help "hmouse-drv")
+(declare-function hkey-either "hmouse-drv")
+
+;;; FIXME: Circular dependencies -- END
+
 ;;; ************************************************************************
 ;;; Start Initializations
 ;;; ************************************************************************

--- a/hyrolo-logic.el
+++ b/hyrolo-logic.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    13-Jun-89 at 22:57:33
-;; Last-Mod:     24-Oct-22 at 22:49:42 by Bob Weiner
+;; Last-Mod:     28-Sep-23 at 23:48:53 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -58,6 +58,13 @@
 ;;   displayed quickly.
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies -- BEGIN
+
+(declare-function kotl-mode:goto-cell "kotl/kotl-mode")
+
+;;; FIXME: Circular dependencies -- END
+
 ;;; ************************************************************************
 ;;; Other required Elisp libraries
 ;;; ************************************************************************

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Jun-89 at 22:08:29
-;; Last-Mod:     28-Aug-23 at 01:11:54 by Bob Weiner
+;; Last-Mod:     28-Sep-23 at 23:53:51 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -23,6 +23,111 @@
 ;;  See the Info manual entry "(hyperbole)HyRolo" for usage information.
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies -- BEGIN
+
+;; Forward declare for now before moving to top
+(defvar hyrolo--wconfig)
+(defvar hyrolo-entry-group-number)
+(defvar hyrolo-entry-trailing-space-group-number)
+(defvar hyrolo-hdr-format)
+(defvar hyrolo-hdr-regexp)
+(defvar hyrolo-match-regexp)
+(defvar hyrolo-mode-map)
+(defvar hyrolo-mode-syntax-table)
+
+(defvar org-directory) ; "org.el"
+(defvar markdown-regex-header) ; "markdown-mode.el"
+(defvar google-contacts-buffer-name) ; "ext:google-contacts.el"
+
+; Aliases should be declared before its referent BEGIN
+(define-obsolete-variable-alias 'rolo-display-buffer 'hyrolo-display-buffer "06.00")
+(defvar hyrolo-display-buffer "*HyRolo*"
+  "Buffer used to display set of last matching rolo entries.")
+
+;; Need to define the group before the defcustom variable so moved it here.
+(defgroup hyperbole-rolo nil
+  "Hyperbole Rolo hierarchical contact manager customizations."
+  :group 'hyperbole)
+
+(defcustom hyrolo-google-contacts-flag t
+  "Non-nil means search Google Contacts on each hyrolo query.
+The google-contact package must be loaded and a gpg encryption
+executable must be found as well (for Oauth security)."
+  :type 'boolean)
+
+(defun hyrolo-google-contacts-p ()
+  "Non-nil means google contacts package is available and feature is enabled.
+Requires `hyrolo-google-contacts-flag' set as non-nil and
+google-contacts package and gpg executables to be available for
+use."
+  (and hyrolo-google-contacts-flag
+       (featurep 'google-contacts)
+       (boundp 'google-contacts-buffer-name)
+       ;; If no gpg encryption executable, Oauth login to Google will fail.
+       (or (executable-find "gpg2") (executable-find "gpg"))))
+
+(defun hyrolo--initialize-file-list ()
+  (delq nil
+        (list "~/.rolo.otl"
+              (if (and (boundp 'bbdb-file) (stringp bbdb-file)) bbdb-file)
+              (when (hyrolo-google-contacts-p) google-contacts-buffer-name))))
+
+(define-obsolete-variable-alias 'rolo-file-list 'hyrolo-file-list "06.00")
+(defcustom hyrolo-file-list (hyrolo--initialize-file-list)
+  "List of files containing rolo entries.
+The first file should be a user-specific rolo file, typically in the home
+directory.
+
+A hyrolo-file consists of:
+   (1) an optional header beginning with and ending with a line which matches
+       hyrolo-hdr-regexp;
+   (2) one or more rolo entries which each begin with
+       hyrolo-entry-regexp and may be nested."
+  :type '(repeat file))
+
+(define-obsolete-variable-alias 'rolo-entry-regexp 'hyrolo-entry-regexp "06.00")
+(defvar hyrolo-entry-regexp "^\\(\\*+\\)\\([ \t]+\\)"
+  "Regular expression to match the beginning of a rolo entry.
+This pattern must match the beginning of a line.
+`hyrolo-entry-group-number' must capture the entry's level in the
+hierarchy.  `hyrolo-entry-trailing-space-group-number' must capture
+the whitespace following the entry hierarchy level.")
+
+;; Support hyrolo searches in markdown files
+(add-hook 'markdown-mode-hook
+	  (lambda ()
+	    (make-local-variable 'hyrolo-entry-regexp)
+	    (make-local-variable 'hyrolo-entry-group-number)
+	    (make-local-variable 'hyrolo-entry-trailing-space-group-number)
+	    (setq hyrolo-entry-regexp markdown-regex-header
+		  hyrolo-entry-group-number 4
+		  ;; `hyrolo-add' handles removing # prefix from
+		  ;; trailing-space grouping below
+		  hyrolo-entry-trailing-space-group-number 4)))
+;; Aliases should be declared before its referent END
+
+(declare-function find-library-name "find-func")
+(declare-function hbut:to-key-src "hbut")
+(declare-function hui:hbut-act "hui")
+(declare-function ibut:at-p "hbut")
+(declare-function kcell-view:indent "kotl/kview")
+(declare-function outline-back-to-heading "outline")
+(declare-function outline-backward-same-level "outline")
+(declare-function outline-end-of-subtree "outline")
+(declare-function outline-forward-same-level "outline")
+(declare-function outline-hide-sublevels "outline")
+(declare-function outline-hide-subtree "outline")
+(declare-function outline-level "outline")
+(declare-function outline-next-heading "outline")
+(declare-function outline-next-visible-heading "outline")
+(declare-function outline-previous-heading "outline")
+(declare-function outline-previous-visible-heading "outline")
+(declare-function outline-show-all "outline")
+(declare-function outline-up-heading "outline")
+
+;;; FIXME: Circular dependencies -- END
+
 ;;; ************************************************************************
 ;;; Other required Elisp libraries
 ;;; ************************************************************************
@@ -82,10 +187,6 @@
 ;;; Public variables
 ;;; ************************************************************************
 
-(defgroup hyperbole-rolo nil
-  "Hyperbole Rolo hierarchical contact manager customizations."
-  :group 'hyperbole)
-
 (defcustom hyrolo-date-format "%m/%d/%Y"
   "Format of date string used in Rolo automatic date stamps.
 Default is American style.  See documentation of the function
@@ -120,12 +221,6 @@ Use the `hyrolo-edit' function instead to edit a new or existing entry."
   "Function used by HyRolo to read `hyrolo-file-list' files into Emacs."
   :type 'function)
 
-(defcustom hyrolo-google-contacts-flag t
-  "Non-nil means search Google Contacts on each hyrolo query.
-The google-contact package must be loaded and a gpg encryption
-executable must be found as well (for Oauth security)."
-  :type 'boolean)
-
 (defvar hyrolo-next-match-function #'hyrolo-next-regexp-match
   "Value is the function to find next match within a HyRolo file.
 Must take two arguments, `match-pattern' and `headline-only-flag'.
@@ -142,24 +237,7 @@ match is found.")
 
 (defvar hproperty:highlight-face)
 
-(defun hyrolo-google-contacts-p ()
-  "Non-nil means google contacts package is available and feature is enabled.
-Requires `hyrolo-google-contacts-flag' set as non-nil and
-google-contacts package and gpg executables to be available for
-use."
-  (and hyrolo-google-contacts-flag
-       (featurep 'google-contacts)
-       (boundp 'google-contacts-buffer-name)
-       ;; If no gpg encryption executable, Oauth login to Google will fail.
-       (or (executable-find "gpg2") (executable-find "gpg"))))
-
 ;; '("~/.rolo.otl" "~/.rolo.org")
-
-(defun hyrolo--initialize-file-list ()
-  (delq nil
-        (list "~/.rolo.otl"
-              (if (and (boundp 'bbdb-file) (stringp bbdb-file)) bbdb-file)
-              (when (hyrolo-google-contacts-p) google-contacts-buffer-name))))
 
 ;;;###autoload
 (defun hyrolo-initialize-file-list (&optional force-init-flag)
@@ -171,19 +249,6 @@ use."
     (when (called-interactively-p 'interactive)
       (message "HyRolo Search List: %S" hyrolo-file-list))
     hyrolo-file-list))
-
-(define-obsolete-variable-alias 'rolo-file-list 'hyrolo-file-list "06.00")
-(defcustom hyrolo-file-list (hyrolo--initialize-file-list)
-  "List of files containing rolo entries.
-The first file should be a user-specific rolo file, typically in the home
-directory.
-
-A hyrolo-file consists of:
-   (1) an optional header beginning with and ending with a line which matches
-       hyrolo-hdr-regexp;
-   (2) one or more rolo entries which each begin with
-       hyrolo-entry-regexp and may be nested."
-  :type '(repeat file))
 
 (defcustom hyrolo-highlight-face 'match
   "Face used to highlight rolo search matches."
@@ -1110,7 +1175,7 @@ Return number of matching entries found."
       (insert "No result.")
     (print contacts (get-buffer-create "*contacts-data*"))
     (dolist (contact contacts)
-      (let* ((child)
+      (let* ((child nil)
 	     (name-value (nth 0 (xml-get-children contact 'gd:name)))
              (fullname (xml-node-child-string (nth 0 (xml-get-children name-value 'gd:fullName))))
              (givenname (xml-node-child-string (nth 0 (xml-get-children name-value 'gd:givenName))))
@@ -1995,36 +2060,12 @@ Return final point."
 ;;; Private variables
 ;;; ************************************************************************
 
-(define-obsolete-variable-alias 'rolo-display-buffer 'hyrolo-display-buffer "06.00")
-(defvar hyrolo-display-buffer "*HyRolo*"
-  "Buffer used to display set of last matching rolo entries.")
-
 (defvar hyrolo-entry-group-number 1
   "Group number whose length represents the level of any entry matched.
 See `hyrolo-entry-regexp'")
 
 (defvar hyrolo-entry-trailing-space-group-number 2
   "Group number within `hyrolo-entry-regexp; containing trailing space.")
-
-(define-obsolete-variable-alias 'rolo-entry-regexp 'hyrolo-entry-regexp "06.00")
-(defvar hyrolo-entry-regexp "^\\(\\*+\\)\\([ \t]+\\)"
-  "Regular expression to match the beginning of a rolo entry.
-This pattern must match the beginning of a line.
-`hyrolo-entry-group-number' must capture the entry's level in the
-hierarchy.  `hyrolo-entry-trailing-space-group-number' must capture
-the whitespace following the entry hierarchy level.")
-
-;; Support hyrolo searches in markdown files
-(add-hook 'markdown-mode-hook
-	  (lambda ()
-	    (make-local-variable 'hyrolo-entry-regexp)
-	    (make-local-variable 'hyrolo-entry-group-number)
-	    (make-local-variable 'hyrolo-entry-trailing-space-group-number)
-	    (setq hyrolo-entry-regexp markdown-regex-header
-		  hyrolo-entry-group-number 4
-		  ;; `hyrolo-add' handles removing # prefix from
-		  ;; trailing-space grouping below
-		  hyrolo-entry-trailing-space-group-number 4)))
 
 (defconst hyrolo-hdr-format
   (concat

--- a/kotl/kcell.el
+++ b/kotl/kcell.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-May-93
-;; Last-Mod:     28-Aug-23 at 00:23:39 by Bob Weiner
+;; Last-Mod:     27-Sep-23 at 21:47:35 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -27,11 +27,15 @@
 ;;   separately.  This also allows fast retrieval.
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies
+(require 'kproperty)
+
 ;;; ************************************************************************
 ;;; Other required Elisp libraries
 ;;; ************************************************************************
 
-(eval-and-compile (mapc #'require '(hinit htz klabel kview)))
+(eval-and-compile (mapc #'require '(hinit htz kview)))
 
 ;;; ************************************************************************
 ;;; Public variables

--- a/kotl/kcell.el
+++ b/kotl/kcell.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-May-93
-;; Last-Mod:     27-Sep-23 at 21:47:35 by Mats Lidell
+;; Last-Mod:     29-Sep-23 at 16:31:47 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -169,7 +169,7 @@ Augment capabilities not yet implemented and ignored for now:
 		       (save-excursion
 			 (goto-char (point-min))
 			 (when (re-search-forward (concat "^[ \t]*" (regexp-quote idstamp-string)
-							  (regexp-quote (kview:label-separator kview)))
+							  (regexp-quote (kview:label-separator hypb-kview)))
 						  nil t)
 
 			   (setq idstamp-string (kcell-view:idstamp))
@@ -225,7 +225,7 @@ assuming it is the cell at point and filling in the missing information."
 	 (vector idstamp plist)
        (kcell-data:create
 	(kcell:create plist)
-	(or idstamp (kview:id-increment kview))))))
+	(or idstamp (kview:id-increment hypb-kview))))))
 
 (defun kcell-data:idstamp (kcell-data)
   (aref kcell-data 0))

--- a/kotl/kexport.el
+++ b/kotl/kexport.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    26-Feb-98
-;; Last-Mod:     28-Aug-23 at 02:14:28 by Bob Weiner
+;; Last-Mod:     29-Sep-23 at 16:32:17 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -485,7 +485,7 @@ used.  Also converts Urls and Klinks into Html hyperlinks.
 		(replace-regexp-in-string
 		 ">" "&gt;"
 		 (replace-regexp-in-string
-		  "<" "&lt;" (kview:label-separator kview))))
+		  "<" "&lt;" (kview:label-separator hypb-kview))))
                no-sibling-stack)
 
           (princ "<ul>\n")
@@ -513,7 +513,7 @@ used.  Also converts Urls and Klinks into Html hyperlinks.
                    (while (pop no-sibling-stack)
                      (princ "</ul>\n")
                      (princ "</li>\n"))))))
-	   kview t)
+	   hypb-kview t)
 
           (princ "</ul>\n")
 

--- a/kotl/kfile.el
+++ b/kotl/kfile.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    10/31/93
-;; Last-Mod:     28-Aug-23 at 00:23:33 by Bob Weiner
+;; Last-Mod:     27-Sep-23 at 20:54:08 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -19,7 +19,7 @@
 ;;; Other required Elisp libraries
 ;;; ************************************************************************
 
-(eval-and-compile (mapc #'require '(kproperty kmenu kview)))
+(eval-and-compile (mapc #'require '(kproperty kmenu kview kvspec kcell)))
 
 ;;; ************************************************************************
 ;;; Public variables

--- a/kotl/kfile.el
+++ b/kotl/kfile.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    10/31/93
-;; Last-Mod:     27-Sep-23 at 20:54:08 by Mats Lidell
+;; Last-Mod:     29-Sep-23 at 16:39:47 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -60,11 +60,11 @@ Return the new kview."
     ;; Finding the file may have already done a kfile:read as invoked through
     ;; kotl-mode via a file local variable setting.  If so, don't read it
     ;; again.
-    (unless (kview:is-p kview)
+    (unless (kview:is-p hypb-kview)
       (kfile:read buffer existing-file))
     (unless (derived-mode-p 'kotl-mode)
       (kotl-mode))
-    kview))
+    hypb-kview))
 
 ;;;###autoload
 (defun kfile:is-p ()
@@ -259,12 +259,12 @@ If V3-FLAG is true, read as a version-3 buffer."
   "Update kfile internal structure so that view is ready for saving to a file.
 Leave outline file expanded with structure data showing unless optional
 VISIBLE-ONLY-P is non-nil.  Signal an error if kotl is not attached to a file."
-  (let* ((top (kview:top-cell kview))
+  (let* ((top (kview:top-cell hypb-kview))
 	 (file buffer-file-name)
-	 (label-type (kview:label-type kview))
-	 (label-min-width (kview:label-min-width kview))
-	 (label-separator (kview:label-separator kview))
-	 (level-indent (kview:level-indent kview))
+	 (label-type (kview:label-type hypb-kview))
+	 (label-min-width (kview:label-min-width hypb-kview))
+	 (label-separator (kview:label-separator hypb-kview))
+	 (level-indent (kview:level-indent hypb-kview))
 	 ;; If this happens to be non-nil, it is virtually impossible to save
 	 ;; a file, so ensure it is nil.
 	 (debug-on-error))
@@ -289,7 +289,7 @@ VISIBLE-ONLY-P is non-nil.  Signal an error if kotl is not attached to a file."
 		kcell-num
 		(kcell-data:create cell (kcell-view:idstamp-integer)))
 	  (setq kcell-num (1+ kcell-num)))
-	kview t)
+	hypb-kview t)
       ;; Save top cell, 0, last since above loop may increment the total
       ;; number of cells counter stored in it, if any invalid cells are
       ;; encountered.
@@ -351,7 +351,7 @@ VISIBLE-ONLY-P is non-nil.  Signal an error if kotl is not attached to a file."
   (set-buffer-modified-p t)
   ;; This next line must come before the save-buffer so write-file-functions
   ;; can make use of it.
-  (kview:set-buffer kview (current-buffer))
+  (kview:set-buffer hypb-kview (current-buffer))
   (save-buffer))
 
 ;;; ************************************************************************
@@ -405,8 +405,8 @@ hidden."
 	    (setq kcell-data (car kcell-list)
 		  ;; Repair invalid idstamps on the fly.
 		  idstamp (if (vectorp kcell-data)
-			      (or (kcell-data:idstamp kcell-data) (kview:id-increment kview))
-			    (kview:id-increment kview)))
+			      (or (kcell-data:idstamp kcell-data) (kview:id-increment hypb-kview))
+			    (kview:id-increment hypb-kview)))
 	    (kproperty:set 'idstamp idstamp)
 	    (kproperty:set 'kcell (car kcell-list))
 	    (setq kcell-list (cdr kcell-list)))
@@ -431,8 +431,8 @@ hidden."
 	    (setq kcell-data (aref kcell-vector kcell-num)
 		  ;; Repair invalid idstamps on the fly.
 		  idstamp (if (vectorp kcell-data)
-			      (or (kcell-data:idstamp kcell-data) (kview:id-increment kview))
-			    (kview:id-increment kview)))
+			      (or (kcell-data:idstamp kcell-data) (kview:id-increment hypb-kview))
+			    (kview:id-increment hypb-kview)))
 	    (kproperty:set 'idstamp idstamp)
 	    (kproperty:set 'kcell (kcell-data:to-kcell-v3 kcell-data))
 	    (setq kcell-num (1+ kcell-num)))
@@ -441,7 +441,7 @@ hidden."
 (defun kfile:narrow-to-kcells ()
   "Narrow kotl file to kcell section only."
   (interactive)
-  (when (kview:is-p kview)
+  (when (kview:is-p hypb-kview)
     (let ((start-text) (end-text))
       (save-excursion
 	(widen)

--- a/kotl/kfill.el
+++ b/kotl/kfill.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    23-Jan-94
-;; Last-Mod:      8-Aug-23 at 23:10:00 by Bob Weiner
+;; Last-Mod:     27-Sep-23 at 21:01:38 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -16,6 +16,9 @@
 ;;; Commentary:
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies
+(declare-function kcell-view:indent "kcell")
 
 ;;; ************************************************************************
 ;;; Public variables

--- a/kotl/kimport.el
+++ b/kotl/kimport.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Nov-93 at 11:57:05
-;; Last-Mod:     27-Sep-23 at 21:12:26 by Mats Lidell
+;; Last-Mod:     29-Sep-23 at 16:31:47 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -612,7 +612,7 @@ will be added as children of the cell where this function leaves point
 	(widen)
 	(delete-region (point-min) (point-max)))
       (unless (kfile:is-p)
-	(setq kview nil)
+	(setq hypb-kview nil)
 	(kotl-mode))))
   output-to)
 

--- a/kotl/kimport.el
+++ b/kotl/kimport.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Nov-93 at 11:57:05
-;; Last-Mod:      7-May-23 at 16:11:58 by Bob Weiner
+;; Last-Mod:     27-Sep-23 at 21:12:26 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -21,6 +21,9 @@
 
 (require 'kfile)
 (require 'hyrolo)
+
+;;; FIXME: Circular dependencies
+(require 'klabel)
 
 ;;; ************************************************************************
 ;;; Public variables

--- a/kotl/klabel.el
+++ b/kotl/klabel.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    17-Apr-94
-;; Last-Mod:     27-Sep-23 at 21:14:53 by Mats Lidell
+;; Last-Mod:     29-Sep-23 at 16:35:57 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -37,7 +37,7 @@
 
 (defun klabel:child (label)
   "Return LABEL's child cell label."
-  (funcall (kview:get-attr kview 'label-child) label))
+  (funcall (kview:get-attr hypb-kview 'label-child) label))
 
 (defun klabel:idstamp-p (label)
   "Return t if LABEL is an idstamp label, else nil."
@@ -48,12 +48,12 @@
 
 (defun klabel:increment (label)
   "Return LABEL's sibling label."
-  (funcall (kview:get-attr kview 'label-increment) label))
+  (funcall (kview:get-attr hypb-kview 'label-increment) label))
 
 (defun klabel:format (label)
   "Format a generic cell LABEL (a string) and return the display type.
 Return the proper display type for the current kview."
-  (let ((label-type (or (kview:get-attr kview 'label-type) kview:default-label-type)))
+  (let ((label-type (or (kview:get-attr hypb-kview 'label-type) kview:default-label-type)))
     (cond ((memq label-type '(alpha id legal partial-alpha))
 	   label)
 	  ((eq label-type 'no) "")
@@ -63,7 +63,7 @@ Return the proper display type for the current kview."
 
 (defun klabel:level (label)
   "Return outline level of LABEL using current kview label type."
-  (let ((label-type (kview:label-type kview)))
+  (let ((label-type (kview:label-type hypb-kview)))
     (cond ((memq label-type '(alpha legal))
 	   (funcall (intern-soft (concat "klabel:level-"
 					 (symbol-name label-type)))
@@ -77,7 +77,7 @@ Return the proper display type for the current kview."
 
 (defun klabel:parent (label)
   "Return LABEL's parent label."
-  (funcall (kview:get-attr kview 'label-parent) label))
+  (funcall (kview:get-attr hypb-kview 'label-parent) label))
 
 ;;;
 ;;; klabel-type - kview-specific label type functions
@@ -92,7 +92,7 @@ Return the proper display type for the current kview."
 	((eq label-type 'star)
 	 (lambda (label) (concat label "*")))
 	((eq label-type 'id)
-	 (lambda (_label) (format "0%s" (or (kview:id-counter kview) ""))))
+	 (lambda (_label) (format "0%s" (or (kview:id-counter hypb-kview) ""))))
 	(t (error
 	    "(klabel-type:child): Invalid label type setting: `%s'"
 	    label-type))))
@@ -109,7 +109,7 @@ is computed."
 	((eq label-type 'star)
 	 (lambda (label) (if (string-equal label "0") "*" label)))
 	((eq label-type 'id)
-	 (lambda (_label) (format "0%s" (or (kview:id-increment kview) ""))))
+	 (lambda (_label) (format "0%s" (or (kview:id-increment hypb-kview) ""))))
 	(t (error
 	    "(klabel:increment): Invalid label type setting: `%s'" label-type))))
 
@@ -272,7 +272,7 @@ Function signature is: (func prev-label &optional child-p), where
 prev-label is the display label of the cell preceding the current
 one and child-p is non-nil if cell is to be the child of the
 preceding cell."
-  (or label-type (setq label-type (kview:label-type kview)))
+  (or label-type (setq label-type (kview:label-type hypb-kview)))
   (cond ((eq label-type 'no)
 	 (lambda (_prev-label &optional _child-p)
 	   ""))
@@ -373,7 +373,7 @@ and the start of its contents."
       (if (and (not current-tree-only)
 	       (kcell-view:next nil lbl-sep-len)
 	       (< (abs (- (kcell-view:indent nil lbl-sep-len) current-indent))
-		  (kview:level-indent kview)))
+		  (kview:level-indent hypb-kview)))
 	  (setq suffix-val (1+ suffix-val)
 		label-suffix (funcall suffix-function suffix-val)
 		current-cell-label (concat label-prefix label-suffix))
@@ -418,7 +418,7 @@ and the start of its contents."
       (if (and (not current-tree-only)
 	       (kcell-view:next nil lbl-sep-len)
 	       (< (abs (- (kcell-view:indent nil lbl-sep-len) current-indent))
-		  (kview:level-indent kview)))
+		  (kview:level-indent hypb-kview)))
 	  (setq suffix-val (1+ suffix-val)
 		label-suffix (int-to-string suffix-val)
 		current-cell-label (concat label-prefix label-suffix))
@@ -468,7 +468,7 @@ and the start of its contents."
       (if (and (not current-tree-only)
 	       (kcell-view:next nil lbl-sep-len)
 	       (< (abs (- (kcell-view:indent nil lbl-sep-len) current-indent))
-		  (kview:level-indent kview)))
+		  (kview:level-indent hypb-kview)))
 	  (setq suffix-val (1+ suffix-val)
 		label-suffix (funcall suffix-function suffix-val)
 		current-cell-label label-suffix)
@@ -493,7 +493,7 @@ and the start of its contents."
   "Update the labels of current cell, its following siblings and their subtrees.
 CURRENT-CELL-LABEL is the label to display for the current cell.
 If, however, it is \"0\", then all cell labels are updated."
-  (let ((label-type (kview:label-type kview)))
+  (let ((label-type (kview:label-type hypb-kview)))
     (when (memq label-type '(alpha legal partial-alpha))
       (if (string-equal current-cell-label "0")
 	  ;; Update all cells in view.
@@ -506,14 +506,14 @@ If, however, it is \"0\", then all cell labels are updated."
   "Update the labels of current cell and its subtree.
 CURRENT-CELL-LABEL is the label to display for the current cell.
 Use `(klabel-type:update-labels \"0\")' to update all cells in an outline."
-  (let ((label-type (kview:label-type kview))
-	(lbl-sep-len (kview:label-separator-length kview)))
+  (let ((label-type (kview:label-type hypb-kview))
+	(lbl-sep-len (kview:label-separator-length hypb-kview)))
     (save-excursion
       (funcall (intern-soft (concat "klabel-type:set-"
 				    (symbol-name label-type)))
 	       first-label lbl-sep-len
 	       (kcell-view:indent nil lbl-sep-len)
-	       (kview:level-indent kview)
+	       (kview:level-indent hypb-kview)
 	       ;; Update current tree only.
 	       t))))
 
@@ -634,7 +634,7 @@ Return NEW-LABEL string."
 	(buffer-read-only)
 	(thru-label (- (kcell-view:indent nil lbl-sep-len)
 		       (or lbl-sep-len
-			   (kview:label-separator-length kview)))))
+			   (kview:label-separator-length hypb-kview)))))
     (save-excursion
       (kcell-view:to-label-end)
       ;; delete backwards thru label
@@ -652,13 +652,13 @@ For example, the full label \"1a2\" has kotl-label \"2\", as does \"1.1.2\"."
     (error "(klabel:to-kotl-label): Invalid label, `%s'" label)))
 
 (defun klabel-type:update-labels-from-point (label-type first-label)
-  (let ((lbl-sep-len (kview:label-separator-length kview)))
+  (let ((lbl-sep-len (kview:label-separator-length hypb-kview)))
     (save-excursion
       (funcall (intern-soft (concat "klabel-type:set-"
 				    (symbol-name label-type)))
 	       first-label lbl-sep-len
 	       (kcell-view:indent nil lbl-sep-len)
-	       (kview:level-indent kview)))))
+	       (kview:level-indent hypb-kview)))))
 
 (provide 'klabel)
 

--- a/kotl/klabel.el
+++ b/kotl/klabel.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    17-Apr-94
-;; Last-Mod:     21-Sep-23 at 22:51:56 by Mats Lidell
+;; Last-Mod:     27-Sep-23 at 21:14:53 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -15,6 +15,10 @@
 ;;; Commentary:
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies
+(require 'kview)
+(declare-function kotl-mode:first-cell-p "kotl-mode")
 
 ;;; ************************************************************************
 ;;; Public variables

--- a/kotl/klabel.el
+++ b/kotl/klabel.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    17-Apr-94
-;; Last-Mod:     18-Jul-22 at 21:58:23 by Mats Lidell
+;; Last-Mod:     21-Sep-23 at 22:51:56 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -15,6 +15,7 @@
 ;;; Commentary:
 
 ;;; Code:
+
 ;;; ************************************************************************
 ;;; Public variables
 ;;; ************************************************************************

--- a/kotl/klink.el
+++ b/kotl/klink.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Nov-93 at 12:15:16
-;; Last-Mod:      8-Aug-23 at 23:57:36 by Bob Weiner
+;; Last-Mod:     27-Sep-23 at 21:25:18 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -66,6 +66,14 @@
 (require 'subr-x) ;; For string-trim
 (require 'hmouse-tag) ;; For smart-c-include-regexp
 (eval-when-compile (require 'hbut)) ;; For defib.
+
+;;; FIXME: Circular dependencies
+(defvar klink:cell-ref-regexp) ;; Forward declaration!?
+(declare-function kcell-view:label "kview")
+(declare-function hbut:get-key-src "hbut")
+(declare-function hbut:label-p "hbut")
+(declare-function hargs:iform-read "hargs")
+(declare-function hattr:set "hbut")
 
 ;;; ************************************************************************
 ;;; Public variables

--- a/kotl/kmenu.el
+++ b/kotl/kmenu.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    28-Mar-94 at 11:22:09
-;; Last-Mod:     17-Apr-22 at 23:51:03 by Mats Lidell
+;; Last-Mod:     27-Sep-23 at 21:38:49 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -15,6 +15,11 @@
 ;;; Commentary:
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies
+(defvar kotl-mode-map)
+;; (require 'kotl-mode)
+
 ;;; ************************************************************************
 ;;; Other required Elisp libraries
 ;;; ************************************************************************

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:     28-Aug-23 at 01:52:34 by Bob Weiner
+;; Last-Mod:     27-Sep-23 at 21:34:26 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -15,6 +15,11 @@
 ;;; Commentary:
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies
+(declare-function outline-invisible-in-p "hyperbole")
+(require 'klabel)
+
 ;;; ************************************************************************
 ;;; Other required Lisp Libraries
 ;;; ************************************************************************

--- a/kotl/kotl-orgtbl.el
+++ b/kotl/kotl-orgtbl.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    10/18/2020
-;; Last-Mod:     28-Aug-23 at 00:56:07 by Bob Weiner
+;; Last-Mod:     27-Sep-23 at 21:52:17 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -46,6 +46,13 @@
 ;;  performs its normal table-based alignment and movement.
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies
+(require 'hmouse-drv)
+;;(require 'kotl-mode)
+(declare-function kotl-mode:next-line "kotl-mode")
+(declare-function kotl-mode:transpose-lines "kotl-mode")
+(declare-function kotl-mode:tab-command "kotl-mode")
 
 ;;; ************************************************************************
 ;;; Other required Elisp libraries

--- a/kotl/kproperty.el
+++ b/kotl/kproperty.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    7/27/93
-;; Last-Mod:     16-Oct-22 at 10:01:41 by Bob Weiner
+;; Last-Mod:     22-Sep-23 at 00:12:40 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -22,7 +22,7 @@
 ;;; ************************************************************************
 
 ;; Ensure kotl/ is in load-path.
-(require 'hyperbole)
+;; (require 'hyperbole)
 
 ;;; ************************************************************************
 ;;; Public functions

--- a/kotl/kview.el
+++ b/kotl/kview.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:     30-Jun-23 at 21:43:29 by Mats Lidell
+;; Last-Mod:     21-Sep-23 at 22:46:12 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -30,7 +30,8 @@
 ;;; Public variables
 ;;; ************************************************************************
 
-(set-default 'kview nil)
+(defvar-local kview nil "Buffer local kview object.")
+;;(set-default 'kview nil)
 
 (defcustom kview:default-blank-lines t
   "*Default setting of whether to show blank lines between koutline cells.

--- a/kotl/kview.el
+++ b/kotl/kview.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:     21-Sep-23 at 22:46:12 by Mats Lidell
+;; Last-Mod:     27-Sep-23 at 22:50:39 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -15,23 +15,58 @@
 ;;; Commentary:
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies
+(require 'kproperty)
+(defvar kotl-mode:refill-flag)
+
 ;;; ************************************************************************
 ;;; Other required Lisp Libraries
 ;;; ************************************************************************
 
-(eval-and-compile (mapc #'require '(hact klabel kfill klink hypb)))
+(eval-and-compile (mapc #'require '(hact kfill klink)))
 ;; Quiet byte compiler warnings for this free variable.
 
 (define-obsolete-variable-alias 'label-sep-len 'kview-label-sep-len "8.0.1")
 (defvar kview-label-sep-len nil
   "Length of the separation between cell's label and start of its contents.")
 
+;;; FIXME: Circular dependencies
+(declare-function klabel:format "klabel.el")
+(declare-function klabel:idstamp-p "klabel.el")
+(declare-function kcell:create-top "kcell")
+(declare-function kcell:create "kcell")
+(declare-function kcell:get-attr "kcell")
+(declare-function kcell:plist "kcell")
+(declare-function kcell:remove-attr "kcell")
+(declare-function kcell:set-attr "kcell")
+(declare-function kfile:narrow-to-kcells "kfile")
+(declare-function klabel-type:child "klabel")
+(declare-function klabel-type:function "klabel")
+(declare-function klabel-type:increment "klabel")
+(declare-function klabel-type:parent "klabel")
+(declare-function klabel-type:set-labels "klabel")
+(declare-function kotl-mode:beginning-of-line "kotl-mode")
+(declare-function kotl-mode:fill-cell "kotl-mode")
+(declare-function kotl-mode:goto-cell "kotl-mode")
+(declare-function kotl-mode:hide-subtree "kotl-mode")
+(declare-function kotl-mode:to-end-of-line "kotl-mode")
+(declare-function kotl-mode:to-visible-position "kotl-mode")
+(declare-function kotl-mode:tree-end "kotl-mode")
+(declare-function kvspec:show-lines-this-cell "kvspec")
+(declare-function kvspec:update "kvspec")
+;;(declare-function outline-flag-region "")
+(require 'outline)
+
 ;;; ************************************************************************
 ;;; Public variables
 ;;; ************************************************************************
 
-(defvar-local kview nil "Buffer local kview object.")
-;;(set-default 'kview nil)
+;;; FIXME: Circular dependencies
+;;(defvar-local kview nil "Buffer local kview object.")
+(defvar kview)
+
+(set-default 'kview nil)
 
 (defcustom kview:default-blank-lines t
   "*Default setting of whether to show blank lines between koutline cells.

--- a/kotl/kvspec.el
+++ b/kotl/kvspec.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Oct-95 at 15:17:07
-;; Last-Mod:     18-Jul-22 at 21:57:01 by Mats Lidell
+;; Last-Mod:     27-Sep-23 at 22:08:57 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -51,6 +51,38 @@
 ;;                 can be used for browsing and view setting.
 
 ;;; Code:
+
+;;; FIXME: Circular dependencies
+;;; Move private vars to top, see below
+
+(declare-function kotl-mode:hide-subtree "kotl-mode")
+(declare-function kfile:narrow-to-kcells "kfile")
+
+;;; ************************************************************************
+;;; Private variables
+;;; ************************************************************************
+
+ (defconst kvspec:label-type-alist
+  '((?0 . id)
+    (?1 . alpha)
+    (?. . legal)
+    ;; (?2 . partial-alpha)
+    ;; (?* . star)
+    ;; (?~ . no)
+    )
+  "Alist of (view-spec-character . label-type) pairs.")
+
+(defvar kvspec:string ""
+  "String displayed in koutline modelines to reflect the current view spec.
+It is local to each koutline.  Set this to nil to disable modeline display of
+the view spec settings.")
+
+(defvar kvspec:string-format " <|%s>"
+  "Format of the kview spec modeline display.
+It must contain a `%s' which is replaced with the current set of view spec
+characters at run-time.")
+
+
 ;;; ************************************************************************
 ;;; Other required Elisp libraries
 ;;; ************************************************************************
@@ -322,30 +354,6 @@ available, the cell remains fully expanded."
       ;; selected.
       (kvspec:numbering)) ;; n
     (set-buffer-modified-p modified-p)))
-
-;;; ************************************************************************
-;;; Private variables
-;;; ************************************************************************
-
-(defconst kvspec:label-type-alist
-  '((?0 . id)
-    (?1 . alpha)
-    (?. . legal)
-    ;; (?2 . partial-alpha)
-    ;; (?* . star)
-    ;; (?~ . no)
-    )
-  "Alist of (view-spec-character . label-type) pairs.")
-
-(defvar kvspec:string ""
-  "String displayed in koutline modelines to reflect the current view spec.
-It is local to each koutline.  Set this to nil to disable modeline display of
-the view spec settings.")
-
-(defvar kvspec:string-format " <|%s>"
-  "Format of the kview spec modeline display.
-It must contain a `%s' which is replaced with the current set of view spec
-characters at run-time.")
 
 (provide 'kvspec)
 

--- a/kotl/kvspec.el
+++ b/kotl/kvspec.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Oct-95 at 15:17:07
-;; Last-Mod:     27-Sep-23 at 22:08:57 by Mats Lidell
+;; Last-Mod:     29-Sep-23 at 16:40:02 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -142,18 +142,18 @@ display all levels of cells."
        (if (kcell-view:next t)
 	   (kcell-view:previous)
 	 (goto-char (point-max)))))
-   kview t)
-  (kview:set-attr kview 'levels-to-show levels-to-keep))
+   hypb-kview t)
+  (kview:set-attr hypb-kview 'levels-to-show levels-to-keep))
 
 (defun kvspec:show-lines-per-cell (num)
   "Show NUM lines per visible cell; 0 means show all lines in each visible cell."
   (if (or (not (integerp num)) (< num 0))
       (error "(kvspec:show-lines-per-cell): Invalid lines per cell, `%d'" num))
-  (kview:set-attr kview 'lines-to-show num)
+  (kview:set-attr hypb-kview 'lines-to-show num)
   ;; Now show NUM lines in cells.
   (kview:map-tree (lambda (_kview)
 		    (kcell-view:expand (point))
-		    (kvspec:show-lines-this-cell num)) kview t t))
+		    (kvspec:show-lines-this-cell num)) hypb-kview t t))
 
 (defun kvspec:toggle-blank-lines ()
   "Toggle blank lines between cells on or off."
@@ -199,10 +199,10 @@ view specs."
 	(buffer-read-only))
       (if (string-match "b" kvspec:current)
 	  ;; On
-	  (progn (kview:set-attr kview 'blank-lines t)
+	  (progn (kview:set-attr hypb-kview 'blank-lines t)
 		 (kproperty:remove (point-min) (point-max) '(invisible t)))
 	;; Off
-	(kview:set-attr kview 'blank-lines nil)
+	(kview:set-attr hypb-kview 'blank-lines nil)
 	(save-excursion
 	  (goto-char (point-max))
 	  (while (re-search-backward "[\n\r][\n\r]" nil t)
@@ -221,10 +221,10 @@ view specs."
    ;; it off when he resets the view specs.
 
    ;; b - blank separator lines
-   (if (kview:get-attr kview 'blank-lines) "b")
+   (if (kview:get-attr hypb-kview 'blank-lines) "b")
 
    ;; c - cutoff lines per cell
-   (let ((lines (kview:get-attr kview 'lines-to-show)))
+   (let ((lines (kview:get-attr hypb-kview 'lines-to-show)))
      (if (zerop lines)
 	 nil
        (concat "c" (int-to-string lines))))
@@ -233,17 +233,17 @@ view specs."
    (if selective-display-ellipses "e")
 
    ;; l - hide some levels
-   (let ((levels (kview:get-attr kview 'levels-to-show)))
+   (let ((levels (kview:get-attr hypb-kview 'levels-to-show)))
      (if (zerop levels)
 	 nil
        (concat "l" (int-to-string levels))))
 
    ;; n - numbering type
-   (let ((type (kview:label-type kview)))
+   (let ((type (kview:label-type hypb-kview)))
      (cond ((eq type 'no) nil)
 	   ((eq type kview:default-label-type) "n")
 	   (t (concat "n" (char-to-string
-			   (car (rassq (kview:label-type kview)
+			   (car (rassq (kview:label-type hypb-kview)
 				       kvspec:label-type-alist)))))))))
 
 (defun kvspec:elide ()
@@ -286,7 +286,7 @@ view specs."
 	  (setq spec (string-to-char (match-string 1 kvspec:current))
 		type (cdr (assq spec kvspec:label-type-alist)))
 	(setq type kview:default-label-type))
-      (kview:set-label-type kview type))))
+      (kview:set-label-type hypb-kview type))))
 
 (defun kvspec:show-lines-this-cell (num)
   "Assume current cell is fully expanded and collapse to show NUM lines within it.

--- a/test/kotl-mode-tests.el
+++ b/test/kotl-mode-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    18-May-21 at 22:14:10
-;; Last-Mod:     28-Aug-23 at 00:07:23 by Bob Weiner
+;; Last-Mod:     29-Sep-23 at 16:48:42 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -103,7 +103,7 @@
           (should (string= (kcell-view:label (point)) "1"))
           (should (hact 'kbd-key "C-c C-v 0 RET"))
           (hy-test-helpers:consume-input-events)
-          (should (eq (kview:label-type kview) 'id))
+          (should (eq (kview:label-type hypb-kview) 'id))
           (should (string= (kcell-view:label (point)) "01")))
       (hy-delete-file-and-buffer kotl-file))))
 
@@ -119,7 +119,7 @@
 
           ;; Verify idstamp label
           (kvspec:activate "ben0")
-          (should (eq (kview:label-type kview) 'id))
+          (should (eq (kview:label-type hypb-kview) 'id))
           (should (string= (kcell-view:idstamp) "01"))
           (should (string= (kcell-view:label (point)) "01"))
 
@@ -128,7 +128,7 @@
           (save-buffer)
           (kill-buffer)
           (find-file kotl-file)
-          (should (eq (kview:label-type kview) 'id))
+          (should (eq (kview:label-type hypb-kview) 'id))
           (should (string= (kcell-view:idstamp) "01"))
           (should (string= (kcell-view:label (point)) "01")))
       (hy-delete-file-and-buffer kotl-file))))


### PR DESCRIPTION
## What

First stab at compiling files separately - and remove warnings that are shown then

## Why

We want to remove warnings.

## Note

I flipped the coin and used the compiler to tell me what functions and variable that needs to be declared to silence the compiler. The added declarations are made to stand out by the header `;; FIXME: Circular dependencies`. (Not all declarations are due to circular dependencies but I started out that way. ) This is done with the hope that is will be easier to see what changes we should promote to master when we see in clear text what is missing.

One idea is to let these changes in, after removing the boiler plat comments, with the regular declarations and work over time to reduce the number of functions and vars that are declared in favor of using require. Not sure about the best practice here. I thought the proper way was to use `require` and work on the dependencies so that the amount of `declarations` are minimal. But if you can load the package and things work then maybe it does not matter and using declarations is a means to cut dependency circles!? 

The `kview` global variable had to be fixed as well. I renamed it `hypb-kview`. That change is committed in a separate commit for easier review.

It does not show here but if this is compiled with the new `new-bin` target, that compiles each file in isolation, there are nearly no warnings left.  For what I know this is equivalent with how the package manager compiles the files.

Worth to note is that I have problems with the mouse actions on the master branch so I can't rule out that this PR introduces problems. All test pass though which is encouraging. 