### PR TITLE
Remove compiler warnings introduced lately

### DIFF
--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:      3-Oct-23 at 17:26:52 by Mats Lidell
+;; Last-Mod:      4-Oct-23 at 20:00:02 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -52,6 +52,7 @@ Use the function, (hbut:max-len), to read the proper value.")
 (declare-function hpath:substitute-var "hpath")
 (declare-function hpath:symlink-referent "hpath")
 (declare-function hpath:www-p "hpath")
+(declare-function hpath:shorten "hpath")
 (declare-function hsys-org-block-start-at-p "hsys-org")
 (declare-function hsys-org-src-block-start-at-p "hsys-org")
 (declare-function hui:buf-writable-err "hui")

--- a/hmouse-drv.el
+++ b/hmouse-drv.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-90
-;; Last-Mod:      3-Oct-23 at 23:22:38 by Mats Lidell
+;; Last-Mod:      4-Oct-23 at 20:04:08 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -652,7 +652,7 @@ RELEASE-WINDOW is interactively selected via the `ace-window' command.
 The selected window does not change.
 
 With no prefix argument, create an explicit button.
-With a C-u '(4) prefix argument, create an unnamed implicit button.
+With a C-u \\='(4) prefix argument, create an unnamed implicit button.
 With a M-1 prefix argument, create an named implicit button."
   (interactive
    (list (let ((mode-line-text (concat " Ace - Hyperbole: " (nth 2 (assq ?w aw-dispatch-alist)))))

--- a/hui-mouse.el
+++ b/hui-mouse.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-89
-;; Last-Mod:      3-Oct-23 at 22:56:59 by Mats Lidell
+;; Last-Mod:      6-Oct-23 at 16:13:42 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -48,6 +48,8 @@
 (unless (fboundp 'smart-c-at-tag-p)
   (require 'hmouse-tag))
 (require 'imenu)
+(eval-when-compile
+  (require 'eieio))
 
 (eval-when-compile (require 'tar-mode))
 
@@ -1531,6 +1533,11 @@ If assist-key is pressed:
 	   (if non-text-area-p
 	       (magit-section-cycle-global)
 	     (smart-magit-display-file (key-binding (kbd "RET"))))))))
+
+;; Silence compiler about unknown slot. From eieio-tests.el
+(eval-when-compile
+  (dolist (slot '(content washer hidden start))
+    (cl-pushnew slot eieio--known-slot-names)))
 
 ;; Thanks to Jonas Bernoulli <tarsius>, magit author, for most of this
 ;; next function.

--- a/hui.el
+++ b/hui.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 21:42:03
-;; Last-Mod:      3-Oct-23 at 23:02:02 by Mats Lidell
+;; Last-Mod:      4-Oct-23 at 20:07:50 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1291,7 +1291,7 @@ drag from a window to another window's modeline."
       ;; single C-u prefix argument.  In such a case, don't use the
       ;; prefix argument as a flag to prompt for the ibutton name as
       ;; we want to just insert the appropriate ibut without any prompting.
-      (when (and name-arg-flag (not (eq name-arg-flag '(4))) (not name-key))
+      (when (and name-arg-flag (not (equal name-arg-flag '(4))) (not name-key))
 	(setq but-name (hui:hbut-label
 			(cond ((hmouse-prior-active-region)
 			       hkey-region)

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:      4-Oct-23 at 19:10:12 by Mats Lidell
+;; Last-Mod:      6-Oct-23 at 23:15:03 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -29,6 +29,7 @@
 (defvar cmpl-last-insert-location)
 (defvar cmpl-original-string)
 (defvar completion-to-accept)
+(defvar mwheel-scroll-down-function)    ; "mwheel"
 
 (declare-function outline-invisible-in-p "hyperbole")
 


### PR DESCRIPTION
## What

Remove compiler warnings introduced lately. These are the last easy warning to remove.

## Why

We want hyperbole to compile with not warnings.