### PR TITLE
Add kotl prefix to kview buffer local variable

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2023-10-05  Mats Lidell  <matsl@gnu.org>
+
+* test/kotl-mode-tests.el (kotl-mode-kview-buffer-local)
+    (kotl-mode-kvspec-saved-with-file)
+    (kotl-mode-kvspec-independent-between-files): Add test for buffer
+    local kotl-kview.
+
 2023-10-04  Mats Lidell  <matsl@gnu.org>
 
 * kotl/kview.el (kotl-kview): Add kotl prefix to kview and use

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2023-10-04  Mats Lidell  <matsl@gnu.org>
+
+* kotl/kview.el (kotl-kview): Add kotl prefix to kview and use
+    defvar-local.
+
+* General removal of warnings by using defvar and declare-function for
+    variables and functions not covered by requires.
+
 2023-10-03  Mats Lidell  <matsl@gnu.org>
 
 * Makefile: Compile each el file in a separate Emacs process so that the

--- a/kotl/kcell.el
+++ b/kotl/kcell.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-May-93
-;; Last-Mod:      3-Oct-23 at 22:39:29 by Mats Lidell
+;; Last-Mod:      4-Oct-23 at 19:10:12 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -165,7 +165,7 @@ Augment capabilities not yet implemented and ignored for now:
 		       (save-excursion
 			 (goto-char (point-min))
 			 (when (re-search-forward (concat "^[ \t]*" (regexp-quote idstamp-string)
-							  (regexp-quote (kview:label-separator kview)))
+							  (regexp-quote (kview:label-separator kotl-kview)))
 						  nil t)
 
 			   (setq idstamp-string (kcell-view:idstamp))
@@ -221,7 +221,7 @@ assuming it is the cell at point and filling in the missing information."
 	 (vector idstamp plist)
        (kcell-data:create
 	(kcell:create plist)
-	(or idstamp (kview:id-increment kview))))))
+	(or idstamp (kview:id-increment kotl-kview))))))
 
 (defun kcell-data:idstamp (kcell-data)
   (aref kcell-data 0))

--- a/kotl/kexport.el
+++ b/kotl/kexport.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    26-Feb-98
-;; Last-Mod:     28-Aug-23 at 02:14:28 by Bob Weiner
+;; Last-Mod:      4-Oct-23 at 19:23:08 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -485,7 +485,7 @@ used.  Also converts Urls and Klinks into Html hyperlinks.
 		(replace-regexp-in-string
 		 ">" "&gt;"
 		 (replace-regexp-in-string
-		  "<" "&lt;" (kview:label-separator kview))))
+		  "<" "&lt;" (kview:label-separator kotl-kview))))
                no-sibling-stack)
 
           (princ "<ul>\n")
@@ -513,7 +513,7 @@ used.  Also converts Urls and Klinks into Html hyperlinks.
                    (while (pop no-sibling-stack)
                      (princ "</ul>\n")
                      (princ "</li>\n"))))))
-	   kview t)
+	   kotl-kview t)
 
           (princ "</ul>\n")
 

--- a/kotl/kfile.el
+++ b/kotl/kfile.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    10/31/93
-;; Last-Mod:     27-Sep-23 at 20:54:08 by Mats Lidell
+;; Last-Mod:      4-Oct-23 at 19:10:12 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -60,11 +60,11 @@ Return the new kview."
     ;; Finding the file may have already done a kfile:read as invoked through
     ;; kotl-mode via a file local variable setting.  If so, don't read it
     ;; again.
-    (unless (kview:is-p kview)
+    (unless (kview:is-p kotl-kview)
       (kfile:read buffer existing-file))
     (unless (derived-mode-p 'kotl-mode)
       (kotl-mode))
-    kview))
+    kotl-kview))
 
 ;;;###autoload
 (defun kfile:is-p ()
@@ -259,12 +259,12 @@ If V3-FLAG is true, read as a version-3 buffer."
   "Update kfile internal structure so that view is ready for saving to a file.
 Leave outline file expanded with structure data showing unless optional
 VISIBLE-ONLY-P is non-nil.  Signal an error if kotl is not attached to a file."
-  (let* ((top (kview:top-cell kview))
+  (let* ((top (kview:top-cell kotl-kview))
 	 (file buffer-file-name)
-	 (label-type (kview:label-type kview))
-	 (label-min-width (kview:label-min-width kview))
-	 (label-separator (kview:label-separator kview))
-	 (level-indent (kview:level-indent kview))
+	 (label-type (kview:label-type kotl-kview))
+	 (label-min-width (kview:label-min-width kotl-kview))
+	 (label-separator (kview:label-separator kotl-kview))
+	 (level-indent (kview:level-indent kotl-kview))
 	 ;; If this happens to be non-nil, it is virtually impossible to save
 	 ;; a file, so ensure it is nil.
 	 (debug-on-error))
@@ -289,7 +289,7 @@ VISIBLE-ONLY-P is non-nil.  Signal an error if kotl is not attached to a file."
 		kcell-num
 		(kcell-data:create cell (kcell-view:idstamp-integer)))
 	  (setq kcell-num (1+ kcell-num)))
-	kview t)
+	kotl-kview t)
       ;; Save top cell, 0, last since above loop may increment the total
       ;; number of cells counter stored in it, if any invalid cells are
       ;; encountered.
@@ -351,7 +351,7 @@ VISIBLE-ONLY-P is non-nil.  Signal an error if kotl is not attached to a file."
   (set-buffer-modified-p t)
   ;; This next line must come before the save-buffer so write-file-functions
   ;; can make use of it.
-  (kview:set-buffer kview (current-buffer))
+  (kview:set-buffer kotl-kview (current-buffer))
   (save-buffer))
 
 ;;; ************************************************************************
@@ -405,8 +405,8 @@ hidden."
 	    (setq kcell-data (car kcell-list)
 		  ;; Repair invalid idstamps on the fly.
 		  idstamp (if (vectorp kcell-data)
-			      (or (kcell-data:idstamp kcell-data) (kview:id-increment kview))
-			    (kview:id-increment kview)))
+			      (or (kcell-data:idstamp kcell-data) (kview:id-increment kotl-kview))
+			    (kview:id-increment kotl-kview)))
 	    (kproperty:set 'idstamp idstamp)
 	    (kproperty:set 'kcell (car kcell-list))
 	    (setq kcell-list (cdr kcell-list)))
@@ -431,8 +431,8 @@ hidden."
 	    (setq kcell-data (aref kcell-vector kcell-num)
 		  ;; Repair invalid idstamps on the fly.
 		  idstamp (if (vectorp kcell-data)
-			      (or (kcell-data:idstamp kcell-data) (kview:id-increment kview))
-			    (kview:id-increment kview)))
+			      (or (kcell-data:idstamp kcell-data) (kview:id-increment kotl-kview))
+			    (kview:id-increment kotl-kview)))
 	    (kproperty:set 'idstamp idstamp)
 	    (kproperty:set 'kcell (kcell-data:to-kcell-v3 kcell-data))
 	    (setq kcell-num (1+ kcell-num)))
@@ -441,7 +441,7 @@ hidden."
 (defun kfile:narrow-to-kcells ()
   "Narrow kotl file to kcell section only."
   (interactive)
-  (when (kview:is-p kview)
+  (when (kview:is-p kotl-kview)
     (let ((start-text) (end-text))
       (save-excursion
 	(widen)

--- a/kotl/kimport.el
+++ b/kotl/kimport.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Nov-93 at 11:57:05
-;; Last-Mod:      3-Oct-23 at 22:42:02 by Mats Lidell
+;; Last-Mod:      4-Oct-23 at 19:10:12 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -610,7 +610,7 @@ will be added as children of the cell where this function leaves point
 	(widen)
 	(delete-region (point-min) (point-max)))
       (unless (kfile:is-p)
-	(setq kview nil)
+	(setq kotl-kview nil)
 	(kotl-mode))))
   output-to)
 

--- a/kotl/klabel.el
+++ b/kotl/klabel.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    17-Apr-94
-;; Last-Mod:      3-Oct-23 at 22:32:09 by Mats Lidell
+;; Last-Mod:      4-Oct-23 at 19:13:00 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -41,7 +41,7 @@
 
 (defun klabel:child (label)
   "Return LABEL's child cell label."
-  (funcall (kview:get-attr kview 'label-child) label))
+  (funcall (kview:get-attr kotl-kview 'label-child) label))
 
 (defun klabel:idstamp-p (label)
   "Return t if LABEL is an idstamp label, else nil."
@@ -52,12 +52,12 @@
 
 (defun klabel:increment (label)
   "Return LABEL's sibling label."
-  (funcall (kview:get-attr kview 'label-increment) label))
+  (funcall (kview:get-attr kotl-kview 'label-increment) label))
 
 (defun klabel:format (label)
   "Format a generic cell LABEL (a string) and return the display type.
 Return the proper display type for the current kview."
-  (let ((label-type (or (kview:get-attr kview 'label-type) kview:default-label-type)))
+  (let ((label-type (or (kview:get-attr kotl-kview 'label-type) kview:default-label-type)))
     (cond ((memq label-type '(alpha id legal partial-alpha))
 	   label)
 	  ((eq label-type 'no) "")
@@ -67,7 +67,7 @@ Return the proper display type for the current kview."
 
 (defun klabel:level (label)
   "Return outline level of LABEL using current kview label type."
-  (let ((label-type (kview:label-type kview)))
+  (let ((label-type (kview:label-type kotl-kview)))
     (cond ((memq label-type '(alpha legal))
 	   (funcall (intern-soft (concat "klabel:level-"
 					 (symbol-name label-type)))
@@ -81,7 +81,7 @@ Return the proper display type for the current kview."
 
 (defun klabel:parent (label)
   "Return LABEL's parent label."
-  (funcall (kview:get-attr kview 'label-parent) label))
+  (funcall (kview:get-attr kotl-kview 'label-parent) label))
 
 ;;;
 ;;; klabel-type - kview-specific label type functions
@@ -96,7 +96,7 @@ Return the proper display type for the current kview."
 	((eq label-type 'star)
 	 (lambda (label) (concat label "*")))
 	((eq label-type 'id)
-	 (lambda (_label) (format "0%s" (or (kview:id-counter kview) ""))))
+	 (lambda (_label) (format "0%s" (or (kview:id-counter kotl-kview) ""))))
 	(t (error
 	    "(klabel-type:child): Invalid label type setting: `%s'"
 	    label-type))))
@@ -113,7 +113,7 @@ is computed."
 	((eq label-type 'star)
 	 (lambda (label) (if (string-equal label "0") "*" label)))
 	((eq label-type 'id)
-	 (lambda (_label) (format "0%s" (or (kview:id-increment kview) ""))))
+	 (lambda (_label) (format "0%s" (or (kview:id-increment kotl-kview) ""))))
 	(t (error
 	    "(klabel:increment): Invalid label type setting: `%s'" label-type))))
 
@@ -276,7 +276,7 @@ Function signature is: (func prev-label &optional child-p), where
 prev-label is the display label of the cell preceding the current
 one and child-p is non-nil if cell is to be the child of the
 preceding cell."
-  (or label-type (setq label-type (kview:label-type kview)))
+  (or label-type (setq label-type (kview:label-type kotl-kview)))
   (cond ((eq label-type 'no)
 	 (lambda (_prev-label &optional _child-p)
 	   ""))
@@ -377,7 +377,7 @@ and the start of its contents."
       (if (and (not current-tree-only)
 	       (kcell-view:next nil lbl-sep-len)
 	       (< (abs (- (kcell-view:indent nil lbl-sep-len) current-indent))
-		  (kview:level-indent kview)))
+		  (kview:level-indent kotl-kview)))
 	  (setq suffix-val (1+ suffix-val)
 		label-suffix (funcall suffix-function suffix-val)
 		current-cell-label (concat label-prefix label-suffix))
@@ -422,7 +422,7 @@ and the start of its contents."
       (if (and (not current-tree-only)
 	       (kcell-view:next nil lbl-sep-len)
 	       (< (abs (- (kcell-view:indent nil lbl-sep-len) current-indent))
-		  (kview:level-indent kview)))
+		  (kview:level-indent kotl-kview)))
 	  (setq suffix-val (1+ suffix-val)
 		label-suffix (int-to-string suffix-val)
 		current-cell-label (concat label-prefix label-suffix))
@@ -472,7 +472,7 @@ and the start of its contents."
       (if (and (not current-tree-only)
 	       (kcell-view:next nil lbl-sep-len)
 	       (< (abs (- (kcell-view:indent nil lbl-sep-len) current-indent))
-		  (kview:level-indent kview)))
+		  (kview:level-indent kotl-kview)))
 	  (setq suffix-val (1+ suffix-val)
 		label-suffix (funcall suffix-function suffix-val)
 		current-cell-label label-suffix)
@@ -497,7 +497,7 @@ and the start of its contents."
   "Update the labels of current cell, its following siblings and their subtrees.
 CURRENT-CELL-LABEL is the label to display for the current cell.
 If, however, it is \"0\", then all cell labels are updated."
-  (let ((label-type (kview:label-type kview)))
+  (let ((label-type (kview:label-type kotl-kview)))
     (when (memq label-type '(alpha legal partial-alpha))
       (if (string-equal current-cell-label "0")
 	  ;; Update all cells in view.
@@ -510,14 +510,14 @@ If, however, it is \"0\", then all cell labels are updated."
   "Update the labels of current cell and its subtree.
 CURRENT-CELL-LABEL is the label to display for the current cell.
 Use `(klabel-type:update-labels \"0\")' to update all cells in an outline."
-  (let ((label-type (kview:label-type kview))
-	(lbl-sep-len (kview:label-separator-length kview)))
+  (let ((label-type (kview:label-type kotl-kview))
+	(lbl-sep-len (kview:label-separator-length kotl-kview)))
     (save-excursion
       (funcall (intern-soft (concat "klabel-type:set-"
 				    (symbol-name label-type)))
 	       first-label lbl-sep-len
 	       (kcell-view:indent nil lbl-sep-len)
-	       (kview:level-indent kview)
+	       (kview:level-indent kotl-kview)
 	       ;; Update current tree only.
 	       t))))
 
@@ -638,7 +638,7 @@ Return NEW-LABEL string."
 	(buffer-read-only)
 	(thru-label (- (kcell-view:indent nil lbl-sep-len)
 		       (or lbl-sep-len
-			   (kview:label-separator-length kview)))))
+			   (kview:label-separator-length kotl-kview)))))
     (save-excursion
       (kcell-view:to-label-end)
       ;; delete backwards thru label
@@ -656,13 +656,13 @@ For example, the full label \"1a2\" has kotl-label \"2\", as does \"1.1.2\"."
     (error "(klabel:to-kotl-label): Invalid label, `%s'" label)))
 
 (defun klabel-type:update-labels-from-point (label-type first-label)
-  (let ((lbl-sep-len (kview:label-separator-length kview)))
+  (let ((lbl-sep-len (kview:label-separator-length kotl-kview)))
     (save-excursion
       (funcall (intern-soft (concat "klabel-type:set-"
 				    (symbol-name label-type)))
 	       first-label lbl-sep-len
 	       (kcell-view:indent nil lbl-sep-len)
-	       (kview:level-indent kview)))))
+	       (kview:level-indent kotl-kview)))))
 
 (provide 'klabel)
 

--- a/kotl/kview.el
+++ b/kotl/kview.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:      3-Oct-23 at 22:38:35 by Mats Lidell
+;; Last-Mod:      4-Oct-23 at 19:14:00 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -59,7 +59,7 @@
 (defvar kview-label-sep-len nil
   "Length of the separation between cell's label and start of its contents.")
 
-(defvar-local kview nil "Buffer local kview object.")
+(defvar-local kotl-kview nil "Buffer local kview object.")
 
 (defcustom kview:default-blank-lines t
   "*Default setting of whether to show blank lines between koutline cells.
@@ -126,7 +126,7 @@ Default value is 3."
 With optional VISIBLE-P, consider only visible cells.
 Return t unless no such cell."
   (or lbl-sep-len (setq lbl-sep-len
-			  (kview:label-separator-length kview)))
+			  (kview:label-separator-length kotl-kview)))
   (let ((opoint (point))
 	(found) (done)
 	(curr-indent 0)
@@ -138,7 +138,7 @@ Return t unless no such cell."
 		 (goto-char opoint))
 	(setq curr-indent (kcell-view:indent nil lbl-sep-len))
 	(cond ((< (abs (- curr-indent start-indent))
-		  (kview:level-indent kview))
+		  (kview:level-indent kotl-kview))
 	       (goto-char (kcell-view:start nil lbl-sep-len))
 	       (setq found t))
 	      ((< curr-indent start-indent)
@@ -162,7 +162,7 @@ Trigger an error if CELL-REF is not a string or is not found."
       (let ((idstamp (kcell:ref-to-id cell-ref))
 	    pos)
 	(cond ((and (integerp idstamp) (zerop idstamp))
-	       (kview:top-cell kview))
+	       (kview:top-cell kotl-kview))
 	      ((and (integerp idstamp) (setq pos (kproperty:position 'idstamp idstamp)))
 	       (kcell-view:cell pos))
 	      (t (error "(kcell:get-from-ref): No such Koutline cell: '%s'" cell-ref))))
@@ -178,11 +178,11 @@ a cell's label and the start of its contents."
 	 (prev-indent (kcell-view:indent nil lbl-sep-len))
 	 (next (kcell-view:next visible-p lbl-sep-len)))
     (unless lbl-sep-len
-      (setq lbl-sep-len (kview:label-separator-length kview)))
+      (setq lbl-sep-len (kview:label-separator-length kotl-kview)))
     ;; Since kcell-view:next leaves point at the start of a cell, the cell's
     ;; indent is just the current-column of point.
     (if (and next (>= (- (current-column) prev-indent)
-		      (kview:level-indent kview)))
+		      (kview:level-indent kotl-kview)))
 	t
       ;; Move back to previous point and return nil.
       (goto-char opoint)
@@ -349,7 +349,7 @@ Excludes blank lines following cell contents."
 With optional VISIBLE-P, consider only visible cells.
 Return t unless no such cell."
   (unless lbl-sep-len
-    (setq lbl-sep-len (kview:label-separator-length kview)))
+    (setq lbl-sep-len (kview:label-separator-length kotl-kview)))
   (let ((opoint (point))
 	(found) (done)
 	(curr-indent 0)
@@ -358,7 +358,7 @@ Return t unless no such cell."
 		(kcell-view:next visible-p lbl-sep-len))
       (setq curr-indent (kcell-view:indent nil lbl-sep-len))
       (cond ((< (abs (- curr-indent start-indent))
-		(kview:level-indent kview))
+		(kview:level-indent kotl-kview))
 	     (goto-char (kcell-view:start nil lbl-sep-len))
 	     (setq found t))
 	    ((< curr-indent start-indent)
@@ -378,7 +378,7 @@ Use 0 for POS to retrieve top cell's attributes."
   (if (eq pos 0)
       (if (eq attribute 'idstamp)
 	  0
-	(kcell:get-attr (kview:top-cell kview) attribute))
+	(kcell:get-attr (kview:top-cell kotl-kview) attribute))
     (save-excursion
       (goto-char (or pos (kcell-view:plist-point)))
       (if (eq attribute 'idstamp)
@@ -404,7 +404,7 @@ cell's label and the start of its contents."
   (+ (save-excursion
        (kcell-view:to-label-end pos)
        (current-column))
-     (or lbl-sep-len (kview:label-separator-length kview)
+     (or lbl-sep-len (kview:label-separator-length kotl-kview)
 	 (length kview:default-label-separator))))
 
 (defun kcell-view:label (&optional pos)
@@ -413,7 +413,7 @@ If labels are off, return cell's idstamp as a string."
   (save-excursion
     (when pos
       (goto-char pos))
-    (let ((label-type (kview:label-type kview)))
+    (let ((label-type (kview:label-type kotl-kview)))
       (if (eq label-type 'no)
 	  (kcell-view:idstamp)
 	(kcell-view:to-label-end)
@@ -427,9 +427,9 @@ LBL-SEP-LEN is the number of spaces between a cell label and
 the start of its body.  Optional INDENT is the indentation in
 characters of the cell whose level is desired."
   (unless lbl-sep-len
-    (setq lbl-sep-len (kview:label-separator-length kview)))
+    (setq lbl-sep-len (kview:label-separator-length kotl-kview)))
   (floor (/ (- (or indent (kcell-view:indent pos lbl-sep-len)) lbl-sep-len)
-	    (kview:level-indent kview))))
+	    (kview:level-indent kotl-kview))))
 
 (defun kcell-view:line (&optional pos)
   "Return contents of cell line at point or optional POS as a string."
@@ -445,7 +445,7 @@ characters of the cell whose level is desired."
   ;; Use free variable kview-label-sep-len bound in kview:map-* for speed.
   (if (kcell-view:invisible-p)
       0
-    (let* ((start (kcell-view:start nil (kview:label-separator-length kview)))
+    (let* ((start (kcell-view:start nil (kview:label-separator-length kotl-kview)))
 	   (end (kview:first-invisible-point start)))
       ;; Prevent bounds error with empty cells that have hidden subtrees.
       (max 1 (count-lines start end)))))
@@ -477,7 +477,7 @@ If parent is top cell, move to first cell within view and return 0.
 Otherwise, return t unless optional VISIBLE-P is non-nil and the parent cell
 is not part of the current view, else nil."
   (unless lbl-sep-len
-    (setq lbl-sep-len (kview:label-separator-length kview)))
+    (setq lbl-sep-len (kview:label-separator-length kotl-kview)))
   (let ((opoint (point))
 	(parent-level (1- (kcell-view:level nil lbl-sep-len))))
     (if (= parent-level 0) ;; top cell
@@ -587,7 +587,7 @@ Use 0 for POS to set top cell's attributes."
 	  (progn (kproperty:set attribute value)
 		 (kcell-view:cell))
 	;; Returns kcell
-	(let ((mod-cell (kcell:set-attr (if (eq pos 0) (kview:top-cell kview) (kcell-view:cell))
+	(let ((mod-cell (kcell:set-attr (if (eq pos 0) (kview:top-cell kotl-kview) (kcell-view:cell))
 					attribute value)))
 	  (kproperty:add-properties (list 'kcell mod-cell))
 	  mod-cell)))))
@@ -611,7 +611,7 @@ With optional VISIBLE-P, consider only visible siblings."
   "Return start position of visible cell contents from optional POS or point."
   (save-excursion
     (+ (kcell-view:to-label-end pos)
-       (or lbl-sep-len (kview:label-separator-length kview)))))
+       (or lbl-sep-len (kview:label-separator-length kotl-kview)))))
 
 (defun kcell-view:to-visible-label-end (&optional pos)
   "Move point to end of the visible cell's label.
@@ -649,9 +649,9 @@ This function does not renumber any other cells.  1 = first
 level."
   (let* ((idstamp (if (klabel:idstamp-p klabel)
 		      (if (stringp klabel) (string-to-number klabel) klabel)
-		    (kview:id-increment kview)))
+		    (kview:id-increment kotl-kview)))
 	 (new-cell (kcell:create prop-list)))
-    (kcell-view:create kview new-cell contents level idstamp klabel no-fill sibling-p)
+    (kcell-view:create kotl-kview new-cell contents level idstamp klabel no-fill sibling-p)
     new-cell))
 
 (defun kview:beginning-of-actual-line ()
@@ -699,11 +699,11 @@ are used.
 	   (error "(kview:create): 2nd arg, `%s', must be an integer" id-counter)))
     (set-buffer buf)
     ;; Don't recreate view if it exists.
-    (unless (and (boundp 'kview) (kview:is-p kview) (eq (kview:buffer kview) buf))
-      (make-local-variable 'kview)
+    (unless (and (boundp 'kotl-kview) (kview:is-p kotl-kview) (eq (kview:buffer kotl-kview) buf))
+      (make-local-variable 'kotl-kview)
       ;; Update cell count id-counter.
       (setq top-cell-attributes (plist-put top-cell-attributes 'id-counter id-counter))
-      (setq kview
+      (setq kotl-kview
 	    (list 'kview 'plist
 		  (list 'view-buffer (current-buffer)
 			'top-cell
@@ -725,7 +725,7 @@ are used.
 			'lines-to-show
 			(or lines-to-show kview:default-lines-to-show))))
       (kview:set-functions (or label-type kview:default-label-type)))
-    kview))
+    kotl-kview))
 
 (defun kview:delete-region (start end)
   "Delete cells between START and END points from current view."
@@ -743,7 +743,7 @@ With optional JUSTIFY, justify region as well.
 Fill-prefix must be a string of spaces the length of this cell's indent, when
 this function is called."
   (let ((opoint (set-marker (make-marker) (point)))
-	(lbl-sep-len (kview:label-separator-length kview))
+	(lbl-sep-len (kview:label-separator-length kotl-kview))
 	(continue t)
 	prev-point)
     (goto-char start)
@@ -820,7 +820,7 @@ On success, return t, else nil."
 	 (pos (kproperty:position 'idstamp idstamp)))
     (when pos
       (goto-char pos)
-      (forward-char (kview:label-separator-length kview))
+      (forward-char (kview:label-separator-length kotl-kview))
       t)))
 
 (defun kview:id-counter (kview)
@@ -1155,7 +1155,7 @@ Copy tree if optional COPY-P is non-nil.  Refill cells if optional
 FILL-P is non-nil.  Leave point at TO-START."
   (let ((region (buffer-substring from-start from-end))
 	(new-start (set-marker (make-marker) to-start))
-	(collapsed-cells (kview:get-cells-status kview from-start from-end))
+	(collapsed-cells (kview:get-cells-status kotl-kview from-start from-end))
 	expr new-end space)
 
     ;;
@@ -1189,12 +1189,12 @@ FILL-P is non-nil.  Leave point at TO-START."
 	    ;; Reduce indent in first cell lines which may have an
 	    ;; autonumber or other cell delimiter.
 	    (setq space (- from-indent to-indent
-			   (kview:label-separator-length kview)
+			   (kview:label-separator-length kotl-kview)
 			   1))
 	    (unless (zerop space)
 	      (setq expr (concat "^" (make-string
 				      (- from-indent to-indent
-					 (kview:label-separator-length kview)
+					 (kview:label-separator-length kotl-kview)
 					 1)
 				      ?\ )))
 	      (kview:map-tree
@@ -1203,18 +1203,18 @@ FILL-P is non-nil.  Leave point at TO-START."
 		   (beginning-of-line)
 		   (when (looking-at expr)
 		     (replace-match "" t t))))
-	       kview t)))
+	       kotl-kview t)))
 	  ;;
 	  (when fill-p
 	    ;; Refill cells lacking no-fill attribute.
 	    (kview:map-tree (lambda (_view) (kotl-mode:fill-cell nil t))
-			    kview t))))
+			    kotl-kview t))))
     ;;
     (goto-char new-start)
     ;;
     ;; Restore status of temporarily expanded cells.
     (when (remq 0 collapsed-cells)
-      (kview:set-cells-status kview new-start new-end collapsed-cells))
+      (kview:set-cells-status kotl-kview new-start new-end collapsed-cells))
     ;;
     ;; Delete temporary markers.
     (set-marker new-start nil)))
@@ -1276,9 +1276,9 @@ displayed, since it has hidden branches."
   "Change KVIEW's label display type to NEW-TYPE, updating all displayed labels.
 See documentation for variable, kview:default-label-type, for
 valid values of NEW-TYPE."
-  (interactive (list kview
+  (interactive (list kotl-kview
 		     (let ((completion-ignore-case)
-			   (label-type (kview:label-type kview))
+			   (label-type (kview:label-type kotl-kview))
 			   new-type-str)
 		       (if (string-equal
 			    ""
@@ -1383,10 +1383,10 @@ unless no previous cell."
 
 (defun kview:set-functions (label-type)
   "Setup functions which handle labels of LABEL-TYPE for current view."
-  (kview:set-attr kview 'label-function (klabel-type:function label-type))
-  (kview:set-attr kview 'label-child (klabel-type:child label-type))
-  (kview:set-attr kview 'label-increment (klabel-type:increment label-type))
-  (kview:set-attr kview 'label-parent (klabel-type:parent label-type)))
+  (kview:set-attr kotl-kview 'label-function (klabel-type:function label-type))
+  (kview:set-attr kotl-kview 'label-child (klabel-type:child label-type))
+  (kview:set-attr kotl-kview 'label-increment (klabel-type:increment label-type))
+  (kview:set-attr kotl-kview 'label-parent (klabel-type:parent label-type)))
 
 (defun kview:set-label-separator (label-separator &optional set-default-p)
   "Set the LABEL-SEPARATOR between labels and cell contents for the current kview.
@@ -1395,16 +1395,16 @@ With optional prefix arg SET-DEFAULT-P, the default separator value used for
 new outlines is also set to this new value."
   (interactive
    (progn (barf-if-buffer-read-only)
-	  (list (if (kview:is-p kview)
+	  (list (if (kview:is-p kotl-kview)
 		    (read-string
 		     (format
 		      "Change current%s label separator from \"%s\" to: "
 		      (if current-prefix-arg " and default" "")
-		      (kview:label-separator kview))))
+		      (kview:label-separator kotl-kview))))
 		current-prefix-arg)))
 
   (barf-if-buffer-read-only)
-  (cond ((not (kview:is-p kview))
+  (cond ((not (kview:is-p kotl-kview))
 	 (error "(kview:set-label-separator): This is not a koutline"))
 	((not (stringp label-separator))
 	 (error "(kview:set-label-separator): Invalid separator, \"%s\""
@@ -1413,7 +1413,7 @@ new outlines is also set to this new value."
 	 (error "(kview:set-label-separator): Separator must be two or more characters, \"%s\""
 		label-separator)))
 
-  (let* ((old-sep-len (kview:label-separator-length kview))
+  (let* ((old-sep-len (kview:label-separator-length kotl-kview))
 	 (sep-len (length label-separator))
 	 (sep-len-increase (- sep-len old-sep-len))
 	 (indent)
@@ -1445,8 +1445,8 @@ new outlines is also set to this new value."
       ;; Reindent all lines in cells except the first line which has already
       ;; been done.
       (funcall reindent-function))
-    (kview:set-attr kview 'label-separator label-separator)
-    (kview:set-attr kview 'label-separator-length sep-len)
+    (kview:set-attr kotl-kview 'label-separator label-separator)
+    (kview:set-attr kotl-kview 'label-separator-length sep-len)
     (when set-default-p
       (setq kview:default-label-separator label-separator))))
 

--- a/kotl/kvspec.el
+++ b/kotl/kvspec.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Oct-95 at 15:17:07
-;; Last-Mod:      3-Oct-23 at 22:28:21 by Mats Lidell
+;; Last-Mod:      4-Oct-23 at 19:10:12 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -141,18 +141,18 @@ display all levels of cells."
        (if (kcell-view:next t)
 	   (kcell-view:previous)
 	 (goto-char (point-max)))))
-   kview t)
-  (kview:set-attr kview 'levels-to-show levels-to-keep))
+   kotl-kview t)
+  (kview:set-attr kotl-kview 'levels-to-show levels-to-keep))
 
 (defun kvspec:show-lines-per-cell (num)
   "Show NUM lines per visible cell; 0 means show all lines in each visible cell."
   (if (or (not (integerp num)) (< num 0))
       (error "(kvspec:show-lines-per-cell): Invalid lines per cell, `%d'" num))
-  (kview:set-attr kview 'lines-to-show num)
+  (kview:set-attr kotl-kview 'lines-to-show num)
   ;; Now show NUM lines in cells.
   (kview:map-tree (lambda (_kview)
 		    (kcell-view:expand (point))
-		    (kvspec:show-lines-this-cell num)) kview t t))
+		    (kvspec:show-lines-this-cell num)) kotl-kview t t))
 
 (defun kvspec:toggle-blank-lines ()
   "Toggle blank lines between cells on or off."
@@ -198,10 +198,10 @@ view specs."
 	(buffer-read-only))
       (if (string-match "b" kvspec:current)
 	  ;; On
-	  (progn (kview:set-attr kview 'blank-lines t)
+	  (progn (kview:set-attr kotl-kview 'blank-lines t)
 		 (kproperty:remove (point-min) (point-max) '(invisible t)))
 	;; Off
-	(kview:set-attr kview 'blank-lines nil)
+	(kview:set-attr kotl-kview 'blank-lines nil)
 	(save-excursion
 	  (goto-char (point-max))
 	  (while (re-search-backward "[\n\r][\n\r]" nil t)
@@ -220,10 +220,10 @@ view specs."
    ;; it off when he resets the view specs.
 
    ;; b - blank separator lines
-   (if (kview:get-attr kview 'blank-lines) "b")
+   (if (kview:get-attr kotl-kview 'blank-lines) "b")
 
    ;; c - cutoff lines per cell
-   (let ((lines (kview:get-attr kview 'lines-to-show)))
+   (let ((lines (kview:get-attr kotl-kview 'lines-to-show)))
      (if (zerop lines)
 	 nil
        (concat "c" (int-to-string lines))))
@@ -232,17 +232,17 @@ view specs."
    (if selective-display-ellipses "e")
 
    ;; l - hide some levels
-   (let ((levels (kview:get-attr kview 'levels-to-show)))
+   (let ((levels (kview:get-attr kotl-kview 'levels-to-show)))
      (if (zerop levels)
 	 nil
        (concat "l" (int-to-string levels))))
 
    ;; n - numbering type
-   (let ((type (kview:label-type kview)))
+   (let ((type (kview:label-type kotl-kview)))
      (cond ((eq type 'no) nil)
 	   ((eq type kview:default-label-type) "n")
 	   (t (concat "n" (char-to-string
-			   (car (rassq (kview:label-type kview)
+			   (car (rassq (kview:label-type kotl-kview)
 				       kvspec:label-type-alist)))))))))
 
 (defun kvspec:elide ()
@@ -285,7 +285,7 @@ view specs."
 	  (setq spec (string-to-char (match-string 1 kvspec:current))
 		type (cdr (assq spec kvspec:label-type-alist)))
 	(setq type kview:default-label-type))
-      (kview:set-label-type kview type))))
+      (kview:set-label-type kotl-kview type))))
 
 (defun kvspec:show-lines-this-cell (num)
   "Assume current cell is fully expanded and collapse to show NUM lines within it.

--- a/test/kotl-mode-tests.el
+++ b/test/kotl-mode-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    18-May-21 at 22:14:10
-;; Last-Mod:     28-Aug-23 at 00:07:23 by Bob Weiner
+;; Last-Mod:      4-Oct-23 at 19:10:12 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -103,7 +103,7 @@
           (should (string= (kcell-view:label (point)) "1"))
           (should (hact 'kbd-key "C-c C-v 0 RET"))
           (hy-test-helpers:consume-input-events)
-          (should (eq (kview:label-type kview) 'id))
+          (should (eq (kview:label-type kotl-kview) 'id))
           (should (string= (kcell-view:label (point)) "01")))
       (hy-delete-file-and-buffer kotl-file))))
 
@@ -119,7 +119,7 @@
 
           ;; Verify idstamp label
           (kvspec:activate "ben0")
-          (should (eq (kview:label-type kview) 'id))
+          (should (eq (kview:label-type kotl-kview) 'id))
           (should (string= (kcell-view:idstamp) "01"))
           (should (string= (kcell-view:label (point)) "01"))
 
@@ -128,7 +128,7 @@
           (save-buffer)
           (kill-buffer)
           (find-file kotl-file)
-          (should (eq (kview:label-type kview) 'id))
+          (should (eq (kview:label-type kotl-kview) 'id))
           (should (string= (kcell-view:idstamp) "01"))
           (should (string= (kcell-view:label (point)) "01")))
       (hy-delete-file-and-buffer kotl-file))))

--- a/test/kotl-mode-tests.el
+++ b/test/kotl-mode-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    18-May-21 at 22:14:10
-;; Last-Mod:      4-Oct-23 at 19:10:12 by Mats Lidell
+;; Last-Mod:      5-Oct-23 at 21:15:10 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -119,7 +119,7 @@
 
           ;; Verify idstamp label
           (kvspec:activate "ben0")
-          (should (eq (kview:label-type kotl-kview) 'id))
+          (should (equal (kview:label-type kotl-kview) 'id))
           (should (string= (kcell-view:idstamp) "01"))
           (should (string= (kcell-view:label (point)) "01"))
 
@@ -132,6 +132,64 @@
           (should (string= (kcell-view:idstamp) "01"))
           (should (string= (kcell-view:label (point)) "01")))
       (hy-delete-file-and-buffer kotl-file))))
+
+(ert-deftest kotl-mode-kview-buffer-local ()
+  "Verify kotl-kview is buffer local."
+  (let ((kotl-file (make-temp-file "hypb" nil ".kotl")))
+    (unwind-protect
+        (progn
+          (find-file kotl-file)
+          (should (string-match-p (concat "Local in buffer " (file-name-nondirectory (buffer-file-name)))
+                                  (describe-variable 'kotl-kview))))
+      (hy-delete-file-and-buffer kotl-file))))
+
+(ert-deftest kotl-mode-kvspec-saved-with-file ()
+  "The active view mode is saved with the file."
+  (let ((kotl-file (make-temp-file "hypb" nil ".kotl")))
+    (unwind-protect
+        (progn
+          (find-file kotl-file)
+          (should (equal (kview:label-type kotl-kview) 'alpha))
+          (should (equal kvspec:current "ben"))
+
+          (kvspec:activate "en.")
+          (should (equal (kview:label-type kotl-kview) 'legal))
+
+          ;; Verify kvspec is kept when saving and opening
+          (set-buffer-modified-p t)
+          (save-buffer)
+          (kill-buffer)
+          (find-file kotl-file)
+          (should (equal kvspec:current "en."))
+          (should (equal (kview:label-type kotl-kview) 'legal)))
+      (hy-delete-file-and-buffer kotl-file))))
+
+(ert-deftest kotl-mode-kvspec-independent-between-files ()
+  "Modifying kvspec in one file does not affect another."
+  (let ((kotl-file-a (make-temp-file "hypb" nil ".kotl"))
+        (kotl-file-b (make-temp-file "hypb" nil ".kotl")))
+    (unwind-protect
+        (progn
+          (find-file kotl-file-a)
+          (should (equal (kview:label-type kotl-kview) 'alpha))
+          (should (equal kvspec:current "ben"))
+          (kvspec:activate "en.")
+          (should (equal (kview:label-type kotl-kview) 'legal))
+          (should (equal kvspec:current "en."))
+
+          (find-file kotl-file-b)
+          (should (equal (kview:label-type kotl-kview) 'alpha))
+          (should (equal kvspec:current "ben"))
+          (kvspec:activate "en0")
+          (should (equal (kview:label-type kotl-kview) 'id))
+          (should (equal kvspec:current "en0"))
+
+          ;; Verify kvspec is kept in kotl-file-a
+          (find-file kotl-file-a)
+          (should (equal (kview:label-type kotl-kview) 'legal))
+          (should (equal kvspec:current "en.")))
+      (hy-delete-file-and-buffer kotl-file-a)
+      (hy-delete-file-and-buffer kotl-file-b))))
 
 (ert-deftest kotl-mode-demote-keeps-idstamp ()
   "When tree is demoted the idstamp label is not changed."


### PR DESCRIPTION
## What

Add kotl prefix to kview buffer local variable.

## Why

Removes warnings for kview lacking a prefix. Makes code easier to read since parameters exists with the same name. Warnings for that are also avoided by this change.