### PR TITLE
Verify number of global ibuts and ebuts

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,11 +3,11 @@
 * test/hui-tests.el (hui-gbut-number-of-gebuts-from-mail-mode): Remove
     expected to fail.
 
-* hbut.el (gbut:ebut-key-list): Use hbdata--to-entry-in-file for global
+* hbut.el (gbut:ebut-key-list): Use hbdata:to-entry-in-file for global
     button file data.
 
-* hbdata.el (hbdata--is-but-data-stored-in-buffer)
-    (hbdata--to-entry-in-buffer, hbdata--to-entry-in-file): Refactor into
+* hbdata.el (hbdata:is-but-data-stored-in-buffer)
+    (hbdata:to-entry-in-buffer, hbdata:to-entry-in-file): Refactor into
     three methods to separate out button data stored in a file.
     (hbdata:to-entry-buf): Use new methods.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2023-10-22  Mats Lidell  <matsl@gnu.org>
+
+* test/hui-tests.el (hui-gbut-number-of-gbuts-with-no-buttons)
+    (hui-gbut-number-of-gibuts-one, hui-gbut-number-of-gebuts-one)
+    (hui-gbut-number-of-gibuts-from-mail-mode)
+    (hui-gbut-number-of-gebuts-from-mail-mode): Verify number of global
+    ibuts and ebuts.
+
 2023-10-22  Bob Weiner  <rsw@gnu.org>
 
 * hbut.el (gbut:save-buffer): Add function to use after global button file is

--- a/ChangeLog
+++ b/ChangeLog
@@ -14,7 +14,8 @@
 2023-10-11  Mats Lidell  <matsl@gnu.org>
 
 * test/hui-tests.el (hui-gbut-number-of-gbuts-with-no-buttons)
-    (hui-gbut-number-of-gibuts-one, hui-gbut-number-of-gebuts-one)
+    (hui-gbut-number-of-gibuts-when-one-button)
+    (hui-gbut-number-of-gebuts-when-one-button)
     (hui-gbut-number-of-gibuts-from-mail-mode)
     (hui-gbut-number-of-gebuts-from-mail-mode): Verify number of global
     ibuts and ebuts.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,18 @@
 2023-10-22  Mats Lidell  <matsl@gnu.org>
 
+* test/hui-tests.el (hui-gbut-number-of-gebuts-from-mail-mode): Remove
+    expected to fail.
+
+* hbut.el (gbut:ebut-key-list): Use hbdata--to-entry-in-file for global
+    button file data.
+
+* hbdata.el (hbdata--is-but-data-stored-in-buffer)
+    (hbdata--to-entry-in-buffer, hbdata--to-entry-in-file): Refactor into
+    three methods to separate out button data stored in a file.
+    (hbdata:to-entry-buf): Use new methods.
+
+2023-10-11  Mats Lidell  <matsl@gnu.org>
+
 * test/hui-tests.el (hui-gbut-number-of-gbuts-with-no-buttons)
     (hui-gbut-number-of-gibuts-one, hui-gbut-number-of-gebuts-one)
     (hui-gbut-number-of-gibuts-from-mail-mode)

--- a/hbdata.el
+++ b/hbdata.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Apr-91
-;; Last-Mod:     22-Oct-23 at 14:39:18 by Mats Lidell
+;; Last-Mod:     22-Oct-23 at 14:42:47 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -459,14 +459,13 @@ Return value of evaluation when a matching entry is found or nil."
 Note: Button buffer has no file attached.  With optional CREATE,
 if no such line exists, insert a new entry at the beginning of
 the hbdata (which is created if necessary).  Return t."
-  (progn
-    (if (hmail:hbdata-to-p) ;; Might change the buffer
-	(setq buffer-read-only nil)
-      (when create
-	(setq buffer-read-only nil)
-	(insert "\n" hmail:hbdata-sep "\n")))
-    (backward-char 1)
-    t))
+  (if (hmail:hbdata-to-p) ;; Might change the buffer
+      (setq buffer-read-only nil)
+    (when create
+      (setq buffer-read-only nil)
+      (insert "\n" hmail:hbdata-sep "\n")))
+  (backward-char 1)
+  t)
 
 (defun hbdata:to-entry-in-file (key-src &optional directory create)
   "Move point to end of line in but data buffer matching KEY-SRC.

--- a/hbdata.el
+++ b/hbdata.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Apr-91
-;; Last-Mod:     18-Oct-23 at 22:48:05 by Mats Lidell
+;; Last-Mod:     22-Oct-23 at 14:39:18 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -443,7 +443,7 @@ Return value of evaluation when a matching entry is found or nil."
 	  (when end-func (funcall end-func)))))
     rtn))
 
-(defun hbdata--is-but-data-stored-in-buffer (key-src)
+(defun hbdata:is-but-data-stored-in-buffer (key-src)
   "True if we store but-data in the buffer rather than in a file."
   ;; Drafts of mail messages now have a buffer-file-name since they
   ;; are temporarily saved to a file until sent.  But but-data still
@@ -454,7 +454,7 @@ Return value of evaluation when a matching entry is found or nil."
            (set-buffer key-src)
 	   (not buffer-file-name))))
 
-(defun hbdata--to-entry-in-buffer (create)
+(defun hbdata:to-entry-in-buffer (create)
   "Move point to end of line in but data in current buffer.
 Note: Button buffer has no file attached.  With optional CREATE,
 if no such line exists, insert a new entry at the beginning of
@@ -468,7 +468,7 @@ the hbdata (which is created if necessary).  Return t."
     (backward-char 1)
     t))
 
-(defun hbdata--to-entry-in-file (key-src &optional directory create)
+(defun hbdata:to-entry-in-file (key-src &optional directory create)
   "Move point to end of line in but data buffer matching KEY-SRC.
 Use hbdata file in KEY-SRC's directory, or optional DIRECTORY or if nil, use
 `default-directory'.
@@ -506,9 +506,9 @@ Use hbdata file in KEY-SRC's directory, or optional DIRECTORY or if nil, use
 With optional CREATE, if no such line exists, insert a new file entry at the
 beginning of the hbdata file (which is created if necessary).
 Return non-nil if KEY-SRC is found or created, else nil."
-    (if (hbdata--is-but-data-stored-in-buffer key-src)
-        (hbdata--to-entry-in-buffer create)
-      (hbdata--to-entry-in-file key-src directory create)))
+    (if (hbdata:is-but-data-stored-in-buffer key-src)
+        (hbdata:to-entry-in-buffer create)
+      (hbdata:to-entry-in-file key-src directory create)))
 
 (defun hbdata:to-hbdata-buffer (dir &optional create)
   "Read in the file containing DIR's button data, if any, and return buffer.

--- a/hbdata.el
+++ b/hbdata.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Apr-91
-;; Last-Mod:      3-Oct-23 at 22:48:03 by Mats Lidell
+;; Last-Mod:     18-Oct-23 at 22:48:05 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -443,7 +443,32 @@ Return value of evaluation when a matching entry is found or nil."
 	  (when end-func (funcall end-func)))))
     rtn))
 
-(defun hbdata:to-entry-buf (key-src &optional directory create)
+(defun hbdata--is-but-data-stored-in-buffer (key-src)
+  "True if we store but-data in the buffer rather than in a file."
+  ;; Drafts of mail messages now have a buffer-file-name since they
+  ;; are temporarily saved to a file until sent.  But but-data still
+  ;; should be stored in the mail buffer itself, so check explicitly
+  ;; whether is a mail composition buffer in such cases.
+  (or (hmail:mode-is-p)
+      (and (get-buffer key-src)
+           (set-buffer key-src)
+	   (not buffer-file-name))))
+
+(defun hbdata--to-entry-in-buffer (create)
+  "Move point to end of line in but data in current buffer.
+Note: Button buffer has no file attached.  With optional CREATE,
+if no such line exists, insert a new entry at the beginning of
+the hbdata (which is created if necessary).  Return t."
+  (progn
+    (if (hmail:hbdata-to-p) ;; Might change the buffer
+	(setq buffer-read-only nil)
+      (when create
+	(setq buffer-read-only nil)
+	(insert "\n" hmail:hbdata-sep "\n")))
+    (backward-char 1)
+    t))
+
+(defun hbdata--to-entry-in-file (key-src &optional directory create)
   "Move point to end of line in but data buffer matching KEY-SRC.
 Use hbdata file in KEY-SRC's directory, or optional DIRECTORY or if nil, use
 `default-directory'.
@@ -452,43 +477,38 @@ beginning of the hbdata file (which is created if necessary).
 Return non-nil if KEY-SRC is found or created, else nil."
   (let (rtn
 	ln-dir)
-    ;; Drafts of mail messages now have a buffer-file-name since they
-    ;; are temporarily saved to a file until sent.  But but-data still
-    ;; should be stored in the mail buffer itself, so check explicitly
-    ;; whether is a mail composition buffer in such cases.
-    (if (or (hmail:mode-is-p)
-	    (and (get-buffer key-src)
-		 (set-buffer key-src)
-		 (not buffer-file-name)))
-	;; Button buffer has no file attached
-	(progn (if (hmail:hbdata-to-p) ;; Might change the buffer
-		   (setq buffer-read-only nil)
-		 (when create
-		   (setq buffer-read-only nil)
-		   (insert "\n" hmail:hbdata-sep "\n")))
-	       (backward-char 1)
-	       (setq rtn t))
-      (setq directory (or (file-name-directory key-src) directory))
-      (let ((ln-file) (link-p key-src))
-	(while (setq link-p (file-symlink-p link-p))
-	  (setq ln-file link-p))
-	(if ln-file
-	    (setq ln-dir (file-name-directory ln-file)
-		  key-src (file-name-nondirectory ln-file))
-	  (setq key-src (file-name-nondirectory key-src))))
-      (when (or (hbdata:to-hbdata-buffer directory create)
-		(and ln-dir (hbdata:to-hbdata-buffer ln-dir nil)
-		     (setq create nil
-			   directory ln-dir)))
-	(goto-char 1)
-	(cond ((search-forward (concat "\^L\n\"" key-src "\"")
-			       nil t)
-	       (setq rtn t))
-	      (create
-	       (setq rtn t)
-	       (insert "\^L\n\"" key-src "\"\n")
-	       (backward-char 1)))))
+    (setq directory (or (file-name-directory key-src) directory))
+    (let ((ln-file) (link-p key-src))
+      (while (setq link-p (file-symlink-p link-p))
+	(setq ln-file link-p))
+      (if ln-file
+	  (setq ln-dir (file-name-directory ln-file)
+		key-src (file-name-nondirectory ln-file))
+	(setq key-src (file-name-nondirectory key-src))))
+    (when (or (hbdata:to-hbdata-buffer directory create)
+	      (and ln-dir (hbdata:to-hbdata-buffer ln-dir nil)
+		   (setq create nil
+			 directory ln-dir)))
+      (goto-char 1)
+      (cond ((search-forward (concat "\^L\n\"" key-src "\"")
+			     nil t)
+	     (setq rtn t))
+	    (create
+	     (setq rtn t)
+	     (insert "\^L\n\"" key-src "\"\n")
+	     (backward-char 1))))
     rtn))
+
+(defun hbdata:to-entry-buf (key-src &optional directory create)
+  "Move point to end of line in but data buffer matching KEY-SRC.
+Use hbdata file in KEY-SRC's directory, or optional DIRECTORY or if nil, use
+`default-directory'.
+With optional CREATE, if no such line exists, insert a new file entry at the
+beginning of the hbdata file (which is created if necessary).
+Return non-nil if KEY-SRC is found or created, else nil."
+    (if (hbdata--is-but-data-stored-in-buffer key-src)
+        (hbdata--to-entry-in-buffer create)
+      (hbdata--to-entry-in-file key-src directory create)))
 
 (defun hbdata:to-hbdata-buffer (dir &optional create)
   "Read in the file containing DIR's button data, if any, and return buffer.

--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:     22-Oct-23 at 15:33:08 by Mats Lidell
+;; Last-Mod:     22-Oct-23 at 15:34:09 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -838,7 +838,7 @@ Return the symbol for the button when found, else nil."
   "Return a list of explicit button label keys from the global button file."
   (save-excursion
     (save-restriction
-      (when (hbdata--to-entry-in-file (gbut:file))
+      (when (hbdata:to-entry-in-file (gbut:file))
 	(let (gbuts)
 	  (save-restriction
 	    (narrow-to-region (point) (if (search-forward "\f" nil t)

--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:     22-Oct-23 at 08:42:11 by Bob Weiner
+;; Last-Mod:     22-Oct-23 at 15:33:08 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -838,7 +838,7 @@ Return the symbol for the button when found, else nil."
   "Return a list of explicit button label keys from the global button file."
   (save-excursion
     (save-restriction
-      (when (hbdata:to-entry-buf (gbut:file))
+      (when (hbdata--to-entry-in-file (gbut:file))
 	(let (gbuts)
 	  (save-restriction
 	    (narrow-to-region (point) (if (search-forward "\f" nil t)

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     22-Oct-23 at 15:19:40 by Mats Lidell
+;; Last-Mod:     22-Oct-23 at 15:25:05 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -140,10 +140,6 @@
           (gbut:ebut-program "label" 'link-to-directory "/tmp")
           (find-file message-mode-file)
           (message-mode)
-          ;; Remove next line after bug is fixed. We should not care
-          ;; about the message mode file when listing the keys for the
-          ;; global buttons but we do now. See `hbdata:to-entry-buf'
-          (insert "Add text so file is not empty.")
           (should (= 1 (length (gbut:ebut-key-list)))))
       (hy-delete-file-and-buffer global-but-file)
       (hy-delete-file-and-buffer message-mode-file))))

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     11-Oct-23 at 14:40:16 by Mats Lidell
+;; Last-Mod:     18-Oct-23 at 22:49:17 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -131,7 +131,6 @@
 
 (ert-deftest hui-gbut-number-of-gebuts-from-mail-mode ()
   "Verify number of global ebuts are one even from within Hyperbole mail mode."
-  :expected-result :failed
   (defvar global-but-file)
   (let ((global-but-file (make-temp-file "gbut" nil ".txt"))
         (message-mode-file (make-temp-file "gbut" nil ".txt")))

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     17-Jun-23 at 23:02:12 by Bob Weiner
+;; Last-Mod:     11-Oct-23 at 14:40:16 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -83,6 +83,71 @@
       (hy-delete-file-and-buffer linked-file)
       (when (file-writable-p hbmap:dir-user)
 	(delete-directory hbmap:dir-user t)))))
+
+(ert-deftest hui-gbut-number-of-gbuts-with-no-buttons ()
+  "Verify number of buttons are zero when no buttons have been created."
+  (defvar global-but-file)
+  (let ((global-but-file (make-temp-file "gbut" nil ".txt")))
+    (unwind-protect
+        (mocklet ((gbut:file => global-but-file))
+          (should (= 0 (length (gbut:key-list)))))
+      (hy-delete-file-and-buffer global-but-file))))
+
+(ert-deftest hui-gbut-number-of-gibuts-one ()
+  "Verify number of ibuts are one after one button has been created."
+  (defvar file)
+  (let ((file (make-temp-file "gbut" nil ".txt")))
+    (unwind-protect
+        (with-mock
+          (stub gbut:file => file)
+          (hui:gibut-create "global" "/tmp")
+          (should (= 1 (length (gbut:ibut-key-list)))))
+      (hy-delete-file-and-buffer file))))
+
+(ert-deftest hui-gbut-number-of-gebuts-one ()
+  "Verify number of ebuts are one after one button has been created."
+  (defvar global-but-file)
+  (let ((global-but-file (make-temp-file "gbut" nil ".txt")))
+    (unwind-protect
+        (mocklet ((gbut:file => global-but-file)
+                  (hpath:find-noselect => (find-file-noselect global-but-file)))
+          (gbut:ebut-program "label" 'link-to-directory "/tmp")
+          (should (= 1 (length (gbut:ebut-key-list)))))
+      (hy-delete-file-and-buffer global-but-file))))
+
+(ert-deftest hui-gbut-number-of-gibuts-from-mail-mode ()
+  "Verify number of global ibuts are one even from within Hyperbole mail mode."
+  (defvar global-but-file)
+  (let ((global-but-file (make-temp-file "gbut" nil ".txt"))
+        (message-mode-file (make-temp-file "gbut" nil ".txt")))
+    (unwind-protect
+        (mocklet ((gbut:file => global-but-file))
+          (hui:gibut-create "global" "/tmp")
+          (find-file message-mode-file)
+          (message-mode)
+          (should (= 1 (length (gbut:ibut-key-list)))))
+      (hy-delete-file-and-buffer global-but-file)
+      (hy-delete-file-and-buffer message-mode-file))))
+
+(ert-deftest hui-gbut-number-of-gebuts-from-mail-mode ()
+  "Verify number of global ebuts are one even from within Hyperbole mail mode."
+  :expected-result :failed
+  (defvar global-but-file)
+  (let ((global-but-file (make-temp-file "gbut" nil ".txt"))
+        (message-mode-file (make-temp-file "gbut" nil ".txt")))
+    (unwind-protect
+        (mocklet ((gbut:file => global-but-file)
+                  (hpath:find-noselect => (find-file-noselect global-but-file)))
+          (gbut:ebut-program "label" 'link-to-directory "/tmp")
+          (find-file message-mode-file)
+          (message-mode)
+          ;; Remove next line after bug is fixed. We should not care
+          ;; about the message mode file when listing the keys for the
+          ;; global buttons but we do now. See `hbdata:to-entry-buf'
+          (insert "Add text so file is not empty.")
+          (should (= 1 (length (gbut:ebut-key-list)))))
+      (hy-delete-file-and-buffer global-but-file)
+      (hy-delete-file-and-buffer message-mode-file))))
 
 (ert-deftest hui-ibut-label-create ()
   "Create a label for an implicit button."

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     18-Oct-23 at 22:49:17 by Mats Lidell
+;; Last-Mod:     22-Oct-23 at 15:19:40 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -85,7 +85,7 @@
 	(delete-directory hbmap:dir-user t)))))
 
 (ert-deftest hui-gbut-number-of-gbuts-with-no-buttons ()
-  "Verify number of buttons are zero when no buttons have been created."
+  "Verify number of gbuts with no buttons created."
   (defvar global-but-file)
   (let ((global-but-file (make-temp-file "gbut" nil ".txt")))
     (unwind-protect
@@ -93,8 +93,8 @@
           (should (= 0 (length (gbut:key-list)))))
       (hy-delete-file-and-buffer global-but-file))))
 
-(ert-deftest hui-gbut-number-of-gibuts-one ()
-  "Verify number of ibuts are one after one button has been created."
+(ert-deftest hui-gbut-number-of-gibuts-when-one-button ()
+  "Verify number of ibuts when one button is created."
   (defvar file)
   (let ((file (make-temp-file "gbut" nil ".txt")))
     (unwind-protect
@@ -104,8 +104,8 @@
           (should (= 1 (length (gbut:ibut-key-list)))))
       (hy-delete-file-and-buffer file))))
 
-(ert-deftest hui-gbut-number-of-gebuts-one ()
-  "Verify number of ebuts are one after one button has been created."
+(ert-deftest hui-gbut-number-of-gebuts-when-one-button ()
+  "Verify number of ebuts when one button is created."
   (defvar global-but-file)
   (let ((global-but-file (make-temp-file "gbut" nil ".txt")))
     (unwind-protect
@@ -116,7 +116,7 @@
       (hy-delete-file-and-buffer global-but-file))))
 
 (ert-deftest hui-gbut-number-of-gibuts-from-mail-mode ()
-  "Verify number of global ibuts are one even from within Hyperbole mail mode."
+  "Verify number of global ibuts from within Hyperbole mail mode."
   (defvar global-but-file)
   (let ((global-but-file (make-temp-file "gbut" nil ".txt"))
         (message-mode-file (make-temp-file "gbut" nil ".txt")))
@@ -130,7 +130,7 @@
       (hy-delete-file-and-buffer message-mode-file))))
 
 (ert-deftest hui-gbut-number-of-gebuts-from-mail-mode ()
-  "Verify number of global ebuts are one even from within Hyperbole mail mode."
+  "Verify number of global ebuts from within Hyperbole mail mode."
   (defvar global-but-file)
   (let ((global-but-file (make-temp-file "gbut" nil ".txt"))
         (message-mode-file (make-temp-file "gbut" nil ".txt")))


### PR DESCRIPTION
## What

Verify number of global ibuts and ebuts.

## Why

Noticed a bug in `hbdata:to-entry-buf` where we for ebuts look into the `Hyperbole mail mode` (That are mail and news related modes like Gnus summary mode, message mode etc.) Global buttons should not be affected by what mode we are currently in.

This adds a set of test cases that works and one that pin points the error. It is set as expected failure so not to cause CI/CD to break. 