### PR TITLE
Update defcustom type for hui-mini menus

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-10-07  Mats Lidell  <matsl@gnu.org>
+
+* hui-mini.el: Update defcustom type for hui-mini menus.
+
 2023-10-05  Mats Lidell  <matsl@gnu.org>
 
 * test/kotl-mode-tests.el (kotl-mode-kview-buffer-local)

--- a/hui-mini.el
+++ b/hui-mini.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Oct-91 at 20:13:17
-;; Last-Mod:      3-Oct-23 at 23:19:25 by Mats Lidell
+;; Last-Mod:      7-Oct-23 at 00:56:25 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -965,7 +965,7 @@ The menu is a menu of commands from MENU-ALIST."
 	      (progn (set-default var value)
 		     (hyperbole-minibuffer-menu))
 	    (set-default var value)))
-  :type '(list string sexp (set string nil))
+  :type '(cons (list string) (repeat (list string sexp string)))
   :group 'hyperbole-buttons)
 
 (defcustom hui:menu-to
@@ -1004,7 +1004,7 @@ The menu is a menu of commands from MENU-ALIST."
 	      (progn (set-default var value)
 		     (hyperbole-minibuffer-menu))
 	    (set-default var value)))
-  :type '(list string sexp (set string nil))
+  :type '(cons (list string) (repeat (list string sexp string)))
   :group 'hyperbole-buttons)
 
 (defcustom hui:doc-a-z
@@ -1043,7 +1043,7 @@ The menu is a menu of commands from MENU-ALIST."
 	      (progn (set-default var value)
 		     (hyperbole-minibuffer-menu))
 	    (set-default var value)))
-  :type '(list string sexp (set string nil))
+  :type '(cons (list string) (repeat (list string sexp)))
   :group 'hyperbole-buttons)
 
 ;;; ************************************************************************


### PR DESCRIPTION
## What

Update defcustom type for hui-mini menus so that customize works. Extra bonus removes warnings about not valid type.

## Why

I noted the following warnings for[ the master build](https://github.com/rswgnu/hyperbole/actions/runs/6439996123/attempts/1#summary-17488335276).

```
hui-mini.el:941:12: Warning: in defcustom for `hui:menu-rolo': `nil' is not a valid type
hui-mini.el:971:12: Warning: in defcustom for `hui:menu-to': `nil' is not a valid type
hui-mini.el:1010:12: Warning: in defcustom for `hui:doc-a-z': `nil' is not a valid type
```

That led me to try to use the defcustom for these menues and they were broken. I have verified with 27.2 that the defcustom works as expected after this change.

Q: Do we want to have these menus customizable? (Using customize for long and complicated expressions feels to me like a bad interface. Would you as a user not prefer to define the menu a lisp expression!?) 

## Note

### Different warnings from native run and docker run
Interesting thing is that we are getting a few warnings when we build using the docker images that I don't see when building natively on my machine. I do not get these. I have no idea why. Is it because I run a local emacs that has native compilation!? When I run in docker locally I get the same warnings as in CI/CD which is expected. 

### hui:doc-a-z

This menu is a little complicated since it also have items that does not have an sexp. See the the last "<Quit-Menu>" selection. From the editing perspective it seems like setting the sexp to nil works and the default value is displayed properly. So this menu might benefit from another type definition. 
