### PR TITLE
Set enable-local-variables to nil for tests with DEMO and FAST-DEMO

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2023-12-26  Mats Lidell  <matsl@gnu.org>
+
+* test/hmouse-drv-tests.el:
+  test/hibtypes-tests.el:
+  test/hib-kbd-tests.el:
+  test/demo-tests.el: Set enable-local-variables to nil for test cases
+    where DEMO and FAST-DEMO is loaded to avoid getting queried.
+
 2023-12-26  Bob Weiner  <rsw@gnu.org>
 
 * test/hy-test-helpers.el (hy-test-helpers:ensure-link-possible-type): Add.

--- a/test/demo-tests.el
+++ b/test/demo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     11-Dec-23 at 01:58:53 by Bob Weiner
+;; Last-Mod:     25-Dec-23 at 23:30:20 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -39,7 +39,7 @@
 (ert-deftest demo-smart-mouse-keys-ref-test ()
   "Go to the header from a #ref."
   (unwind-protect
-      (progn
+      (let ((enable-local-variables nil))
         (hypb:display-file-with-logo "DEMO")
         (goto-char (point-min))
         (re-search-forward "#Smart Keys")
@@ -50,7 +50,7 @@
 
 (ert-deftest demo-smart-mouse-keys-ebut-test ()
   (unwind-protect
-      (progn
+      (let ((enable-local-variables nil))
         (hypb:display-file-with-logo "DEMO")
         (goto-char (point-min))
         (re-search-forward "<(Smart")
@@ -61,7 +61,7 @@
 
 (ert-deftest demo-table-of-contents-test ()
   (unwind-protect
-      (progn
+      (let ((enable-local-variables nil))
         (hypb:display-file-with-logo "DEMO")
         (goto-char (point-min))
         (re-search-forward " \\* Koutl")
@@ -74,7 +74,7 @@
 (ert-deftest demo-smart-scrolling-proportional-test ()
   (skip-unless (not noninteractive))
   (unwind-protect
-      (progn
+      (let ((enable-local-variables nil))
         (hypb:display-file-with-logo "DEMO")
         (goto-char (point-min))
         (re-search-forward "Table of Contents")
@@ -88,7 +88,7 @@
 
 (ert-deftest demo-smart-scrolling-non-proportional-test ()
   (unwind-protect
-      (progn
+      (let ((enable-local-variables nil))
         (hypb:display-file-with-logo "DEMO")
         (goto-char (point-min))
         (re-search-forward "Table of Contents")
@@ -127,7 +127,7 @@
 (ert-deftest demo-window-grid-22-test ()
   (skip-unless (not noninteractive))
   (unwind-protect
-      (progn
+      (let ((enable-local-variables nil))
         (hypb:display-file-with-logo "DEMO")
         (should (hact 'kbd-key "C-h h s f @ 22 RET Q"))
         (hy-test-helpers:consume-input-events)
@@ -137,7 +137,7 @@
 (ert-deftest demo-window-grid-33-test ()
   (skip-unless (not noninteractive))
   (unwind-protect
-      (progn
+      (let ((enable-local-variables nil))
         (hypb:display-file-with-logo "DEMO")
         (should (hact 'kbd-key "C-h h s f @ 33 RET Q"))
         (hy-test-helpers:consume-input-events)
@@ -190,7 +190,8 @@
       (with-temp-buffer
         (insert (format "\"%s\"" (expand-file-name "DEMO" hyperb:dir)))
         (goto-char 2)
-        (action-key)
+	(let ((enable-local-variables nil))
+          (action-key))
         (should (string= "DEMO" (buffer-name))))
     (hy-test-helpers:kill-buffer "DEMO")))
 
@@ -199,7 +200,8 @@
       (with-temp-buffer
         (insert "<link-to-file-line \"${hyperb:dir}/DEMO\" 5>")
         (goto-char 5)
-        (action-key)
+	(let ((enable-local-variables nil))
+          (action-key))
         (should (string= "DEMO" (buffer-name)))
         (should (= 5 (line-number-at-pos (point)))))
     (hy-test-helpers:kill-buffer "DEMO")))
@@ -382,7 +384,7 @@
 (ert-deftest demo-occur-test ()
   (skip-unless (not noninteractive))
   (unwind-protect
-      (progn
+      (let ((enable-local-variables nil))
         (hypb:display-file-with-logo "DEMO")
         (should (hact 'kbd-key "C-h h f o Hyperbole RET"))
         (hy-test-helpers:consume-input-events)
@@ -405,7 +407,7 @@
 (ert-deftest demo-factorial-test ()
   (skip-unless (not noninteractive))
   (unwind-protect
-      (progn
+      (let ((enable-local-variables nil))
         (hypb:display-file-with-logo "DEMO")
         (should (hact 'kbd-key "C-h h a factorial RET"))
         (hy-test-helpers:consume-input-events)
@@ -415,7 +417,7 @@
 (ert-deftest demo-factorial-ebutton-test ()
   (skip-unless (not noninteractive))
   (unwind-protect
-      (progn
+      (let ((enable-local-variables nil))
         (hypb:display-file-with-logo "DEMO")
         (re-search-forward "<(factorial)>")
         (forward-char -5)
@@ -465,7 +467,7 @@ Note: Depends on key series in FAST-DEMO and how many files in
 hyberbole folder that starts with kotl."
   (skip-unless (not noninteractive))
   (unwind-protect
-      (progn
+      (let ((enable-local-variables nil))
         (hypb:display-file-with-logo "FAST-DEMO")
 	(goto-char (point-min))
         (search-forward "{C--1 C-c @")

--- a/test/hib-kbd-tests.el
+++ b/test/hib-kbd-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     26-Mar-22 at 11:25:43 by Mats Lidell
+;; Last-Mod:     25-Dec-23 at 23:30:20 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -37,7 +37,7 @@
 (ert-deftest kbd-key-hy-demo-factorial-test ()
   (skip-unless (not noninteractive))
   (unwind-protect
-      (progn
+      (let ((enable-local-variables nil))
         ;; Preload demo files to avoid race with *ert* buffer and set
         ;; *ert* buffer current
         (hypb:display-file-with-logo "DEMO")

--- a/test/hibtypes-tests.el
+++ b/test/hibtypes-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    20-Feb-21 at 23:45:00
-;; Last-Mod:     11-Dec-23 at 02:08:38 by Bob Weiner
+;; Last-Mod:     25-Dec-23 at 23:30:20 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -57,7 +57,8 @@
       (with-temp-buffer
         (insert (format "\"%s\"" (expand-file-name "DEMO" hyperb:dir)))
         (goto-char 2)
-        (ibtypes::pathname)
+	(let ((enable-local-variables nil))
+          (ibtypes::pathname))
         (should (string= "DEMO" (buffer-name))))
     (kill-buffer "DEMO")))
 
@@ -66,7 +67,8 @@
       (with-temp-buffer
         (insert "\"${hyperb:dir}/DEMO\"")
         (goto-char 2)
-        (ibtypes::pathname)
+	(let ((enable-local-variables nil))
+	  (ibtypes::pathname))
         (should (string= "DEMO" (buffer-name))))
     (kill-buffer "DEMO")))
 
@@ -98,7 +100,8 @@
       (with-temp-buffer
         (insert "\"${hyperb:dir}/DEMO#Smart Keys\"")
         (goto-char 2)
-        (ibtypes::pathname)
+        (let ((enable-local-variables nil))
+	  (ibtypes::pathname))
         (should (string= "DEMO" (buffer-name)))
         (should (looking-at "\* Smart Keys")))
     (kill-buffer "DEMO")))
@@ -121,7 +124,8 @@
       (with-temp-buffer
         (insert "\"${hyperb:dir}/DEMO:3:45\"")
         (goto-char 2)
-        (ibtypes::pathname-line-and-column)
+	(let ((enable-local-variables nil))
+          (ibtypes::pathname-line-and-column))
         (should (string= "DEMO" (buffer-name)))
         (should (= (line-number-at-pos) 3))
         (should (= (current-column) 45)))
@@ -234,7 +238,7 @@
 ;; text-toc
 (ert-deftest ibtypes::text-toc-test ()
   (unwind-protect
-      (progn
+      (let ((enable-local-variables nil))
         (hypb:display-file-with-logo "DEMO")
         (goto-char (point-min))
         (re-search-forward " \\* Koutl")

--- a/test/hmouse-drv-tests.el
+++ b/test/hmouse-drv-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    28-Feb-21 at 22:52:00
-;; Last-Mod:     11-Dec-23 at 01:57:54 by Bob Weiner
+;; Last-Mod:     26-Dec-23 at 22:44:10 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -105,7 +105,8 @@
 
 (ert-deftest hbut-defil-it ()
   (defil defil-path-it "<<<" ">>>" ".*" "${hyperb:dir}/\\&")
-  (let ((vc-follow-symlinks nil))
+  (let ((vc-follow-symlinks nil)
+        (enable-local-variables nil))
     (unwind-protect
 	(with-temp-buffer
           (insert "<<<DEMO>>>")
@@ -239,7 +240,8 @@
       (with-temp-buffer
         (insert (format "\"%s\"" (expand-file-name "DEMO" hyperb:dir)))
         (goto-char 2)
-        (action-key)
+	(let ((enable-local-variables nil))
+          (action-key))
         (should (string= "DEMO" (buffer-name))))
     (hy-test-helpers:kill-buffer "DEMO")))
 
@@ -248,7 +250,8 @@
       (with-temp-buffer
         (insert "\"${hyperb:dir}/DEMO\"")
         (goto-char 2)
-        (action-key)
+	(let ((enable-local-variables nil))
+          (action-key))
         (should (string= "DEMO" (buffer-name))))
     (hy-test-helpers:kill-buffer "DEMO")))
 
@@ -458,7 +461,7 @@
 ;; text-toc
 (ert-deftest hbut-text-toc-test ()
   (unwind-protect
-      (progn
+      (let ((enable-local-variables nil))
         (hypb:display-file-with-logo "DEMO")
         (goto-char (point-min))
         (re-search-forward "^[ \t]*\\* Koutl")


### PR DESCRIPTION
# What

Set enable-local-variables to nil for tests with DEMO and FAST-DEMO.

# Why

This avoids the query for the local vars when the tests are run interactively.