### PR TITLE
Declare function to silence warning

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 2023-12-01  Mats Lidell  <matsl@gnu.org>
 
+* hmouse-tag.el (ibtype:def-symbol): Declare function to silence warning.
+
 * test/hyrolo-tests.el (hyrolo-sort-test): Set default date format so the
     format used is well defined.
     (hyrolo-fgrep-and-goto-next-visible-md-heading): Use level one heading

--- a/hmouse-tag.el
+++ b/hmouse-tag.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    24-Aug-91
-;; Last-Mod:     22-Nov-23 at 00:15:24 by Bob Weiner
+;; Last-Mod:      1-Dec-23 at 23:32:23 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -80,6 +80,7 @@
 
 (declare-function hsys-org-get-value "hsys-org")
 (declare-function org-in-src-block-p "org")
+(declare-function ibtype:def-symbol "hbut")
 
 ;; Forward declare needed? Because of optional defined above? Can we
 ;; skip checking if xref is available since it has been at least since


### PR DESCRIPTION
# What

Remove warning for unknown function.

# Why

Keeping the number of warning as low as possible. 