### PR TITLE
Matsl rsw fix failing tests

### DIFF
--- a/test/hyrolo-tests.el
+++ b/test/hyrolo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    19-Jun-21 at 22:42:00
-;; Last-Mod:     26-Dec-23 at 01:57:38 by Bob Weiner
+;; Last-Mod:     27-Dec-23 at 16:52:20 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -294,10 +294,10 @@ and {b} the previous same level cell."
     (unwind-protect
         (progn
           (hyrolo-fgrep "string")
-          (with-current-buffer "*HyRolo*"
-            (should (= (how-many "@loc>") 4))
-            (dolist (f (list org-file kotl-file md-file outl-file))
-              (should (= (how-many (concat "@loc> \"" f "\"")) 1)))))
+          (should (string= (buffer-name) "*HyRolo*"))
+          (should (= (how-many "@loc>") 4))
+          (dolist (f (list org-file kotl-file md-file outl-file))
+            (should (= (how-many (concat "@loc> \"" f "\"")) 1))))
       (dolist (f (list org-file kotl-file md-file outl-file))
         (hy-delete-file-and-buffer f))
       (kill-buffer "*HyRolo*")
@@ -311,13 +311,13 @@ and {b} the previous same level cell."
     (unwind-protect
         (progn
           (hyrolo-fgrep "string")
-          (with-current-buffer "*HyRolo*"
-            (should (= (how-many "@loc>") 1))
-            (should (looking-at-p "==="))
-            (hyrolo-next-visible-heading 1)
-            (should (looking-at-p "* heading")))
-	  (kbd-key:key-series-to-events "y C-f")
-          (action-key)
+          (should (string= (buffer-name) "*HyRolo*"))
+          (should (= (how-many "@loc>") 1))
+          (should (looking-at-p "==="))
+          (hyrolo-next-visible-heading 1)
+          (should (looking-at-p "* heading"))
+          (with-simulated-input "y RET"
+            (action-key))
           (should (equal (current-buffer) (find-buffer-visiting org-file)))
           (should (looking-at-p "* heading")))
       (hy-delete-file-and-buffer org-file)
@@ -338,15 +338,14 @@ and {b} the previous same level cell."
           (kotl-mode:newline 1)
           (insert "more")
           (hyrolo-fgrep "string")
-          (with-current-buffer "*HyRolo*"
-            (should (= (how-many "@loc>") 1))
-            (should (looking-at-p "==="))
-            (hyrolo-next-visible-heading 1)
-            (should (looking-at-p ".*1\\. heading")))
-          (with-simulated-input "y C-f" ; Do you want to revisit the file normally now?
-            (action-key)
-            (should (equal (current-buffer) (find-buffer-visiting kotl-file)))
-            (should (looking-at-p "heading"))))
+          (should (string= (buffer-name) "*HyRolo*"))
+          (should (= (how-many "@loc>") 1))
+          (should (looking-at-p "==="))
+          (hyrolo-next-visible-heading 1)
+          (should (looking-at-p ".*1\\. heading"))
+          (action-key)
+          (should (equal (current-buffer) (find-buffer-visiting kotl-file)))
+          (should (looking-at-p "heading")))
       (hy-delete-file-and-buffer kotl-file)
       (kill-buffer "*HyRolo*")
       (delete-directory temporary-file-directory))))
@@ -359,11 +358,11 @@ and {b} the previous same level cell."
     (unwind-protect
         (progn
           (hyrolo-fgrep "string")
-          (with-current-buffer "*HyRolo*"
-            (should (= (how-many "@loc>") 1))
-            (should (looking-at-p "==="))
-            (hyrolo-next-visible-heading 1)
-            (should (looking-at-p "* heading")))
+          (should (string= (buffer-name) "*HyRolo*"))
+          (should (= (how-many "@loc>") 1))
+          (should (looking-at-p "==="))
+          (hyrolo-next-visible-heading 1)
+          (should (looking-at-p "* heading"))
           (action-key)
           (should (equal (current-buffer) (find-buffer-visiting outl-file)))
           (should (looking-at-p "* heading")))
@@ -372,18 +371,18 @@ and {b} the previous same level cell."
       (delete-directory temporary-file-directory))))
 
 (ert-deftest hyrolo-fgrep-and-goto-next-visible-md-heading ()
-  "Verify move to next heading, then action-key to go to record for markdown mode."
+  "verify move to next heading, then action-key to go to record for markdown mode."
   (let* ((temporary-file-directory (make-temp-file "hypb" t))
          (md-file (make-temp-file "hypb" nil ".md" "# heading\nstring\nmore\n"))
          (hyrolo-file-list (list temporary-file-directory)))
     (unwind-protect
         (progn
           (hyrolo-fgrep "string")
-          (with-current-buffer "*HyRolo*"
-            (should (= (how-many "@loc>") 1))
-            (should (looking-at-p "==="))
-            (hyrolo-next-visible-heading 1)
-            (should (looking-at-p "# heading")))
+          (should (string= (buffer-name) "*HyRolo*"))
+          (should (= (how-many "@loc>") 1))
+          (should (looking-at-p "==="))
+          (hyrolo-next-visible-heading 1)
+          (should (looking-at-p "# heading"))
           (action-key)
           (should (equal (current-buffer) (find-buffer-visiting md-file)))
           (should (looking-at-p "# heading")))
@@ -408,11 +407,11 @@ Match a string in a level 2 child cell."
           (kotl-mode:newline 1)
           (insert "more")
           (hyrolo-fgrep "string")
-          (with-current-buffer "*HyRolo*"
-            (should (= (how-many "@loc>") 1))
-            (should (looking-at-p "==="))
-            (hyrolo-next-visible-heading 1)
-            (should (looking-at-p ".*1a\\. heading")))
+          (should (string= (buffer-name) "*HyRolo*"))
+          (should (= (how-many "@loc>") 1))
+          (should (looking-at-p "==="))
+          (hyrolo-next-visible-heading 1)
+          (should (looking-at-p ".*1a\\. heading"))
           (action-key)
           (should (equal (current-buffer) (find-buffer-visiting kotl-file)))
           (should (looking-at-p "heading")))
@@ -437,11 +436,11 @@ Match a string in the second cell."
           (kotl-mode:newline 1)
           (insert "more")
           (hyrolo-fgrep "string")
-          (with-current-buffer "*HyRolo*"
-            (should (= (how-many "@loc>") 1))
-            (should (looking-at-p "==="))
-            (hyrolo-next-visible-heading 1)
-            (should (looking-at-p ".*2\\. heading")))
+          (should (string= (buffer-name) "*HyRolo*"))
+          (should (= (how-many "@loc>") 1))
+          (should (looking-at-p "==="))
+          (hyrolo-next-visible-heading 1)
+          (should (looking-at-p ".*2\\. heading"))
           (action-key)
           (should (equal (current-buffer) (find-buffer-visiting kotl-file)))
           (should (looking-at-p "heading")))

--- a/test/hyrolo-tests.el
+++ b/test/hyrolo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    19-Jun-21 at 22:42:00
-;; Last-Mod:     27-Dec-23 at 16:52:20 by Mats Lidell
+;; Last-Mod:     28-Dec-23 at 12:01:34 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -316,8 +316,9 @@ and {b} the previous same level cell."
           (should (looking-at-p "==="))
           (hyrolo-next-visible-heading 1)
           (should (looking-at-p "* heading"))
-          (with-simulated-input "y RET"
-            (action-key))
+          (let ((revisit-normally (concat "y" (if noninteractive " RET"))))
+            (with-simulated-input revisit-normally
+              (action-key)))
           (should (equal (current-buffer) (find-buffer-visiting org-file)))
           (should (looking-at-p "* heading")))
       (hy-delete-file-and-buffer org-file)

--- a/test/hyrolo-tests.el
+++ b/test/hyrolo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    19-Jun-21 at 22:42:00
-;; Last-Mod:     28-Dec-23 at 12:01:34 by Mats Lidell
+;; Last-Mod:     28-Dec-23 at 12:48:26 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -372,7 +372,7 @@ and {b} the previous same level cell."
       (delete-directory temporary-file-directory))))
 
 (ert-deftest hyrolo-fgrep-and-goto-next-visible-md-heading ()
-  "verify move to next heading, then action-key to go to record for markdown mode."
+  "Verify move to next heading, then action-key to go to record for markdown mode."
   (let* ((temporary-file-directory (make-temp-file "hypb" t))
          (md-file (make-temp-file "hypb" nil ".md" "# heading\nstring\nmore\n"))
          (hyrolo-file-list (list temporary-file-directory)))

--- a/test/kotl-orgtbl-tests.el
+++ b/test/kotl-orgtbl-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:     2-Nov-21 at 17:04:30
-;; Last-Mod:      1-Mar-22 at 23:24:01 by Mats Lidell
+;; Last-Mod:     27-Dec-23 at 16:54:00 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -61,7 +61,7 @@
           (should (hact 'kbd-key "RET |field1|field2| RET"))
           (hy-test-helpers:consume-input-events)
 
-          (left-char 1)
+          (kotl-mode:backward-char 1)
           (action-key)
           (should-not orgtbl-mode)
           (action-key)


### PR DESCRIPTION
# What

Matsl rsw fix failing tests.

# Why

Two tests were failing due to strange circumstances. This seems to fix it. One problem was with that `y-o-n-p` behaves differently when running `interactive` and `noniniteractive`. So we need to accommodate for that. An alternative would be to mock `y-o-n-p`  to always return t and not depend on any input given!?

For this version I have chosen to keep requiring the input but add a RET if run noninteractively. Consequently I have reinstalled the use of `with-simulated-input` to be consistent with our other tests. Using `kbd-key:key-series-to-events` looks better because it does not crash or complain when not all its input is used. That is a good feature of `with-simulated-input.`

To be fair, I have seen some other strange things in other, unrelated to this test case, with `with-simulated-input,` but I need to understand better what is going on there. So I'll come back to that.

# Note

Did also do some refactoring and changed visiting "*HyRolo*" buffer into actually checking that the search brings us there. Which is the expected behavior.