### PR TITLE
Add tests for non file ebut creation and deletion

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,14 @@
+2024-01-13  Mats Lidell  <matsl@gnu.org>
+
+* test/hbut-tests.el (ebut-program-link-to-directory): Remove test in
+    favor of almost identical copy but keep the simpler name.
+
+    (ebut-program-link-to-directory-in-non-file-buffer)
+    (ebut-program-link-to-directory-in-message-mode-buffer)
+    (ebut-delete-removes-ebut-in-non-file-buffer)
+    (ebut-delete-removes-ebut-in-message-mode-buffer): Add tests for
+    non-file buffer and non-file in message-mode buffer.
+
 2024-01-09  Bob Weiner  <rsw@gnu.org>
 
 * hsys-xref.el: Add forgotten file.

--- a/test/hbut-tests.el
+++ b/test/hbut-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-may-21 at 09:33:00
-;; Last-Mod:     13-Jan-24 at 00:26:25 by Mats Lidell
+;; Last-Mod:     13-Jan-24 at 20:37:07 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -83,7 +83,6 @@ Create button with link-to-directory using `temporary-file-directory`."
 
 (ert-deftest ebut-delete-removes-ebut-in-non-file-buffer ()
   "Remove an ebut from non file buffer."
-  :expected-result :failed ;; BUG: hui:ebut-unmark tries to find file of buffer.
   (with-temp-buffer
     (ebut:program "label" 'link-to-directory "/tmp")
     (should (hbut:at-p))

--- a/test/hbut-tests.el
+++ b/test/hbut-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-may-21 at 09:33:00
-;; Last-Mod:     23-Nov-23 at 01:44:46 by Bob Weiner
+;; Last-Mod:     13-Jan-24 at 00:26:25 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -32,19 +32,6 @@ Needed since hyperbole expands all links to absolute paths and
   (should (and (stringp tmp) (string-match-p "\"?\\(/\\|./\\|/private/\\)tmp\"?\\'" tmp) t)))
 
 (ert-deftest ebut-program-link-to-directory ()
-  "Programatically create ebut with link-to-directory."
-  (let ((file (make-temp-file "hypb_" nil ".txt")))
-    (unwind-protect
-        (progn
-          (find-file file)
-          (ebut:program "label" 'link-to-directory "/tmp")
-          (should (eq (hattr:get (hbut:at-p) 'actype) 'actypes::link-to-directory))
-          (hbut-tests:should-match-tmp-folder (car (hattr:get (hbut:at-p) 'args)))
-          (should (equal (hattr:get (hbut:at-p) 'loc) file))
-          (should (equal (hattr:get (hbut:at-p) 'lbl-key) "label")))
-      (hy-delete-file-and-buffer file))))
-
-(ert-deftest ebut-program-link-to-directory-2 ()
   "Programatically create ebut with link-to-directory using `temporary-file-directory`."
   (let ((file (make-temp-file "hypb_" nil ".txt")))
     (unwind-protect
@@ -53,6 +40,24 @@ Needed since hyperbole expands all links to absolute paths and
           (ebut:program "label" 'link-to-directory temporary-file-directory)
           (hy-test-helpers-verify-hattr-at-p :actype 'actypes::link-to-directory :args (list temporary-file-directory) :loc file :lbl-key "label"))
       (hy-delete-file-and-buffer file))))
+
+(ert-deftest ebut-program-link-to-directory-in-non-file-buffer ()
+  "Programatically create ebut in non file buffer.
+Create button with link-to-directory using `temporary-file-directory`."
+  (with-temp-buffer
+    (ebut:program "label" 'link-to-directory temporary-file-directory)
+    (hy-test-helpers-verify-hattr-at-p :actype 'actypes::link-to-directory :args (list temporary-file-directory) :loc (current-buffer) :lbl-key "label")))
+
+(ert-deftest ebut-program-link-to-directory-in-message-mode-buffer ()
+  "Programatically create ebut in message mode buffer.
+Create button with link-to-directory using `temporary-file-directory`."
+  (with-temp-buffer
+    (unwind-protect
+        (progn
+          (message-mode)
+          (ebut:program "label" 'link-to-directory temporary-file-directory)
+          (hy-test-helpers-verify-hattr-at-p :actype 'actypes::link-to-directory :args (list temporary-file-directory) :loc (current-buffer) :lbl-key "label"))
+      (set-buffer-modified-p nil))))
 
 (ert-deftest ebut-program-shell-cmd ()
   "Programatically create ebut running shell command."
@@ -64,7 +69,7 @@ Needed since hyperbole expands all links to absolute paths and
           (hy-test-helpers-verify-hattr-at-p :actype 'actypes::exec-shell-cmd :args '("ls /tmp") :loc file :lbl-key "label"))
       (hy-delete-file-and-buffer file))))
 
-(ert-deftest ebut-delete-removes-ebut-and-returns-button-data ()
+(ert-deftest ebut-delete-removes-ebut ()
   "Remove an ebut."
   (let ((file (make-temp-file "hypb_" nil ".txt")))
     (unwind-protect
@@ -72,10 +77,27 @@ Needed since hyperbole expands all links to absolute paths and
           (find-file file)
           (ebut:program "label" 'link-to-directory "/tmp")
           (should (hbut:at-p))
-          (let ((success-flag (hui:hbut-delete)))
-            (should-not (hbut:at-p))
-            (should (eq success-flag t))))
+          (should (hui:hbut-delete))
+          (should-not (hbut:at-p)))
       (hy-delete-file-and-buffer file))))
+
+(ert-deftest ebut-delete-removes-ebut-in-non-file-buffer ()
+  "Remove an ebut from non file buffer."
+  :expected-result :failed ;; BUG: hui:ebut-unmark tries to find file of buffer.
+  (with-temp-buffer
+    (ebut:program "label" 'link-to-directory "/tmp")
+    (should (hbut:at-p))
+    (should (hui:hbut-delete))
+    (should-not (hbut:at-p))))
+
+(ert-deftest ebut-delete-removes-ebut-in-message-mode-buffer ()
+  "Remove an ebut from `message-mode' buffer."
+  (with-temp-buffer
+    (message-mode)
+    (ebut:program "label" 'link-to-directory "/tmp")
+    (should (hbut:at-p))
+    (should (hui:hbut-delete))
+    (should-not (hbut:at-p))))
 
 (ert-deftest gbut-program-calls-ebut-program ()
   "Programatically create gbut calls ebut:program."


### PR DESCRIPTION
# What

Matsl rsw add tests for various ebut in non-file buffers and non-file buffers in message-mode.

# Why

More tests are good and we have a TODO-item around this.

# Note

See `ebut-delete-removes-ebut-in-non-file-buffer`. It looks like `hui:ebut-unmark` tries to get the corresponding file of the buffer which does not exists. Oddly the message-mode test works but might be due to the special tests around mail buffers. I haven't debugged it that deep yet. The test is marked as expected failed.

Also removed a test case that was almost identical with a variation.