### PR TITLE
Improve tag/symbol finding, <> and {} handling

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,44 @@
+2023-11-23  Bob Weiner  <rsw@gnu.org>
+
+* hui-select.el (hui-select-syntax-table): Change to copy syntax
+    table so changes do not affect the parent.
+
+* hbut.el (hbut:modify-syntax): Add <> and {} pair support in text
+    and fundamental modes.
+          (require 'mode-local): Use in 'hbut:modify-syntax'.
+  hib-kbd.el (defib kbd-key): Remove explicit syntax setting of braces
+    and just temporarily use Hyperbole-modified text-mode syntax table.
+  hyrolo.el (hyrolo-mode-syntax-table): Remove explicit syntax setting
+    of < > delimiters; inherit from 'text-mode-syntax-table' instead.
+
+* test/hui-select-tests.el (hui-select--thing): Fix to skip 'indent-def
+    by removing final newline.  Label each test section with the type
+    of match expected.
+    (hui-select--thing-interactive-prints-type-of-match): Make similar
+    fixes as in above function.
+
+2023-11-22  Bob Weiner  <rsw@gnu.org>
+
+* hui-mouse.el (hkey-alist): Add clause to handle Smart Key when in
+    a vertico minibuffer window; make it behave like standard vertico
+    which exits and selects the first minibuffer line, not the candidate
+    presently selected.
+
+* hargs.el (hargs:delimited):
+           (require 'thingatpt): For 'bounds-of-thing-at-point'
+    used in 'hargs:delimited' on single char matching delims.
+
+* hui-select.el (hui-select-scan-sexps): Add to fix brace handling
+    as a matching pair when selecting things by using previously
+    unused 'hui-select-syntax-table'.
+
+* hmouse-tag.el (smart-lisp-bound-symbol-def): Rewrite to support
+    Hyperbole type defs like defib, etc.  This improves finding
+    the proper definition of a Hyperbole type.
+                (find-defact-regexp, find-defal-regexp,
+                 find-defib-regexp, find-defil-regexp): Add these
+    entries to 'find-function-regexp-alist'.
+
 2023-11-21  Bob Weiner  <rsw@gnu.org>
 
 * hui-select.el (hui-select-initialize): Fix to set 'syntax-table-sym'

--- a/DEMO
+++ b/DEMO
@@ -1,3 +1,5 @@
+-*- Mode: org; org-cycle-global-at-bob: t; hsys-org-enable-smart-keys: t -*-
+
 * GNU Hyperbole Full Demo/Tutorial by Bob Weiner
 
   Send an email or a testimonial if you like Hyperbole to <rsw@gnu.org>.

--- a/FAST-DEMO
+++ b/FAST-DEMO
@@ -1,4 +1,4 @@
-;;; -*- Mode: org; org-cycle-global-at-bob: t; hsys-org-enable-smart-keys: t -*-
+-*- Mode: org; org-cycle-global-at-bob: t; hsys-org-enable-smart-keys: t -*-
 
 * GNU Hyperbole Fast Demo by Bob Weiner
 
@@ -191,11 +191,11 @@
        Press {C-h A} when over any Hyperbole button for an explanation of
        what it does.
 
-    {M-x dired-other-window RET ${hyperb:dir}/*.el RET}
+    {M-x dired-other-window RET ${hyperb:dir}/*.el M-RET}
 
        Hyperbole home directory Dired listing of Emacs Lisp files only
 
-    {C-c @ 22 RET}
+    {C-22 C-c @}
 
        Display a 2x2 windows grid in the current frame of the 4 most recently
        used buffers.  Before you try this, remember the binding {C-h h h} for
@@ -207,7 +207,7 @@
        Find the Hyperbole Koutliner source files that begin with 'kotl' and
        display them in an auto-sized grid of windows.
 
-    {C-u 0 C-c @ emacs-lisp-mode RET 33 RET}
+    {C-0 C-c @ emacs-lisp-mode RET 33 RET}
 
        Display the 9 mostly recently used Emacs Lisp buffers in a 3x3 grid.
        A BLANK buffer fills in the grid if there are not enough Emacs Lisp
@@ -215,7 +215,8 @@
 
     {C-x 4 d ${hyperb:dir} RET}
 
-       Dired the Hyperbole home directory based on its variable.
+       Dired the Hyperbole home directory based on its variable.  {M-RET} on
+       the directory itself will display the directory's value in the minibuffer.
 
        Within this dired buffer, mark a few files with {m} and then press {@}
        to display a window grid of those files only.  That works in Buffer

--- a/HY-NEWS
+++ b/HY-NEWS
@@ -1,3 +1,5 @@
+-*- Mode: org; org-cycle-global-at-bob: t; hsys-org-enable-smart-keys: t -*-
+
 *			  What's New in GNU Hyperbole
 				 by Bob Weiner
 

--- a/README
+++ b/README
@@ -3,9 +3,9 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    19-Oct-91 at 03:27:47
-# Last-Mod:     24-Jan-22 at 00:19:12 by Bob Weiner
+# Last-Mod:     24-Jan-23 at 00:19:12 by Bob Weiner
 #
-# Copyright (C) 1989-2021  Free Software Foundation, Inc.
+# Copyright (C) 1989-2023  Free Software Foundation, Inc.
 # See the "HY-COPY" file for license information.
 #
 # This file is part of GNU Hyperbole.

--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:     15-Nov-23 at 01:52:15 by Bob Weiner
+;; Last-Mod:     23-Nov-23 at 03:29:51 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1507,18 +1507,22 @@ calls `hbut:modify-syntax'.")
 
 ;;;###autoload
 (defun    hbut:modify-syntax ()
-  "Modify syntactic character pairs in syntax tables.
-Modify `hbut:syntax-table' and `help-mode-syntax-table'.  For use
-with implicit button activations."
-  ;; Treat angle brackets as opening and closing delimiters for ease
-  ;; of matching.
+  "Make <> and {} behave as syntactic character pairs in major syntax tables.
+Modify `hbut:syntax-table', `help-mode-syntax-table',`text-mode-syntax-table',
+and `fundamental-mode's syntax table.  For use with implicit button
+activations."
+  ;; Treat angle brackets and braces as opening and closing delimiters
+  ;; for ease  of matching.
   (mapc (lambda (syntax-table)
 	  (modify-syntax-entry ?\< "(>" syntax-table)
 	  (modify-syntax-entry ?\> ")<" syntax-table)
 	  ;; Treat braces as opening and closing delimiters for ease of matching.
 	  (modify-syntax-entry ?\{ "(}" syntax-table)
 	  (modify-syntax-entry ?\} "){" syntax-table))
-	(list hbut:syntax-table help-mode-syntax-table))
+	(list hbut:syntax-table help-mode-syntax-table
+	      text-mode-syntax-table
+	      ;; fundamental-mode syntax table
+	      (standard-syntax-table)))
   nil)
 
 (defun    hbut:outside-comment-p ()

--- a/hui-mouse.el
+++ b/hui-mouse.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-89
-;; Last-Mod:     15-Nov-23 at 01:52:38 by Bob Weiner
+;; Last-Mod:     23-Nov-23 at 03:45:24 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -227,14 +227,26 @@ Its default value is `smart-scroll-down'.  To disable it, set it to
      . ((smart-push-button nil (mouse-event-p last-command-event))
 	. (smart-push-button-help nil (mouse-event-p last-command-event))))
     ;;
-    ;; If click in the minibuffer and reading an argument (aside from
+    ;; If in the minibuffer and reading an argument with vertico
+    ;; run the vertico command on {M-RET} which accepts the first
+    ;; line of minibuffer input, rather than any candidate.
+    ((and hargs:reading-type
+	  (> (minibuffer-depth) 0)
+	  (eq (selected-window) (minibuffer-window))
+	  (not (bound-and-true-p ivy-mode))
+	  (and (bound-and-true-p vertico-mode)
+	       ;; Is vertico prompting for an argument?
+	       (vertico--command-p nil (current-buffer))))
+     . ((vertico-exit-input) . (vertico-exit-input)))
+    ;;
+    ;; If in the minibuffer and reading an argument (aside from
     ;; with vertico or ivy), accept argument or give completion help.
     ((and hargs:reading-type
 	  (> (minibuffer-depth) 0)
 	  (eq (selected-window) (minibuffer-window))
 	  (not (bound-and-true-p ivy-mode))
 	  (not (and (bound-and-true-p vertico-mode)
-		    ;; Is vertico is prompting for an argument?
+		    ;; Is vertico prompting for an argument?
 		    (vertico--command-p nil (current-buffer))))
 	  (not (eq hargs:reading-type 'hmenu))
 	  (not (smart-helm-alive-p)))

--- a/hui-select.el
+++ b/hui-select.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Oct-96 at 02:25:27
-;; Last-Mod:     21-Nov-23 at 02:41:17 by Bob Weiner
+;; Last-Mod:     23-Nov-23 at 03:07:22 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -256,10 +256,12 @@ Used to include a final line when marking indented code.")
 ;;; ************************************************************************
 
 (defconst hui-select-syntax-table
-  (let ((st (make-syntax-table emacs-lisp-mode-syntax-table)))
+  (let ((st (copy-syntax-table emacs-lisp-mode-syntax-table)))
     ;; Make braces be thing delimiters, not punctuation.
     (modify-syntax-entry ?\{ "(}" st)
     (modify-syntax-entry ?\} "){" st)
+    (modify-syntax-entry ?< "(>" st)
+    (modify-syntax-entry ?> ")<" st)
     st)
   "Syntax table to use when selecting delimited things.")
 
@@ -460,6 +462,11 @@ Also, add language-specific syntax setups to aid in thing selection."
   (let ((region-bounds (hui-select-get-region-boundaries)))
     (when region-bounds
       (buffer-substring-no-properties (car region-bounds) (cdr region-bounds)))))
+
+(defun hui-select-scan-sexps (from count)
+  "Scan FROM point across COUNT sexpressions."
+  (with-syntax-table hui-select-syntax-table
+    (scan-sexps from count)))
 
 ;;;###autoload
 (defun hui-select-thing ()
@@ -1006,7 +1013,7 @@ language must be included in the list, hui-select-brace-modes."
 		      (ignore-errors
 			;; Leave point at opening brace.
 			(goto-char
-			 (scan-sexps (1+ (point)) -1))
+			 (hui-select-scan-sexps (1+ (point)) -1))
 			;; Test if these are defun braces.
 			(save-excursion
 			  (beginning-of-line)
@@ -1072,7 +1079,7 @@ language must be included in the list, hui-select-brace-modes."
 			  (error (point-max)))))
 	    (when (= (following-char) ?\})
 	      ;; Leave point at opening brace.
-	      (goto-char (scan-sexps (1+ (point)) -1)))
+	      (goto-char (hui-select-scan-sexps (1+ (point)) -1)))
 	    (when (= (following-char) ?\{)
 	      (while (and (zerop (forward-line -1))
 			  (not (hui-select-at-blank-line-or-comment))))
@@ -1148,9 +1155,9 @@ list, hui-select-indent-modes."
 	          '(?w ?_))
 	  (setq hui-select-previous 'symbol)
 	  (condition-case ()
-	      (let ((end (scan-sexps pos 1)))
+	      (let ((end (hui-select-scan-sexps pos 1)))
 		(hui-select-set-region
-		 (min pos (scan-sexps end -1)) end))
+		 (min pos (hui-select-scan-sexps end -1)) end))
 	    (error nil))))))
 
 (defun hui-select-sexp-start (pos)
@@ -1159,14 +1166,14 @@ list, hui-select-indent-modes."
       (hui-select-brace-def-or-declaration pos)
       (save-excursion
 	(setq hui-select-previous 'sexp-start)
-	(ignore-errors (hui-select-set-region pos (scan-sexps pos 1))))))
+	(ignore-errors (hui-select-set-region pos (hui-select-scan-sexps pos 1))))))
 
 (defun hui-select-sexp-end (pos)
   "Return (start . end) of sexp ending at POS."
   (or (hui-select-brace-def-or-declaration pos)
       (save-excursion
 	(setq hui-select-previous 'sexp-end)
-	(ignore-errors (hui-select-set-region (scan-sexps (1+ pos) -1) (1+ pos))))))
+	(ignore-errors (hui-select-set-region (hui-select-scan-sexps (1+ pos) -1) (1+ pos))))))
 
 (defun hui-select-sexp (pos)
   "Return (start . end) of the sexp that POS is within."

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Jun-89 at 22:08:29
-;; Last-Mod:     19-Nov-23 at 18:11:33 by Bob Weiner
+;; Last-Mod:     23-Nov-23 at 02:02:12 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -2231,10 +2231,7 @@ String search expressions are converted to regular expressions.")
 
 (if hyrolo-mode-syntax-table
     ()
-  (setq hyrolo-mode-syntax-table (make-syntax-table text-mode-syntax-table))
-  ;; Support syntactic selection of delimited e-mail addresses.
-  (modify-syntax-entry ?\<  "(>" hyrolo-mode-syntax-table)
-  (modify-syntax-entry ?\>  ")<" hyrolo-mode-syntax-table))
+  (setq hyrolo-mode-syntax-table (make-syntax-table text-mode-syntax-table)))
 
 (defvar hyrolo-mode-map nil
   "Keymap for the hyrolo match buffer.")

--- a/kotl/kvspec.el
+++ b/kotl/kvspec.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Oct-95 at 15:17:07
-;; Last-Mod:      4-Oct-23 at 19:10:12 by Mats Lidell
+;; Last-Mod:     21-Nov-23 at 13:20:57 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -104,7 +104,7 @@ characters at run-time.")
 (defun kvspec:activate (&optional view-spec)
   "Activate optional VIEW-SPEC or existing view spec in the current koutline.
 VIEW-SPEC is a string or t, which means recompute the current view spec.  See
-<${hyperb:dir}/kotl/EXAMPLE.kotl, 2b17=048> for details on valid view specs."
+${hyperb:dir}/kotl/EXAMPLE.kotl#3b19c=042 for details on valid view specs."
   (interactive (list (read-string "Set view spec: " kvspec:current)))
   (kotl-mode:is-p)
   (kfile:narrow-to-kcells)
@@ -169,8 +169,7 @@ display all levels of cells."
 VIEW-SPEC is a string or t, which means recompute the current view
 spec.  A nil value of VIEW-SPEC updates the modeline viewspec display
 to be current but does not recompute the viewspec itself.  See
-<${hyperb:dir}/kotl/EXAMPLE.kotl, 3b18=048> for details on valid
-view specs."
+${hyperb:dir}/kotl/EXAMPLE.kotl#3b19c=042 for details on valid view specs."
   (cond ((stringp view-spec)
 	 ;; Use given view-spec after removing extraneous characters.
 	 (setq view-spec

--- a/test/hbut-tests.el
+++ b/test/hbut-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-may-21 at 09:33:00
-;; Last-Mod:     19-Aug-23 at 01:12:57 by Bob Weiner
+;; Last-Mod:     23-Nov-23 at 01:44:46 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -323,7 +323,7 @@ Needed since hyperbole expands all links to absolute paths and
 		     (save-excursion
 		       (apply #'actype:act actype args)
 		       (setq actype (hattr:get 'hbut:current 'actype))))
-		   ;; These shoulds show the value of these variables when you
+		   ;; These should show the value of these variables when you
 		   ;; use the {l} command on failure, allowing quick debugging.
 		   (should expected-ibtype)
 		   (should expected-actype)

--- a/test/hui-select-tests.el
+++ b/test/hui-select-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    14-Apr-22 at 23:45:52
-;; Last-Mod:     11-Jul-22 at 23:29:45 by Mats Lidell
+;; Last-Mod:     23-Nov-23 at 02:12:38 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -85,27 +85,40 @@
   (skip-unless (not noninteractive))
   (hui-select-reset)
   (with-temp-buffer
-    (insert "Buffer\n\nParagraph\nline.  One word.\n")
+    (insert "Buffer\n\nParagraph\nline.  One word.")
     (forward-char -3)
 
-    (should (hui-select-thing))
-    (should (string= (buffer-substring-no-properties (region-beginning) (region-end)) "word"))
-
-    (should (hui-select-thing))
-    (should (string= (buffer-substring-no-properties (region-beginning) (region-end)) "One word."))
-
+    ;; word
     (should (hui-select-thing))
     (should (string= (buffer-substring-no-properties (region-beginning) (region-end))
-                     "line.  One word.\n"))
+		     "word"))
 
+    ;; symbol
     (should (hui-select-thing))
     (should (string= (buffer-substring-no-properties (region-beginning) (region-end))
-                     "\nParagraph\nline.  One word.\n"))
+		     "word."))
 
+    ;; sentence
     (should (hui-select-thing))
     (should (string= (buffer-substring-no-properties (region-beginning) (region-end))
-                     "Buffer\n\nParagraph\nline.  One word.\n"))
+		     "One word."))
 
+    ;; line
+    (should (hui-select-thing))
+    (should (string= (buffer-substring-no-properties (region-beginning) (region-end))
+                     "line.  One word."))
+
+    ;; paragraph
+    (should (hui-select-thing))
+    (should (string= (buffer-substring-no-properties (region-beginning) (region-end))
+                     "\nParagraph\nline.  One word."))
+
+    ;; buffer
+    (should (hui-select-thing))
+    (should (string= (buffer-substring-no-properties (region-beginning) (region-end))
+                     "Buffer\n\nParagraph\nline.  One word."))
+
+    ;; error
     (should-not (hui-select-thing))
     (hy-test-helpers:should-last-message
      "(hui-select-boundaries): ‘buffer’ is the largest selectable region")))
@@ -117,11 +130,16 @@ Verifies right type of match is printed when `hui-select-display-type' is set to
   (let ((hui-select-display-type t))
     (hui-select-reset)
     (with-temp-buffer
-      (insert "Buffer\n\nParagraph\nline.  One word.\n")
+      (insert "Buffer\n\nParagraph\nline.  One word.")
       (forward-char -3)
+
       (should (call-interactively 'hui-select-thing))
       (hy-test-helpers:should-last-message "word")
       (should (string= (buffer-substring-no-properties (region-beginning) (region-end)) "word"))
+
+      (should (call-interactively 'hui-select-thing))
+      (hy-test-helpers:should-last-message "symbol")
+      (should (string= (buffer-substring-no-properties (region-beginning) (region-end)) "word."))
 
       (should (call-interactively 'hui-select-thing))
       (hy-test-helpers:should-last-message "sentence")
@@ -130,17 +148,17 @@ Verifies right type of match is printed when `hui-select-display-type' is set to
       (should (call-interactively 'hui-select-thing))
       (hy-test-helpers:should-last-message "line")
       (should (string= (buffer-substring-no-properties (region-beginning) (region-end))
-                       "line.  One word.\n"))
+                       "line.  One word."))
 
       (should (call-interactively 'hui-select-thing))
       (hy-test-helpers:should-last-message "paragraph")
       (should (string= (buffer-substring-no-properties (region-beginning) (region-end))
-                       "\nParagraph\nline.  One word.\n"))
+                       "\nParagraph\nline.  One word."))
 
       (should (call-interactively 'hui-select-thing))
       (hy-test-helpers:should-last-message "Buffer")
       (should (string= (buffer-substring-no-properties (region-beginning) (region-end))
-                       "Buffer\n\nParagraph\nline.  One word.\n"))
+                       "Buffer\n\nParagraph\nline.  One word."))
 
       (should-not (call-interactively 'hui-select-thing))
       (hy-test-helpers:should-last-message


### PR DESCRIPTION
hui-mouse.el (hkey-alist): Add clause to handle Smart Key when in a vertico minibuffer window; make it behave like standard vertico which exits and selects the first minibuffer line, not the candidate.

If in the minibuffer and reading an argument with vertico run the vertico command on {M-RET} which accepts the first line of minibuffer input, rather than any candidate.