### PR TITLE
Remove warnings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,9 +3,6 @@
 * hyrolo.el: Move private variables before their first use to remove
     warnings.
 
-* hibtypes.el (annot-bib):
-* hbut.el (hbut:comment): Call derived-mode-p with a list of symbols.
-
 * Remove warnings for unknown functions by using declare-function.
 
 2023-11-21  Bob Weiner  <rsw@gnu.org>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-11-25  Mats Lidell  <matsl@gnu.org>
+
+* Remove warnings for unknown functions by using declare-function.
+
 2023-11-21  Bob Weiner  <rsw@gnu.org>
 
 * hui-select.el (hui-select-initialize): Fix to set 'syntax-table-sym'

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2023-11-25  Mats Lidell  <matsl@gnu.org>
 
+* hyrolo.el: Move private variables before their first use to remove
+    warnings.
+
 * hibtypes.el (annot-bib):
 * hbut.el (hbut:comment): Call derived-mode-p with a list of symbols.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2023-11-25  Mats Lidell  <matsl@gnu.org>
 
+* hibtypes.el (annot-bib):
+* hbut.el (hbut:comment): Call derived-mode-p with a list of symbols.
+
 * Remove warnings for unknown functions by using declare-function.
 
 2023-11-21  Bob Weiner  <rsw@gnu.org>

--- a/hactypes.el
+++ b/hactypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    23-Sep-91 at 20:34:36
-;; Last-Mod:     29-Oct-23 at 23:46:32 by Bob Weiner
+;; Last-Mod:     25-Nov-23 at 16:36:26 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -26,6 +26,9 @@
 
 (declare-function kotl-mode:goto-cell "kotl-mode")
 (declare-function kotl-mode:beginning-of-buffer "kotl-mode")
+(declare-function kotl-mode:goto-cell-ref "kotl-mode")
+(declare-function kcell-view:indent "kcell-view")
+
 (declare-function rmail:msg-to-p "hrmail")
 (declare-function org-roam-id-find "‎ext:org-roam-id")
 

--- a/hargs.el
+++ b/hargs.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    31-Oct-91 at 23:17:35
-;; Last-Mod:      2-Nov-23 at 00:03:43 by Bob Weiner
+;; Last-Mod:     25-Nov-23 at 16:38:50 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -62,6 +62,8 @@
 (declare-function kcell-view:label "kview")
 (declare-function kcell-view:reference "kview")
 (declare-function rmail:msg-id-get "hmail")
+
+(declare-function smart-dired-pathname-up-to-point "hui-mouse")
 
 ;;; ************************************************************************
 ;;; Public variables

--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:     15-Nov-23 at 01:52:15 by Bob Weiner
+;; Last-Mod:     25-Nov-23 at 17:10:28 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -63,6 +63,8 @@ Use the function, (hbut:max-len), to read the proper value.")
 (declare-function kbd-key:act "hib-kbd")
 (declare-function kbd-key:is-p "hib-kbd")
 (declare-function org-context "org")
+
+(declare-function hpath:file-position-to-line-and-column "hpath")
 
 ;;; ************************************************************************
 ;;; Private variables

--- a/hbut.el
+++ b/hbut.el
@@ -1088,7 +1088,7 @@ When called interactively, display help for the button at point as well."
 Comment only when major mode is derived from `prog-mode' or `sgml-mode' and
 `comment-start' is non-nil.  Ignore email-related buffers."
   (when (and comment-start (not (memq major-mode '(mail-mode message-mode)))
-	     (derived-mode-p 'prog-mode 'sgml-mode) (not (hmail:mode-is-p)) )
+	     (derived-mode-p (list 'prog-mode 'sgml-mode)) (not (hmail:mode-is-p)) )
     (save-excursion
       (if (or (equal comment-end "")
 	      (null comment-end))

--- a/hbut.el
+++ b/hbut.el
@@ -1088,7 +1088,7 @@ When called interactively, display help for the button at point as well."
 Comment only when major mode is derived from `prog-mode' or `sgml-mode' and
 `comment-start' is non-nil.  Ignore email-related buffers."
   (when (and comment-start (not (memq major-mode '(mail-mode message-mode)))
-	     (derived-mode-p (list 'prog-mode 'sgml-mode)) (not (hmail:mode-is-p)) )
+	     (derived-mode-p 'prog-mode 'sgml-mode) (not (hmail:mode-is-p)) )
     (save-excursion
       (if (or (equal comment-end "")
 	      (null comment-end))

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:     11-Nov-23 at 11:27:23 by Bob Weiner
+;; Last-Mod:     25-Nov-23 at 17:18:25 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -74,6 +74,8 @@
 (declare-function set:member "set")
 (declare-function symset:add "hact")
 (declare-function symtable:add "hact")
+
+(declare-function hyrolo-get-file-list "hyrolo")
 
 ;;; ************************************************************************
 ;;; Public implicit button types

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -376,7 +376,7 @@ attached file."
        buffer-file-name
        (let ((chr (aref (buffer-name) 0)))
          (not (or (eq chr ?\ ) (eq chr ?*))))
-       (not (apply #'derived-mode-p '((prog-mode c-mode objc-mode c++-mode java-mode markdown-mode org-mode))))
+       (not (apply #'derived-mode-p '(prog-mode c-mode objc-mode c++-mode java-mode markdown-mode org-mode)))
        (let ((ref (hattr:get 'hbut:current 'lbl-key))
 	     (lbl-start (hattr:get 'hbut:current 'lbl-start)))
          (and ref

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -376,7 +376,7 @@ attached file."
        buffer-file-name
        (let ((chr (aref (buffer-name) 0)))
          (not (or (eq chr ?\ ) (eq chr ?*))))
-       (not (apply #'derived-mode-p '(prog-mode c-mode objc-mode c++-mode java-mode markdown-mode org-mode)))
+       (not (apply #'derived-mode-p '((prog-mode c-mode objc-mode c++-mode java-mode markdown-mode org-mode))))
        (let ((ref (hattr:get 'hbut:current 'lbl-key))
 	     (lbl-start (hattr:get 'hbut:current 'lbl-start)))
          (and ref

--- a/hpath.el
+++ b/hpath.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Nov-91 at 00:44:23
-;; Last-Mod:     19-Nov-23 at 18:56:31 by Bob Weiner
+;; Last-Mod:     25-Nov-23 at 16:42:29 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -127,6 +127,9 @@ The format is ${variable}.  Match grouping 1 is the name of the variable.")
 (declare-function hargs:delimited "hargs")
 (declare-function hypb:object-p "hypb")
 (declare-function Info-find-node "info")
+
+(declare-function kcell-view:indent "kcell-view")
+(declare-function klink:act "klink")
 
 ;;; ************************************************************************
 ;;; MS WINDOWS PATH CONVERSIONS

--- a/hsys-org.el
+++ b/hsys-org.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Jul-16 at 14:54:14
-;; Last-Mod:     29-Oct-23 at 16:14:28 by Bob Weiner
+;; Last-Mod:     25-Nov-23 at 16:45:25 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -41,6 +41,8 @@
 ;;; ************************************************************************
 ;;; Public declarations
 ;;; ************************************************************************
+
+(declare-function consult-grep "ext:consult")
 
 (defcustom hsys-org-consult-grep-func #'consult-grep
   "Function for consult grep searching over files."

--- a/hycontrol.el
+++ b/hycontrol.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Jun-16 at 15:35:36
-;; Last-Mod:     21-Nov-23 at 03:01:07 by Bob Weiner
+;; Last-Mod:     25-Nov-23 at 16:47:02 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -147,6 +147,8 @@
 (defvar org-mode-map)                   ; "org.el"
 (defvar outline-mode-map)               ; "outline.el"
 (defvar outline-minor-mode-map)         ; "outline.el"
+
+(declare-function kbd-key:key-series-to-events "hib-kbd")
 
 ;;; ************************************************************************
 ;;; Public variables

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Jun-89 at 22:08:29
-;; Last-Mod:     19-Nov-23 at 18:11:33 by Bob Weiner
+;; Last-Mod:     25-Nov-23 at 17:09:20 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -96,6 +96,13 @@
 (declare-function outline-previous-visible-heading "outline")
 (declare-function outline-show-all "outline")
 (declare-function outline-up-heading "outline")
+
+(declare-function hmouse-pulse-line "hui-window")
+(declare-function hpath:find "hpath")
+(declare-function hpath:expand-list "hpath")
+(declare-function hbut:get-key-src "hbut")
+(declare-function markdown-outline-level "ext:markdown-mode")
+(declare-function org-outline-level "org")
 
 (defvar org-directory)                  ; "org.el"
 (defvar markdown-regex-header)          ; "markdown-mode.el"

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -137,35 +137,6 @@ executable must be found as well (for Oauth security)."
   :type 'boolean
   :group 'hyperbole-hyrolo)
 
-(defun hyrolo-google-contacts-p ()
-  "Non-nil means google contacts package is available and feature is enabled.
-Requires `hyrolo-google-contacts-flag' set as non-nil and
-google-contacts package and gpg executables to be available for
-use."
-  (and hyrolo-google-contacts-flag
-       (featurep 'google-contacts)
-       (boundp 'google-contacts-buffer-name)
-       ;; If no gpg encryption executable, Oauth login to Google will fail.
-       (or (executable-find "gpg2") (executable-find "gpg"))))
-
-(defun hyrolo-expand-path-list (paths)
-  "Expand and return non-nil PATHS's dirs, file variables and file wildcards.
-If PATHS is nil, return a default set of hyrolo files to use.
-
-Single ${env-or-lisp-variable} references are resolved within
-each path using `hpath:expand'; this also expands paths to
-absolute paths.  Then directories are expanded into the files
-they contain that match `hyrolo-file-suffix-regexp'.  Then, if
-`find-file-wildcards' is non-nil (the default), any files
-containing [char-matches] or * wildcards are expanded to their
-matches."
-  (if paths
-      (hpath:expand-list paths hyrolo-file-suffix-regexp)
-    (delq nil
-	  (list "~/.rolo.otl"
-		(if (and (boundp 'bbdb-file) (stringp bbdb-file)) bbdb-file)
-		(when (hyrolo-google-contacts-p) google-contacts-buffer-name)))))
-
 (defcustom hyrolo-file-list nil
   "List of files containing hyrolo entries.
 The first file should be a user-specific hyrolo file, typically in the home
@@ -293,6 +264,117 @@ Only unmodified buffers are killed."
   "*A function of two arguments, START and END, invoked after a `hyrolo-yank'.
 It should reformat the region given by the arguments to some preferred style.
 Default value is to perform no reformatting.")
+
+(defun hyrolo-google-contacts-p ()
+  "Non-nil means google contacts package is available and feature is enabled.
+Requires `hyrolo-google-contacts-flag' set as non-nil and
+google-contacts package and gpg executables to be available for
+use."
+  (and hyrolo-google-contacts-flag
+       (featurep 'google-contacts)
+       (boundp 'google-contacts-buffer-name)
+       ;; If no gpg encryption executable, Oauth login to Google will fail.
+       (or (executable-find "gpg2") (executable-find "gpg"))))
+
+(defun hyrolo-expand-path-list (paths)
+  "Expand and return non-nil PATHS's dirs, file variables and file wildcards.
+If PATHS is nil, return a default set of hyrolo files to use.
+
+Single ${env-or-lisp-variable} references are resolved within
+each path using `hpath:expand'; this also expands paths to
+absolute paths.  Then directories are expanded into the files
+they contain that match `hyrolo-file-suffix-regexp'.  Then, if
+`find-file-wildcards' is non-nil (the default), any files
+containing [char-matches] or * wildcards are expanded to their
+matches."
+  (if paths
+      (hpath:expand-list paths hyrolo-file-suffix-regexp)
+    (delq nil
+	  (list "~/.rolo.otl"
+		(if (and (boundp 'bbdb-file) (stringp bbdb-file)) bbdb-file)
+		(when (hyrolo-google-contacts-p) google-contacts-buffer-name)))))
+
+;;; ************************************************************************
+;;; Private variables
+;;; ************************************************************************
+
+(defvar hyrolo--expanded-file-list nil
+  "List of hyrolo files after directory and file wildcard expansions.
+Hyrolo sets this internally; never set it yourself.")
+
+(defvar hyrolo-entry-group-number 1
+  "Group number whose length represents the level of any entry matched.
+See `hyrolo-entry-regexp'")
+
+(defvar hyrolo-entry-trailing-space-group-number 2
+  "Group number within `hyrolo-entry-regexp; containing trailing space.")
+
+(defconst hyrolo-hdr-format
+  (concat
+   "===============================================================================\n"
+   "%s\n"
+   "===============================================================================\n")
+  "Header to insert preceding a file's first hyrolo entry match when
+file has none of its own.  Used with one argument, the file name.")
+
+(defconst hyrolo-hdr-regexp "^==="
+  "Regular expression to match the first and last lines of hyrolo file headers.
+This header is inserted into hyrolo-display-buffer before any entries from the
+file are added.")
+
+(defconst hyrolo-match-regexp nil
+  "Last regular expression used to search the hyrolo.
+Nil before a search is done, including after a logical search is done.
+String search expressions are converted to regular expressions.")
+
+(defvar hyrolo--wconfig nil
+  "Saves frame's window configuration prior to a hyrolo search.")
+
+(defvar hyrolo-mode-syntax-table nil
+  "Syntax table used while in hyrolo match mode.")
+
+(if hyrolo-mode-syntax-table
+    ()
+  (setq hyrolo-mode-syntax-table (make-syntax-table text-mode-syntax-table))
+  ;; Support syntactic selection of delimited e-mail addresses.
+  (modify-syntax-entry ?\<  "(>" hyrolo-mode-syntax-table)
+  (modify-syntax-entry ?\>  ")<" hyrolo-mode-syntax-table))
+
+(defvar hyrolo-mode-map nil
+  "Keymap for the hyrolo match buffer.")
+
+(if hyrolo-mode-map
+    nil
+  (setq hyrolo-mode-map (make-keymap))
+  (if (fboundp 'set-keymap-name)
+      (set-keymap-name hyrolo-mode-map 'hyrolo-mode-map))
+  (suppress-keymap hyrolo-mode-map)
+  (define-key hyrolo-mode-map ","        'hyrolo-to-entry-beginning)
+  (define-key hyrolo-mode-map "."        'hyrolo-to-entry-end)
+  (define-key hyrolo-mode-map "<"        'beginning-of-buffer)
+  (define-key hyrolo-mode-map ">"        'end-of-buffer)
+  (define-key hyrolo-mode-map "?"        'describe-mode)
+  (define-key hyrolo-mode-map "\177"     'scroll-down)
+  (define-key hyrolo-mode-map " "        'scroll-up)
+  (define-key hyrolo-mode-map "a"        'outline-show-all)
+  (define-key hyrolo-mode-map "b"        'hyrolo-backward-same-level)
+  (define-key hyrolo-mode-map "e"        'hyrolo-edit-entry)
+  (define-key hyrolo-mode-map "f"        'hyrolo-forward-same-level)
+  (define-key hyrolo-mode-map "h"        'hyrolo-hide-subtree)
+  (define-key hyrolo-mode-map "l"        'hyrolo-locate)
+  (define-key hyrolo-mode-map "m"        'hyrolo-mail-to)
+  (define-key hyrolo-mode-map "n"        'hyrolo-next-visible-heading)
+  (define-key hyrolo-mode-map "o"        'hyrolo-overview)
+  (define-key hyrolo-mode-map "p"        'hyrolo-previous-visible-heading)
+  (define-key hyrolo-mode-map "q"        'hyrolo-quit)
+  (define-key hyrolo-mode-map "r"        'hyrolo-grep-or-fgrep)
+  (define-key hyrolo-mode-map "s"        'outline-show-subtree)
+  (define-key hyrolo-mode-map "\M-s"     'hyrolo-isearch)
+  (define-key hyrolo-mode-map "t"        'hyrolo-top-level)
+  (define-key hyrolo-mode-map "\C-i"     'hyrolo-next-match)      ;; {TAB}
+  (define-key hyrolo-mode-map "\M-\C-i"  'hyrolo-previous-match)  ;; {M-TAB}
+  (define-key hyrolo-mode-map [backtab]  'hyrolo-previous-match)  ;; {Shift-TAB}
+  (define-key hyrolo-mode-map "u"        'hyrolo-up-heading))
 
 ;;; ************************************************************************
 ;;; Commands
@@ -1602,11 +1684,10 @@ Return number of matching entries found."
 			(forward-line)
 			(setq hdr-pos (cons (point-min) (point))))
 		      (let ((case-fold-search t)
-			    match-start
 			    match-end)
 			(re-search-forward hyrolo-entry-regexp nil t)
 			(while (and (or (null max-matches) (< num-found max-matches))
-				    (setq match-start (funcall hyrolo-next-match-function pattern headline-only)))
+				    (funcall hyrolo-next-match-function pattern headline-only))
 			  (setq match-end (point))
 			  ;; If no entry delimiters found, just return the line of the match alone.
 			  (unless (re-search-backward hyrolo-entry-regexp nil t)
@@ -2196,88 +2277,6 @@ or else the number of characters matched by `outline-regexp' minus
 trailing periods and whitespace."
   (or (cdr (assoc (match-string 0) outline-heading-alist))
       (1- (- (match-end 0) (match-beginning 0)))))
-
-;;; ************************************************************************
-;;; Private variables
-;;; ************************************************************************
-
-(defvar hyrolo--expanded-file-list nil
-  "List of hyrolo files after directory and file wildcard expansions.
-Hyrolo sets this internally; never set it yourself.")
-
-(defvar hyrolo-entry-group-number 1
-  "Group number whose length represents the level of any entry matched.
-See `hyrolo-entry-regexp'")
-
-(defvar hyrolo-entry-trailing-space-group-number 2
-  "Group number within `hyrolo-entry-regexp; containing trailing space.")
-
-(defconst hyrolo-hdr-format
-  (concat
-   "===============================================================================\n"
-   "%s\n"
-   "===============================================================================\n")
-  "Header to insert preceding a file's first hyrolo entry match when
-file has none of its own.  Used with one argument, the file name.")
-
-(defconst hyrolo-hdr-regexp "^==="
-  "Regular expression to match the first and last lines of hyrolo file headers.
-This header is inserted into hyrolo-display-buffer before any entries from the
-file are added.")
-
-(defconst hyrolo-match-regexp nil
-  "Last regular expression used to search the hyrolo.
-Nil before a search is done, including after a logical search is done.
-String search expressions are converted to regular expressions.")
-
-(defvar hyrolo--wconfig nil
-  "Saves frame's window configuration prior to a hyrolo search.")
-
-(defvar hyrolo-mode-syntax-table nil
-  "Syntax table used while in hyrolo match mode.")
-
-(if hyrolo-mode-syntax-table
-    ()
-  (setq hyrolo-mode-syntax-table (make-syntax-table text-mode-syntax-table))
-  ;; Support syntactic selection of delimited e-mail addresses.
-  (modify-syntax-entry ?\<  "(>" hyrolo-mode-syntax-table)
-  (modify-syntax-entry ?\>  ")<" hyrolo-mode-syntax-table))
-
-(defvar hyrolo-mode-map nil
-  "Keymap for the hyrolo match buffer.")
-
-(if hyrolo-mode-map
-    nil
-  (setq hyrolo-mode-map (make-keymap))
-  (if (fboundp 'set-keymap-name)
-      (set-keymap-name hyrolo-mode-map 'hyrolo-mode-map))
-  (suppress-keymap hyrolo-mode-map)
-  (define-key hyrolo-mode-map ","        'hyrolo-to-entry-beginning)
-  (define-key hyrolo-mode-map "."        'hyrolo-to-entry-end)
-  (define-key hyrolo-mode-map "<"        'beginning-of-buffer)
-  (define-key hyrolo-mode-map ">"        'end-of-buffer)
-  (define-key hyrolo-mode-map "?"        'describe-mode)
-  (define-key hyrolo-mode-map "\177"     'scroll-down)
-  (define-key hyrolo-mode-map " "        'scroll-up)
-  (define-key hyrolo-mode-map "a"        'outline-show-all)
-  (define-key hyrolo-mode-map "b"        'hyrolo-backward-same-level)
-  (define-key hyrolo-mode-map "e"        'hyrolo-edit-entry)
-  (define-key hyrolo-mode-map "f"        'hyrolo-forward-same-level)
-  (define-key hyrolo-mode-map "h"        'hyrolo-hide-subtree)
-  (define-key hyrolo-mode-map "l"        'hyrolo-locate)
-  (define-key hyrolo-mode-map "m"        'hyrolo-mail-to)
-  (define-key hyrolo-mode-map "n"        'hyrolo-next-visible-heading)
-  (define-key hyrolo-mode-map "o"        'hyrolo-overview)
-  (define-key hyrolo-mode-map "p"        'hyrolo-previous-visible-heading)
-  (define-key hyrolo-mode-map "q"        'hyrolo-quit)
-  (define-key hyrolo-mode-map "r"        'hyrolo-grep-or-fgrep)
-  (define-key hyrolo-mode-map "s"        'outline-show-subtree)
-  (define-key hyrolo-mode-map "\M-s"     'hyrolo-isearch)
-  (define-key hyrolo-mode-map "t"        'hyrolo-top-level)
-  (define-key hyrolo-mode-map "\C-i"     'hyrolo-next-match)      ;; {TAB}
-  (define-key hyrolo-mode-map "\M-\C-i"  'hyrolo-previous-match)  ;; {M-TAB}
-  (define-key hyrolo-mode-map [backtab]  'hyrolo-previous-match)  ;; {Shift-TAB}
-  (define-key hyrolo-mode-map "u"        'hyrolo-up-heading))
 
 (provide 'hyrolo)
 

--- a/kotl/kcell.el
+++ b/kotl/kcell.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-May-93
-;; Last-Mod:     29-Oct-23 at 09:16:43 by Bob Weiner
+;; Last-Mod:     25-Nov-23 at 16:33:20 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -32,6 +32,12 @@
 ;;; ************************************************************************
 
 (eval-and-compile (mapc #'require '(hinit htz kview kproperty)))
+
+;;; ************************************************************************
+;;; Public declarations
+;;; ************************************************************************
+
+(declare-function kotl-mode:goto-heading "kotl/kotl-mode")
 
 ;;; ************************************************************************
 ;;; Public variables

--- a/kotl/kview.el
+++ b/kotl/kview.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:     29-Oct-23 at 08:55:55 by Bob Weiner
+;; Last-Mod:     25-Nov-23 at 16:34:27 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -44,6 +44,7 @@
 (declare-function kotl-mode:beginning-of-line "kotl-mode")
 (declare-function kotl-mode:fill-cell "kotl-mode")
 (declare-function kotl-mode:goto-cell "kotl-mode")
+(declare-function kotl-mode:goto-heading "kotl/kotl-mode")
 (declare-function kotl-mode:hide-subtree "kotl-mode")
 (declare-function kotl-mode:to-end-of-line "kotl-mode")
 (declare-function kotl-mode:to-visible-position "kotl-mode")


### PR DESCRIPTION
## What

Remove warnings

## Why

Recent updates have introduced a set of new warnings. This tries to remove the warnings by:
1. First of all using declare-function for declaring unknown functions. 
2. ~Fix call to derived-mode-p that only takes one arg, a list, and not multiple args.~ Reverted. This change is introduced in Emacs 30.1 so will not affect older versions and it is backwards compatible so we can ignore this for now.
3. Move private vars before their first use.
4. Remove a warning for a variable not used. (Not in a separate commit. See comment below.)