### PR TITLE
Add more hyrolo show, hide and movement tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+2024-01-09  Mats Lidell  <matsl@gnu.org>
+
+* test/hyrolo-tests.el (hyrolo-tests--outline-next-visible-heading-md)
+    (hyrolo-tests--outline-next-visible-heading-all)
+    (hyrolo-tests--outline-next-visible-heading-kotl)
+    (hyrolo-tests--outline-next-visible-heading-all-file-types)
+    (hyrolo-tests--outline-show-when-moving-out-of-hidden-line): Add more
+    test cases for hyrolo outline show, hide and movement.
+
+    (hyrolo-tests--gen-kotl-outline, hyrolo-tests--verify-hidden-line)
+    (hyrolo-tests--verify-not-hidden-line): Add helper functions and use.
+
 2024-01-09  Bob Weiner  <rsw@gnu.org>
 
 * hact.el (htype:def-symbol, htype:names, actype:def-symbol): Change call
@@ -20,6 +32,9 @@
   Makefile (EL_COMPILE):
   hsys-xref.el (hsys-xref-definitions): Move xref utility functions
     from "hmouse-tag.el" to here and add Hyperbole unique hsys- prefix.
+
+* test/hy-test-helpers.el (hy-delete-files-and-buffers): Add helper for
+    cleaning up multiple files and buffers.
 
 2024-01-06  Mats Lidell  <matsl@gnu.org>
 

--- a/test/hy-test-helpers.el
+++ b/test/hy-test-helpers.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     26-Dec-23 at 11:55:42 by Bob Weiner
+;; Last-Mod:      7-Jan-24 at 00:56:08 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -87,6 +87,11 @@ Checks ACTYPE, ARGS, LOC and LBL-KEY."
         (set-buffer-modified-p nil)
         (kill-buffer))))
   (delete-file file))
+
+(defun hy-delete-files-and-buffers (files)
+  "Delete all FILES and all buffers visiting those files."
+  (dolist (f files)
+    (hy-delete-file-and-buffer f)))
 
 (defun hy-delete-dir-and-buffer (dir)
   "Delete DIR and buffer visiting directory."


### PR DESCRIPTION
# What

Matsl rsw complete hyrolo hiding tests.

# Why

This completes the hyrolo tests for hide/show/movement  in respect to the TODO item for hyrolo tests. When more specific tests are needed lets create new TODO-items for those to avoid having long lasting TODO-items.

# Note

The PR contains skip guards in test cases depending on org folding functionality. i.e. org fold changes in org 9.6. When hyrolo is updated to handle the incompatible changes in org mode these guards shall be removed. 