### PR TITLE
Define and use new java-defun-prompt-regexp

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,9 @@
 2023-10-22  Mats Lidell  <matsl@gnu.org>
 
+* hui-select.el (hui-java-defun-prompt-regexp): Add prompt regexp as
+    separate defconst. Update provided by Alan Mackenzie. Thanks.
+    (hui-select-initialize): Use new java regexp.
+
 * test/hui-tests.el (hui-gbut-number-of-gebuts-from-mail-mode): Remove
     expected to fail.
 


### PR DESCRIPTION
## What

Define and use new java-defun-prompt-regexp.

## Why

Regexp has been refined due to investigations related to [Emacs bug#61436](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=61436).  Update is provided by Alan Mackenzie. Thanks.

## Tests

No tests.

## Note

Adding this as PR for easier testing and potentially use in Hyperbole. The regexp is still in a testing status as stated in the Emacs bug report but from my testing it looks OK.

