### PR TITLE
Matsl rsw hui link possible types

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2023-12-26  Mats Lidell  <matsl@gnu.org>
+
+* test/hy-test-helpers.el (hy-delete-dir-and-buffer): Add test helper for
+    removing buffers for temp folders.
+
+* test/hui-tests.el (hui--link-possible-types): Add test for
+    hui:link-possible-types.
+
 2023-12-26  Bob Weiner  <rsw@gnu.org>
 
 * test/hyrolo-tests.el: Fix with-simulated-input where prompting for 'y'.

--- a/hui.el
+++ b/hui.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 21:42:03
-;; Last-Mod:     10-Dec-23 at 16:18:24 by Bob Weiner
+;; Last-Mod:     25-Dec-23 at 22:28:16 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     30-Nov-23 at 19:53:31 by Mats Lidell
+;; Last-Mod:      7-Dec-23 at 00:32:03 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -931,6 +931,114 @@ With point on label suggest that ibut for rename."
                                                  :lbl-key "button"))))
       (hy-delete-file-and-buffer global-but-file)
       (hy-delete-file-and-buffer file))))
+
+(ert-deftest hui--link-possible-types ()
+  "Verify right type is selected from referent buffer."
+
+  ;; Org Roam or Org Id       link-to-org-id
+  (let ((file (make-temp-file "hypb" nil ".org")))
+    (unwind-protect
+        (progn
+          (find-file file)
+          (org-id-get-create nil)
+          (re-search-forward ":ID:")
+          (should (equal (caar (hui:link-possible-types)) 'link-to-org-id)))
+      (hy-delete-file-and-buffer file)))
+
+  ;; Global Button            link-to-gbut
+  (defvar global-but-file)
+  (let ((global-but-file (make-temp-file "gbut" nil ".txt")))
+    (unwind-protect
+        (mocklet ((gbut:file => global-but-file))
+          (hui:gibut-create "global" "/tmp")
+          (find-file global-but-file)
+          (should (equal (caar (hui:link-possible-types)) 'link-to-gbut)))
+      (hy-delete-file-and-buffer global-but-file)))
+
+  ;; Explicit Button          link-to-ebut
+  (with-temp-buffer
+    (ebut:program "label" 'link-to-directory "/tmp")
+    (should (equal (hattr:get (hbut:at-p) 'categ) 'explicit))
+    ;; BUG!? SHOULD BE LINK TO EBUT HERE
+    (should (equal (caar (hui:link-possible-types)) 'link-to-ibut)))
+
+  ;; Implicit Button          link-to-ibut
+  (with-temp-buffer
+    (insert "<[ibut]> - \"/tmp\"")
+    (goto-char 5)
+    (should (equal (caar (hui:link-possible-types)) 'link-to-ibut)))
+
+  ;; Bookmarks List           link-to-bookmark
+  (with-temp-buffer
+    (insert "   bookmark    ~/bookmarked\n")
+    (bookmark-bmenu-mode)
+    (should (equal (caar (hui:link-possible-types)) 'link-to-bookmark)))
+
+  ;; Info Node                link-to-Info-node
+  (with-temp-buffer
+    (insert "(info)node\n")
+    (goto-char 5)
+    (Info-mode)
+    (should (equal (caar (hui:link-possible-types)) 'link-to-Info-node)))
+
+  ;; Texinfo Node             link-to-texinfo-node
+  (with-temp-buffer
+    (insert "@node node\n")
+    (goto-char 5)
+    (texinfo-mode)
+    (should (equal (caar (hui:link-possible-types)) 'link-to-texinfo-node)))
+
+  ;; Mail Reader Message      link-to-mail
+  (let ((hmail:reader 'gnus-article-mode))
+    (with-temp-buffer
+      (gnus-article-mode)
+      (mocklet ((rmail:msg-id-get => "msg-id"))
+        (should (equal (caar (hui:link-possible-types)) 'link-to-mail)))))
+
+  ;; Directory Name           link-to-directory
+  ;; TBD
+
+  ;; File Name                link-to-file
+  ;; TBD
+
+  ;; Koutline Cell            link-to-kcell
+  (let ((file (make-temp-file "hypb" nil ".kotl")))
+    (unwind-protect
+        (progn
+          (find-file file)
+          (insert "first")
+          (should (equal (caar (hui:link-possible-types)) 'link-to-kcell)))
+      (hy-delete-file-and-buffer file)))
+
+  ;; Outline Heading          link-to-string-match
+  (let ((file (make-temp-file "hypb" nil ".outl" "* heading\nbody\n")))
+    (unwind-protect
+        (progn
+          (find-file file)
+          (outline-mode)
+          (goto-char 1)
+          ;; BUG!? SHOULD link-to-string-match
+          (should (equal (caar (hui:link-possible-types)) 'link-to-file)))
+      (hy-delete-file-and-buffer file)))
+
+  ;; Buffer attached to File  link-to-file
+  (let ((file (make-temp-file "hypb" nil ".txt")))
+    (unwind-protect
+        (progn
+          (find-file file)
+          (should (equal (caar (hui:link-possible-types)) 'link-to-file)))
+      (hy-delete-file-and-buffer file)))
+
+  ;; EOL in Dired Buffer      link-to-directory (dired dir)
+  (let ((dir (make-temp-file "hypb" t)))
+    (unwind-protect
+        (with-current-buffer (dired dir)
+          (should (equal (caar (hui:link-possible-types)) 'link-to-directory)))
+      (hy-delete-dir-and-buffer dir)))
+
+  ;; Buffer without File      link-to-buffer-tmp"
+  (with-temp-buffer
+    (should (equal (caar (hui:link-possible-types)) 'link-to-buffer-tmp))))
 
 ;; This file can't be byte-compiled without `with-simulated-input' which
 ;; is not part of the actual dependencies, so:

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -1049,8 +1049,7 @@ With point on label suggest that ibut for rename."
           (find-file file)
           (outline-mode)
           (goto-char 1)
-          ;; BUG!? Should be link-to-string-match?
-          (should (equal (caar (hui:link-possible-types)) 'link-to-file)))
+          (should (equal (caar (hui:link-possible-types)) 'link-to-string-match)))
       (hy-delete-file-and-buffer file)))
 
   ;; Buffer attached to File  link-to-file

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:      7-Dec-23 at 00:32:03 by Mats Lidell
+;; Last-Mod:     10-Dec-23 at 21:11:07 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -958,9 +958,7 @@ With point on label suggest that ibut for rename."
   ;; Explicit Button          link-to-ebut
   (with-temp-buffer
     (ebut:program "label" 'link-to-directory "/tmp")
-    (should (equal (hattr:get (hbut:at-p) 'categ) 'explicit))
-    ;; BUG!? SHOULD BE LINK TO EBUT HERE
-    (should (equal (caar (hui:link-possible-types)) 'link-to-ibut)))
+    (should (equal (caar (hui:link-possible-types)) 'link-to-ebut)))
 
   ;; Implicit Button          link-to-ibut
   (with-temp-buffer

--- a/test/hy-test-helpers.el
+++ b/test/hy-test-helpers.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     31-Oct-23 at 22:48:26 by Mats Lidell
+;; Last-Mod:     22-Dec-23 at 16:03:21 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -80,6 +80,13 @@ Checks ACTYPE, ARGS, LOC and LBL-KEY."
         (set-buffer-modified-p nil)
         (kill-buffer))))
   (delete-file file))
+
+(defun hy-delete-dir-and-buffer (dir)
+  "Delete DIR and buffer visiting directory."
+  (let ((buf (find-buffer-visiting dir)))
+    (when buf
+      (kill-buffer buf))
+    (delete-directory dir)))
 
 (provide 'hy-test-helpers)
 ;;; hy-test-helpers.el ends here


### PR DESCRIPTION
# What

Matsl rsw hui link possible types based on rsw branch **and** PR against `rsw branch.`

# Why

Basing dev work on rsw branch before potential release. See https://github.com/rswgnu/hyperbole/pull/414 for original PR based on master.
