### PR TITLE
Matsl rsw add missing fast demo tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2023-12-29  Mats Lidell  <matsl@gnu.org>
+
+* test/demo-tests.el
+    (fast-demo-outline-section-anchor-and-relative-line-number-test): Add
+    test for outline section with line and column.
+
 2023-12-28  Bob Weiner  <rsw@gnu.org>
 
 * hypb-ert.el (hypb-ert-def-at-p): Add support for `ert-deftest-async' from the

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,8 +1,16 @@
 2023-12-29  Mats Lidell  <matsl@gnu.org>
 
-* test/demo-tests.el
-    (fast-demo-outline-section-anchor-and-relative-line-number-test): Add
-    test for outline section with line and column.
+* test/demo-tests.el (fast-demo-markdown-anchor-with-spaces)
+    (fast-demo-elisp-or-env-vars, fast-demo-elisp-library-in-load-path)
+    (fast-demo-info-manual-references, fast-demo-grep)
+    (fast-demo-python-trace-back, fast-demo-man-k)
+    (fast-demo-action-button-shell, fast-demo-action-button-fill-column)
+    (fast-demo-display-demo-using-action-buttons)
+    (fast-demo-display-kotl-starting-from-cell)
+    (fast-demo-outline-section-anchor-and-relative-line-number)
+    (fast-demo-markdown-anchor-with-spaces)
+    (fast-demo-elisp-library-in-load-path)
+    (fast-demo-elisp-or-env-vars): Add remaining test cases for fast-demo.
 
 2023-12-28  Bob Weiner  <rsw@gnu.org>
 

--- a/FAST-DEMO
+++ b/FAST-DEMO
@@ -135,11 +135,11 @@
 
 ** Pathname Implicit Buttons
 
-    "HY-NEWS#ORG MODE:2:6"   - outline section anchor & relative line number
+    "HY-NEWS#ORG MODE:3:6"   - outline section anchor & relative line number
 
        Display the file, "HY-NEWS", go to the star-outline section 'ORG
-       MODE', move 2 lines into that section and then move 6 characters
-       forward.  "HY-NEWS#ORG MODE:L2:C6" with the line and column numbers
+       MODE', move 3 lines into that section and then move 6 characters
+       forward.  "HY-NEWS#ORG MODE:L3:C6" with the line and column numbers
        labeled works as well.
 
        Existing files and pathnames without spaces are also recognized without

--- a/test/demo-tests.el
+++ b/test/demo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     25-Dec-23 at 23:30:20 by Mats Lidell
+;; Last-Mod:     28-Dec-23 at 18:58:46 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -424,6 +424,21 @@
         (action-key)
         (hy-test-helpers:should-last-message "Factorial of 5 = 120"))
     (hy-test-helpers:kill-buffer "DEMO")))
+
+;;; Fast demo
+;; Implicit Buttons
+(ert-deftest fast-demo-outline-section-anchor-and-relative-line-number-test ()
+  "Verify star outline section links with line and column works."
+  (dolist (link '("\"HY-NEWS#ORG MODE:3:6\"" "\"HY-NEWS#ORG MODE:L3:C6\""))
+    (unwind-protect
+        (let ((default-directory hyperb:dir))
+          (with-temp-buffer
+            (insert link)
+            (goto-char 3)
+            (action-key)
+            (should (string= (buffer-name (current-buffer)) "HY-NEWS"))
+            (should (looking-at-p "M-RET: Reworked"))))
+      (hy-test-helpers:kill-buffer "HY-NEWS"))))
 
 ;; Fast demo key series
 (ert-deftest fast-demo-key-series-help-buffer ()


### PR DESCRIPTION
# What

Matsl rsw add missing fast demo tests. (That was remaining at the time.)

# Note

This ends this days work. Will be busy most of tomorrow so will pick it up again probably first tomorrow evening.
There are a few tests that could need some improvement but they are hopefully an improvement and much closer to the examples in the FAST-DEMO file.