### PR TITLE
Make separate compilation aware of non byte compiled files

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 2023-10-07  Mats Lidell  <matsl@gnu.org>
 
+* hsys-org-roam.el: Byte compile. Warning is handled by declaration.
+
+* Makefile (EL_SRC): Add macro for all el-files, both compiled and not
+    compiled.
+
 * hui-mini.el: Update defcustom type for hui-mini menus.
 
 2023-10-05  Mats Lidell  <matsl@gnu.org>

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:      3-Oct-23 at 15:47:37 by Mats Lidell
+# Last-Mod:      6-Oct-23 at 00:22:25 by Mats Lidell
 #
 # Copyright (C) 1994-2023  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -185,9 +185,11 @@ EL_COMPILE = hact.el hactypes.el hargs.el hbdata.el hbmap.el hbut.el \
 	     hpath.el hrmail.el hsettings.el hsmail.el hsys-org.el hsys-org-roam.el \
              hsys-www.el hsys-youtube.el htz.el \
 	     hycontrol.el hui-jmenu.el hui-menu.el hui-mini.el hui-mouse.el hui-select.el \
-	     hui-treemacs.el hui-window.el hui.el hvar.el hversion.el hvm.el hypb.el hyperbole.el \
+	     hui-treemacs.el hui-window.el hui.el hvar.el hversion.el hypb.el hyperbole.el \
 	     hyrolo-demo.el hyrolo-logic.el hyrolo-menu.el hyrolo.el hywconfig.el set.el hypb-ert.el \
 	     hui-dired-sidebar.el hypb-maintenance.el hui-em-but.el hui-register.el
+
+EL_SRC = $(EL_COMPILE) hvm.el
 
 EL_KOTL = kotl/kexport.el kotl/kfile.el kotl/kfill.el kotl/kimport.el kotl/klabel.el \
 	  kotl/klink.el kotl/kmenu.el kotl/kotl-mode.el kotl/kotl-orgtbl.el \
@@ -199,7 +201,7 @@ ELC_KOTL = $(EL_KOTL:.el=.elc)
 
 HY-TALK  = HY-TALK/.hypb HY-TALK/HYPB HY-TALK/HY-TALK.org
 
-HYPERBOLE_FILES = dir info html $(EL_COMPILE) $(EL_KOTL) \
+HYPERBOLE_FILES = dir info html $(EL_SRC) $(EL_KOTL) \
 	$(ELC_COMPILE) $(HY-TALK) ChangeLog COPYING Makefile HY-ABOUT HY-ANNOUNCE \
         HY-CONCEPTS.kotl HY-NEWS \
 	HY-WHY.kotl INSTALL DEMO DEMO-ROLO.otl FAST-DEMO MANIFEST README README.md TAGS _hypb \
@@ -208,7 +210,7 @@ HYPERBOLE_FILES = dir info html $(EL_COMPILE) $(EL_KOTL) \
 
 TEST_ERT_FILES = $(wildcard test/*tests.el) $(wildcard test/hy-test-*.el)
 
-EL_TAGS = $(EL_COMPILE) $(EL_KOTL) $(TEST_ERT_FILES)
+EL_TAGS = $(EL_SRC) $(EL_KOTL) $(TEST_ERT_FILES)
 
 .SUFFIXES:            # Delete the default suffixes
 .SUFFIXES: .el .elc   # Define the list of file suffixes to match to rules
@@ -319,23 +321,11 @@ remove-elc:
 
 # Remove and then rebuild all byte-compiled .elc files, even those .elc files
 # which do not yet exist, plus build TAGS file.
-#
-# Use this to suppress docstring warnings.
-#	$(EMACS_BATCH) --eval="(setq-default byte-compile-warnings '(not docstrings))" \
-#		-f batch-byte-compile $(EL_KOTL) $(EL_COMPILE)
 bin: src remove-elc new-bin
 
 # Native compilation (Requires Emacs built with native compilation support.)
 eln: src
 	HYPB_NATIVE_COMP=yes make new-bin
-
-# Create -l file.el load-file command-line args for each Hyperbole .el file for use in
-# eln native compile target below.
-LOAD_EL = $(shell echo "$(EL_KOTL) $(EL_COMPILE)" | sed -e 's+^+./+' -e 's+ + -l ./+g' -e 's+^+-l +')
-
-load-hyperbole:
-	$(EMACS_BATCH) \
-          $(LOAD_EL)
 
 tags: TAGS
 TAGS: $(EL_TAGS)
@@ -520,4 +510,4 @@ package-lint:
 	--eval "(setq package-lint-main-file \"hyperbole.el\")" \
 	--eval "(load-file \"test/hy-test-dependencies.el\")" \
 	-l package-lint.el -f package-lint-batch-and-exit \
-	$(EL_KOTL) $(EL_COMPILE)
+	$(EL_KOTL) $(EL_SRC)

--- a/hsys-org-roam.el
+++ b/hsys-org-roam.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    26-Feb-23 at 11:20:15 by Bob Weiner
-;; Last-Mod:     23-Apr-23 at 22:05:38 by Mats Lidell
+;; Last-Mod:      6-Oct-23 at 00:11:40 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -53,13 +53,6 @@ Prompt for the search pattern."
 	     consult-org-roam-grep-func))))
 
 (provide 'hsys-org-roam)
-
-;;  Don't byte-compile since may not have org-roam package and then
-;;  will get an 'org-roam-directory' undefined error.
-
-;;  Local Variables:
-;;  no-byte-compile: t
-;;  End:
 
 ;;; hsys-org-roam.el ends here
 


### PR DESCRIPTION
## What

Make separate compilation aware of non byte compiled files.

## Why

Two files were set as to not to be byte compiled in the local variables section, `hvm.el` and  `hsys-org-roam.el`. This does not work well with separate compilation of el files. This change makes `make` aware of files that are not supposed to be byte compiled by adding the macro `EL_SRC` that contains all el-files in the root folder. The macro `EL_COMPILE` can then define the files that are supposed to be byte compiled.

As an extra step, byte compilation of `hsys-org-roam.el` is now allowed, since the warning it was meant to avoid is now handled by the declarations. This leaves hvm.el as the single non byte compiled file in the package.