### PR TITLE
Add hyrolo search test cases

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2023-11-29  Mats Lidell  <matsl@gnu.org>
+
+* test/hyrolo-tests.el (hyrolo-fgrep-and-goto-next-visible-org-heading)
+    (hyrolo-fgrep-and-goto-next-visible-kotl-heading)
+    (hyrolo-fgrep-and-goto-next-visible-outl-heading)
+    (hyrolo-fgrep-and-goto-next-visible-md-heading): Add test for moving
+    to next header and that action-key then brings you to the matching
+    record.
+
 2023-11-25  Mats Lidell  <matsl@gnu.org>
 
 * test/hyrolo-tests.el (hyrolo-fgrep-find-all-types-of-files): Test that

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,9 +3,11 @@
 * test/hyrolo-tests.el (hyrolo-fgrep-and-goto-next-visible-org-heading)
     (hyrolo-fgrep-and-goto-next-visible-kotl-heading)
     (hyrolo-fgrep-and-goto-next-visible-outl-heading)
-    (hyrolo-fgrep-and-goto-next-visible-md-heading): Add test for moving
-    to next header and that action-key then brings you to the matching
-    record.
+    (hyrolo-fgrep-and-goto-next-visible-md-heading)
+    (hyrolo-fgrep-and-goto-next-visible-kotl-heading-level-2)
+    (hyrolo-fgrep-and-goto-next-visible-kotl-heading-cell-2): Add test for
+    moving to next header and that action-key then brings you to the
+    matching record.
 
 2023-11-25  Mats Lidell  <matsl@gnu.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2023-11-25  Mats Lidell  <matsl@gnu.org>
 
+* test/hyrolo-tests.el (hyrolo-fgrep-find-all-types-of-files): Test that
+    all files types are searched, matches and give proper @loc>-header.
+
 * hyrolo.el: Move private variables before their first use to remove
     warnings.
 

--- a/test/hyrolo-tests.el
+++ b/test/hyrolo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    19-Jun-21 at 22:42:00
-;; Last-Mod:     17-Nov-23 at 10:48:26 by Bob Weiner
+;; Last-Mod:     25-Nov-23 at 00:16:26 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -269,6 +269,25 @@ and {b} the previous same level cell."
 	       (hyrolo-sort hyrolo-file)
                (should (string= (buffer-string) sorted-hyrolo-file)))
       (hy-delete-file-and-buffer hyrolo-file))))
+
+(ert-deftest hyrolo-fgrep-find-all-types-of-files ()
+  "Verify that all types of files are found in an fgrep search."
+  (let* ((temporary-file-directory (make-temp-file "hypb" t))
+         (org-file (make-temp-file "hypb" nil ".org" "string\n"))
+         (kotl-file (make-temp-file "hypb" nil ".kotl" "string"))
+         (md-file (make-temp-file "hypb" nil ".md" "string\n"))
+         (outl-file (make-temp-file "hypb" nil ".otl" "string\n"))
+         (hyrolo-file-list (list temporary-file-directory)))
+    (unwind-protect
+        (progn
+          (hyrolo-fgrep "string")
+          (with-current-buffer "*HyRolo*"
+            (should (= (how-many "@loc>") 4))
+            (dolist (f (list org-file kotl-file md-file outl-file))
+              (should (= (how-many (concat "@loc> \"" f "\"")) 1)))))
+      (dolist (f (list org-file kotl-file md-file outl-file))
+        (hy-delete-file-and-buffer f))
+      (delete-directory temporary-file-directory))))
 
 (provide 'hyrolo-tests)
 ;;; hyrolo-tests.el ends here

--- a/test/hyrolo-tests.el
+++ b/test/hyrolo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    19-Jun-21 at 22:42:00
-;; Last-Mod:     25-Nov-23 at 00:16:26 by Mats Lidell
+;; Last-Mod:     29-Nov-23 at 22:13:01 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -23,6 +23,7 @@
 (require 'hyrolo)
 (require 'hyrolo-demo)
 (require 'hy-test-helpers "test/hy-test-helpers")
+(require 'with-simulated-input)
 
 (declare-function hy-test-helpers:consume-input-events "hy-test-helpers")
 (declare-function hy-test-helpers:should-last-message "hy-test-helpers")
@@ -287,7 +288,100 @@ and {b} the previous same level cell."
               (should (= (how-many (concat "@loc> \"" f "\"")) 1)))))
       (dolist (f (list org-file kotl-file md-file outl-file))
         (hy-delete-file-and-buffer f))
+      (kill-buffer "*HyRolo*")
       (delete-directory temporary-file-directory))))
+
+(ert-deftest hyrolo-fgrep-and-goto-next-visible-org-heading ()
+  "Verify move to next heading, then action-key to go to record for org mode."
+  (let* ((temporary-file-directory (make-temp-file "hypb" t))
+         (org-file (make-temp-file "hypb" nil ".org" "* heading\nstring\nmore\n"))
+         (hyrolo-file-list (list temporary-file-directory)))
+    (unwind-protect
+        (progn
+          (hyrolo-fgrep "string")
+          (with-current-buffer "*HyRolo*"
+            (should (= (how-many "@loc>") 1))
+            (should (looking-at-p "==="))
+            (hyrolo-next-visible-heading 1)
+            (should (looking-at-p "* heading")))
+          (with-simulated-input "y RET" ; Do you want to revisit the file normally now?
+            (action-key)
+            (should (equal (current-buffer) (find-buffer-visiting org-file)))
+            (should (looking-at-p "* heading"))))
+      (hy-delete-file-and-buffer org-file)
+      (kill-buffer "*HyRolo*")
+      (delete-directory temporary-file-directory))))
+
+(ert-deftest hyrolo-fgrep-and-goto-next-visible-kotl-heading ()
+  "Verify move to next heading, then action-key to go to record for kotl mode."
+  (let* ((temporary-file-directory (make-temp-file "hypb" t))
+         (kotl-file (make-temp-file "hypb" nil ".kotl"))
+         (hyrolo-file-list (list temporary-file-directory)))
+    (unwind-protect
+        (progn
+          (find-file kotl-file)
+          (insert "heading")
+          (kotl-mode:newline 1)
+          (insert "string")
+          (kotl-mode:newline 1)
+          (insert "more")
+          (hyrolo-fgrep "string")
+          (with-current-buffer "*HyRolo*"
+            (should (= (how-many "@loc>") 1))
+            (should (looking-at-p "==="))
+            (hyrolo-next-visible-heading 1)
+            (should (looking-at-p ".*1\\. heading")))
+          (with-simulated-input "y RET" ; Do you want to revisit the file normally now?
+            (action-key)
+            (should (equal (current-buffer) (find-buffer-visiting kotl-file)))
+            (should (looking-at-p "heading"))))
+      (hy-delete-file-and-buffer kotl-file)
+      (kill-buffer "*HyRolo*")
+      (delete-directory temporary-file-directory))))
+
+(ert-deftest hyrolo-fgrep-and-goto-next-visible-outl-heading ()
+  "Verify move to next heading, then action-key to go to record for outline mode."
+  (let* ((temporary-file-directory (make-temp-file "hypb" t))
+         (outl-file (make-temp-file "hypb" nil ".otl" "* heading\nstring\nmore\n"))
+         (hyrolo-file-list (list temporary-file-directory)))
+    (unwind-protect
+        (progn
+          (hyrolo-fgrep "string")
+          (with-current-buffer "*HyRolo*"
+            (should (= (how-many "@loc>") 1))
+            (should (looking-at-p "==="))
+            (hyrolo-next-visible-heading 1)
+            (should (looking-at-p "* heading")))
+          (with-simulated-input "y RET" ; Do you want to revisit the file normally now?
+            (action-key)
+            (should (equal (current-buffer) (find-buffer-visiting outl-file)))
+            (should (looking-at-p "* heading"))))
+      (hy-delete-file-and-buffer outl-file)
+      (kill-buffer "*HyRolo*")
+      (delete-directory temporary-file-directory))))
+
+(ert-deftest hyrolo-fgrep-and-goto-next-visible-md-heading ()
+  "Verify move to next heading, then action-key to go to record for markdown mode."
+  :expected-result :failed
+  (let* ((temporary-file-directory (make-temp-file "hypb" t))
+         (md-file (make-temp-file "hypb" nil ".md" "## heading\nstring\nmore\n"))
+         (hyrolo-file-list (list temporary-file-directory)))
+    (unwind-protect
+        (progn
+          (hyrolo-fgrep "string")
+          (with-current-buffer "*HyRolo*"
+            (should (= (how-many "@loc>") 1))
+            (should (looking-at-p "==="))
+            (hyrolo-next-visible-heading 1)
+            (should (looking-at-p "## heading")))
+          (with-simulated-input "y RET" ; Do you want to revisit the file normally now?
+            (action-key)
+            (should (equal (current-buffer) (find-buffer-visiting md-file)))
+            (should (looking-at-p "## heading"))))
+      (hy-delete-file-and-buffer md-file)
+      (kill-buffer "*HyRolo*")
+      (delete-directory temporary-file-directory))))
+
 
 (provide 'hyrolo-tests)
 ;;; hyrolo-tests.el ends here

--- a/test/hyrolo-tests.el
+++ b/test/hyrolo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    19-Jun-21 at 22:42:00
-;; Last-Mod:     29-Nov-23 at 22:13:01 by Mats Lidell
+;; Last-Mod:     29-Nov-23 at 23:22:15 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -382,6 +382,65 @@ and {b} the previous same level cell."
       (kill-buffer "*HyRolo*")
       (delete-directory temporary-file-directory))))
 
+(ert-deftest hyrolo-fgrep-and-goto-next-visible-kotl-heading-level-2 ()
+  "Verify move to next heading, then action-key to go to record for kotl mode.
+Match a string in a level 2 child cell."
+  (let* ((temporary-file-directory (make-temp-file "hypb" t))
+         (kotl-file (make-temp-file "hypb" nil ".kotl"))
+         (hyrolo-file-list (list temporary-file-directory)))
+    (unwind-protect
+        (progn
+          (find-file kotl-file)
+          (insert "first")
+          (kotl-mode:add-child)
+          (insert "heading")
+          (kotl-mode:newline 1)
+          (insert "string")
+          (kotl-mode:newline 1)
+          (insert "more")
+          (hyrolo-fgrep "string")
+          (with-current-buffer "*HyRolo*"
+            (should (= (how-many "@loc>") 1))
+            (should (looking-at-p "==="))
+            (hyrolo-next-visible-heading 1)
+            (should (looking-at-p ".*1a\\. heading")))
+          (with-simulated-input "y RET" ; Do you want to revisit the file normally now?
+            (action-key)
+            (should (equal (current-buffer) (find-buffer-visiting kotl-file)))
+            (should (looking-at-p "heading"))))
+      (hy-delete-file-and-buffer kotl-file)
+      (kill-buffer "*HyRolo*")
+      (delete-directory temporary-file-directory))))
+
+(ert-deftest hyrolo-fgrep-and-goto-next-visible-kotl-heading-cell-2 ()
+  "Verify move to next heading, then action-key to go to record for kotl mode.
+Match a string in the second cell."
+  (let* ((temporary-file-directory (make-temp-file "hypb" t))
+         (kotl-file (make-temp-file "hypb" nil ".kotl"))
+         (hyrolo-file-list (list temporary-file-directory)))
+    (unwind-protect
+        (progn
+          (find-file kotl-file)
+          (insert "first")
+          (kotl-mode:add-cell)
+          (insert "heading")
+          (kotl-mode:newline 1)
+          (insert "string")
+          (kotl-mode:newline 1)
+          (insert "more")
+          (hyrolo-fgrep "string")
+          (with-current-buffer "*HyRolo*"
+            (should (= (how-many "@loc>") 1))
+            (should (looking-at-p "==="))
+            (hyrolo-next-visible-heading 1)
+            (should (looking-at-p ".*2\\. heading")))
+          (with-simulated-input "y RET" ; Do you want to revisit the file normally now?
+            (action-key)
+            (should (equal (current-buffer) (find-buffer-visiting kotl-file)))
+            (should (looking-at-p "heading"))))
+      (hy-delete-file-and-buffer kotl-file)
+      (kill-buffer "*HyRolo*")
+      (delete-directory temporary-file-directory))))
 
 (provide 'hyrolo-tests)
 ;;; hyrolo-tests.el ends here


### PR DESCRIPTION
## What

Add hyrolo search test cases.

## Note

1. Pushing the first test case that verifies searching all file types with matches gives @loc> headers. Will add more.
2. Added test cases for matching a single record in respective file type and then using action-key to go to record.