### PR TITLE
Matsl rsw add hyrolo tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,7 +7,7 @@
     (hyrolo-tests--outline-next-visible-header)
     (hyrolo-tests--tab-through-matches)
     (hyrolo-tests--outline-hide-show-heading)
-    (hyrolo-tests--outline-up-header)
+    (hyrolo-tests--outline-up-header, hyrolo-tests--edit-entry)
     (hyrolo-tests--outline-next-visible-header-two-sections): Add test for
     working with hyrolo matches.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,15 @@
 2023-01-02  Mats Lidell  <matsl@gnu.org>
 
+* test/hyrolo-tests.el (hyrolo-tests--level-number)
+    (hyrolo-tests--generate-header-contents-for-tests)
+    (hyrolo-tests--gen-outline): Add helper for constructing org files for
+    tests.
+    (hyrolo-tests--outline-next-visible-header)
+    (hyrolo-tests--tab-through-matches): Add test for working with hyrolo
+    matches.
+
+2023-12-31  Mats Lidell  <matsl@gnu.org>
+
 * test/hyrolo-tests.el (hyrolo-tests--get-file-list-change)
     (hyrolo-tests--get-file-list-wrong-suffice): Add hyrolo tests.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -10,11 +10,9 @@
     (hyrolo-tests--outline-up-header, hyrolo-tests--edit-entry)
     (hyrolo-tests--outline-next-visible-header-two-sections): Add test for
     working with hyrolo matches.
-
-2023-12-31  Mats Lidell  <matsl@gnu.org>
-
-* test/hyrolo-tests.el (hyrolo-tests--get-file-list-change)
-    (hyrolo-tests--get-file-list-wrong-suffice): Add hyrolo tests.
+    (hyrolo-tests--get-file-list-change)
+    (hyrolo-tests--get-file-list-wrong-suffice): Add hyrolo tests for
+    get-file-list.
 
 2024-01-02  Mats Lidell  <matsl@gnu.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -5,7 +5,8 @@
     (hyrolo-tests--gen-outline): Add helper for constructing org files for
     tests.
     (hyrolo-tests--outline-next-visible-header)
-    (hyrolo-tests--tab-through-matches): Add test for working with hyrolo
+    (hyrolo-tests--tab-through-matches)
+    (hyrolo-tests--outline-hide-show-heading): Add test for working with hyrolo
     matches.
 
 2023-12-31  Mats Lidell  <matsl@gnu.org>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2023-01-02  Mats Lidell  <matsl@gnu.org>
+
+* test/hyrolo-tests.el (hyrolo-tests--get-file-list-change)
+    (hyrolo-tests--get-file-list-wrong-suffice): Add hyrolo tests.
+
 2024-01-02  Mats Lidell  <matsl@gnu.org>
 
 * test/hypb-ert-tests.el (hypb-ert-tests--def-at-p)

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,8 +6,9 @@
     tests.
     (hyrolo-tests--outline-next-visible-header)
     (hyrolo-tests--tab-through-matches)
-    (hyrolo-tests--outline-hide-show-heading): Add test for working with hyrolo
-    matches.
+    (hyrolo-tests--outline-hide-show-heading)
+    (hyrolo-tests--outline-next-visible-header-two-sections): Add test for
+    working with hyrolo matches.
 
 2023-12-31  Mats Lidell  <matsl@gnu.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@
     (hyrolo-tests--outline-next-visible-header)
     (hyrolo-tests--tab-through-matches)
     (hyrolo-tests--outline-hide-show-heading)
+    (hyrolo-tests--outline-up-header)
     (hyrolo-tests--outline-next-visible-header-two-sections): Add test for
     working with hyrolo matches.
 

--- a/test/hyrolo-tests.el
+++ b/test/hyrolo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    19-Jun-21 at 22:42:00
-;; Last-Mod:     30-Dec-23 at 23:22:54 by Bob Weiner
+;; Last-Mod:     31-Dec-23 at 16:10:00 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -24,6 +24,7 @@
 (require 'hyrolo-demo)
 (require 'hy-test-helpers "test/hy-test-helpers")
 (require 'hib-kbd)
+(require 'kotl-mode)
 (require 'with-simulated-input)
 
 (declare-function hy-test-helpers:consume-input-events "hy-test-helpers")
@@ -448,6 +449,22 @@ Match a string in the second cell."
       (hy-delete-file-and-buffer kotl-file)
       (kill-buffer hyrolo-display-buffer)
       (delete-directory temporary-file-directory))))
+
+(ert-deftest hyrolo-tests--get-file-list-change ()
+  "Verify a change to hyrolo-file-list is noticed by hyrolo-get-file-list."
+  (let* ((tmp-file (make-temp-file "hypb" nil ".org"))
+         (hyrolo-file-list (list tmp-file)))
+    (unwind-protect
+        (let ((hl (hyrolo-get-file-list)))
+          (should (= 1 (length hl)))
+          (should (string= (car hl) tmp-file)))
+      (hy-delete-file-and-buffer tmp-file))))
+
+(ert-deftest hyrolo-tests--get-file-list-wrong-suffice ()
+  "Verify files need to have the proper suffix in hyrolo-file-list."
+  (should-error
+   (let ((hyrolo-file-list (list "file-no-proper-suffix")))
+     ())))
 
 (provide 'hyrolo-tests)
 ;;; hyrolo-tests.el ends here

--- a/test/hyrolo-tests.el
+++ b/test/hyrolo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    19-Jun-21 at 22:42:00
-;; Last-Mod:      1-Jan-24 at 20:56:49 by Mats Lidell
+;; Last-Mod:      1-Jan-24 at 22:06:44 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -535,25 +535,25 @@ Example:
           ;; Move down
           (should (looking-at-p "==="))
           (should (hact 'kbd-key "n"))
-          (should (looking-at-p "^* header 1"))
+          (should (looking-at-p "^\\* header 1"))
           (should (hact 'kbd-key "n"))
-          (should (looking-at-p "^** header 1.2"))
+          (should (looking-at-p "^\\*\\* header 1\\.2"))
           (should (hact 'kbd-key "n"))
-          (should (looking-at-p "^* header 2"))
+          (should (looking-at-p "^\\* header 2"))
           (should (hact 'kbd-key "n"))
-          (should (looking-at-p "^** header 2.2"))
+          (should (looking-at-p "^\\*\\* header 2\\.2"))
           (should (hact 'kbd-key "n"))
           (should (eobp))
 
           ;; Move back up
           (should (hact 'kbd-key "p"))
-          (should (looking-at-p "^** header 2.2"))
+          (should (looking-at-p "^\\*\\* header 2\\.2"))
           (should (hact 'kbd-key "p"))
-          (should (looking-at-p "^* header 2"))
+          (should (looking-at-p "^\\* header 2"))
           (should (hact 'kbd-key "p"))
-          (should (looking-at-p "^** header 1.2"))
+          (should (looking-at-p "^\\*\\* header 1\\.2"))
           (should (hact 'kbd-key "p"))
-          (should (looking-at-p "^* header 1"))
+          (should (looking-at-p "^\\* header 1"))
           (should (hact 'kbd-key "p"))
 
           ;; BUG: This fails in Emacs 29 and 30
@@ -579,11 +579,11 @@ Example:
           ;; Move to last header
           (goto-char (point-max))
           (forward-line -2)
-          (should (looking-at-p "^*** header 2.2.3$"))
+          (should (looking-at-p "^\\*\\*\\* header 2\\.2\\.3$"))
           (should (hact 'kbd-key "u"))
-          (should (looking-at-p "^** header 2.2$"))
+          (should (looking-at-p "^\\*\\* header 2\\.2$"))
           (should (hact 'kbd-key "u"))
-          (should (looking-at-p "^* header 2$"))
+          (should (looking-at-p "^\\* header 2$"))
           (should-error (hact 'kbd-key "u")))
       (kill-buffer "*HyRolo*")
       (hy-delete-file-and-buffer org-file))))
@@ -603,25 +603,25 @@ Example:
           ;; Move down
           (should (looking-at-p "==="))
           (should (hact 'kbd-key "n"))
-          (should (looking-at-p "^* header-a 1$"))
+          (should (looking-at-p "^\\* header-a 1$"))
           (should (hact 'kbd-key "n"))
-          (should (looking-at-p "^** header-a 1.2$"))
+          (should (looking-at-p "^\\*\\* header-a 1\\.2$"))
           (should (hact 'kbd-key "n"))
-          (should (looking-at-p "^* header-b 1$"))
+          (should (looking-at-p "^\\* header-b 1$"))
           (should (hact 'kbd-key "n"))
-          (should (looking-at-p "^** header-b 1.2$"))
+          (should (looking-at-p "^\\*\\* header-b 1\\.2$"))
           (should (hact 'kbd-key "n"))
           (should (eobp))
 
           ;; Move back up
           (should (hact 'kbd-key "p"))
-          (should (looking-at-p "^** header-b 1.2$"))
+          (should (looking-at-p "^\\*\\* header-b 1\\.2$"))
           (should (hact 'kbd-key "p"))
-          (should (looking-at-p "^* header-b 1$"))
+          (should (looking-at-p "^\\* header-b 1$"))
           (should (hact 'kbd-key "p"))
-          (should (looking-at-p "^** header-a 1.2$"))
+          (should (looking-at-p "^\\*\\* header-a 1\\.2$"))
           (should (hact 'kbd-key "p"))
-          (should (looking-at-p "^* header-a 1$"))
+          (should (looking-at-p "^\\* header-a 1$"))
           (should (hact 'kbd-key "p"))
 
           ;; BUG: This fails in Emacs 29 and 30
@@ -648,10 +648,12 @@ Example:
           ;; Hide first line hides whole section
           (should (looking-at-p "==="))
           (should (hact 'kbd-key "h"))
-          (should (looking-at-p "^===+\.\.\.$"))
+          (end-of-line)
+          (should (get-char-property (point) 'invisible))
           (save-excursion
             (next-line)
             (should (eobp)))
+          (goto-char (point-min))
           (should (hact 'kbd-key "a"))
           (should (looking-at-p "^===+$"))
 
@@ -683,22 +685,55 @@ Example:
           (should (hact 'kbd-key "TAB"))
           (should (looking-at-p "^body 1$"))
           (should (hact 'kbd-key "TAB"))
-          (should (looking-at-p "^body 1.2"))
+          (should (looking-at-p "^body 1\\.2"))
           (should (hact 'kbd-key "TAB"))
           (should (looking-at-p "^body 2$"))
           (should (hact 'kbd-key "TAB"))
-          (should (looking-at-p "^body 2.2"))
+          (should (looking-at-p "^body 2\\.2"))
           (should-error (hact 'kbd-key "TAB"))
-          (should (looking-at-p "^body 2.2"))
+          (should (looking-at-p "^body 2\\.2"))
 
           ;; Search Up
           (should (hact 'kbd-key "<backtab>"))
           (should (looking-at-p "^body 2$"))
           (should (hact 'kbd-key "<backtab>"))
-          (should (looking-at-p "^body 1.2"))
+          (should (looking-at-p "^body 1\\.2"))
           (should (hact 'kbd-key "<backtab>"))
           (should (looking-at-p "^body 1$"))
           (should-error (hact 'kbd-key "<backtab>")))
+      (kill-buffer "*HyRolo*")
+      (hy-delete-file-and-buffer org-file))))
+
+(ert-deftest hyrolo-tests--edit-entry ()
+  "Verify {e} brings up entry in new window."
+  (let* ((org-file (make-temp-file "hypb" nil ".org"
+                                   (hyrolo-tests--gen-outline "header" 1 "body" 2)))
+         (hyrolo-file-list (list org-file)))
+    (unwind-protect
+        (progn
+          (hyrolo-grep "body")
+          (should (string= "*HyRolo*" (buffer-name)))
+
+          ;; Search Down
+          (should (looking-at-p "==="))
+          (should (hact 'kbd-key "TAB"))
+          (should (looking-at-p "^body 1$"))
+
+          ;; Edit record
+          (let ((revisit-normally (concat "y" (if noninteractive " RET"))))
+            (with-simulated-input revisit-normally
+              (should (hact 'kbd-key "e"))))
+          (should (string= (buffer-name) (file-name-nondirectory org-file)))
+          (should (looking-at-p "^body 1$"))
+
+          ;; Edit next record
+          (switch-to-buffer "*HyRolo*")
+          (should (hact 'kbd-key "TAB"))
+          (should (looking-at-p "^body 1\\.2$"))
+          (should (hact 'kbd-key "e"))
+          (should (string= (buffer-name) (file-name-nondirectory org-file)))
+          (should (looking-at-p "^body 1\\.2$"))
+          )
       (kill-buffer "*HyRolo*")
       (hy-delete-file-and-buffer org-file))))
 

--- a/test/hyrolo-tests.el
+++ b/test/hyrolo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    19-Jun-21 at 22:42:00
-;; Last-Mod:      1-Jan-24 at 22:06:44 by Mats Lidell
+;; Last-Mod:      1-Jan-24 at 22:38:40 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -43,7 +43,7 @@
           (hyrolo-add "a/b")
           (hyrolo-add "a/b/c")
           (beginning-of-line)
-          (should (looking-at-p "\*\*\*   c")))
+          (should (looking-at-p "\\*\\*\\*   c")))
       (hy-delete-file-and-buffer hyrolo-file))))
 
 (ert-deftest hyrolo-demo-search-work ()
@@ -650,9 +650,6 @@ Example:
           (should (hact 'kbd-key "h"))
           (end-of-line)
           (should (get-char-property (point) 'invisible))
-          (save-excursion
-            (next-line)
-            (should (eobp)))
           (goto-char (point-min))
           (should (hact 'kbd-key "a"))
           (should (looking-at-p "^===+$"))

--- a/test/hyrolo-tests.el
+++ b/test/hyrolo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    19-Jun-21 at 22:42:00
-;; Last-Mod:      1-Jan-24 at 19:29:48 by Mats Lidell
+;; Last-Mod:      1-Jan-24 at 20:56:49 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -563,6 +563,28 @@ Example:
           ;; This is what we get
           (should (looking-at-p "@loc>"))
           (should (= 2 (line-number-at-pos))))
+      (kill-buffer "*HyRolo*")
+      (hy-delete-file-and-buffer org-file))))
+
+(ert-deftest hyrolo-tests--outline-up-header ()
+  "Verify movement from sub header to next header one level above."
+  (let* ((org-file (make-temp-file "hypb" nil ".org"
+                                   (hyrolo-tests--gen-outline "header" 2 "body" 3)))
+         (hyrolo-file-list (list org-file)))
+    (unwind-protect
+        (progn
+          (hyrolo-grep "body")
+          (should (string= "*HyRolo*" (buffer-name)))
+
+          ;; Move to last header
+          (goto-char (point-max))
+          (forward-line -2)
+          (should (looking-at-p "^*** header 2.2.3$"))
+          (should (hact 'kbd-key "u"))
+          (should (looking-at-p "^** header 2.2$"))
+          (should (hact 'kbd-key "u"))
+          (should (looking-at-p "^* header 2$"))
+          (should-error (hact 'kbd-key "u")))
       (kill-buffer "*HyRolo*")
       (hy-delete-file-and-buffer org-file))))
 


### PR DESCRIPTION
## What

Matsl rsw add hyrolo tests.

## Why

Sharing `WIP` because there seems to be version depended problems here between 27 and 28 in respect to 29 and 30. The tests in this work are constructed to work for 29 and 30 but not testing the expected behavior.

## Note

Getting the build checks to stick seems to be problematic. An earlier CI/CD build was created but when I added more tests it went away again. Not sure if that was the cause but it happened.

## Bugs

1. `hyrolo-tests--outline-next-visible-header` -- Moving up using `p` stops on line 2 and can't reach the first line. Expected behavior is to not land on line 2 but go straight to line 1.
2. `hyrolo-tests--outline-next-visible-header-two-sections` -- Same as 1.
3. `hyrolo-tests--outline-hide-show-heading` -- When hitting `h` for hiding the header this error message occurs: *org-fold-region: Calling ‘org-fold-core-region’ with missing SPEC*