### PR TITLE
Matsl rsw forward backward same level tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2024-01-15  Mats Lidell  <matsl@gnu.org>
+
+* test/hyrolo-tests.el (hyrolo-tests--forward-same-level-all-file-types-level1)
+    (hyrolo-tests--forward-same-level-org-level2): Add tests for hyrolo
+    forward and backward movement on same level.
+
 2024-01-14  Bob Weiner  <rsw@gnu.org>
 
 * hypb.el (require 'org): Add to define 'org-show-all'.  Fix typo
@@ -129,6 +135,8 @@
                   (flymake-mode-hook): Check whether `repeat-mode' is
     fboundp or not before trying to enable it (should be autoloaded when
     it exists, probably in Emacs 28 or greater).
+
+2024-01-09  Bob Weiner  <rsw@gnu.org>
 
 * hsys-xref.el: Add forgotten file.
 

--- a/test/hyrolo-tests.el
+++ b/test/hyrolo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    19-Jun-21 at 22:42:00
-;; Last-Mod:     15-Jan-24 at 00:31:26 by Mats Lidell
+;; Last-Mod:     15-Jan-24 at 00:38:13 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -906,6 +906,7 @@ Make cell start with HEADING and follow by next line BODY."
 (ert-deftest hyrolo-tests--forward-same-level-all-file-types-level1 ()
   "Verify forward and backward to first level headers and section lines.
 All files types are present."
+  :expected-result :failed
   (let* ((org-file1 (make-temp-file "hypb" nil ".org"
                                     (hyrolo-tests--gen-outline ?* "heading-org" 1 "body-org" 1)))
          (md-file1 (make-temp-file "hypb" nil ".md"

--- a/test/hyrolo-tests.el
+++ b/test/hyrolo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    19-Jun-21 at 22:42:00
-;; Last-Mod:     13-Jan-24 at 20:05:16 by Bob Weiner
+;; Last-Mod:     15-Jan-24 at 00:31:26 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -900,6 +900,82 @@ Make cell start with HEADING and follow by next line BODY."
           (should (string= (buffer-name) (file-name-nondirectory org-file)))
           (should (looking-at-p "^body 1\\.2$"))
           )
+      (kill-buffer hyrolo-display-buffer)
+      (hy-delete-files-and-buffers hyrolo-file-list))))
+
+(ert-deftest hyrolo-tests--forward-same-level-all-file-types-level1 ()
+  "Verify forward and backward to first level headers and section lines.
+All files types are present."
+  (let* ((org-file1 (make-temp-file "hypb" nil ".org"
+                                    (hyrolo-tests--gen-outline ?* "heading-org" 1 "body-org" 1)))
+         (md-file1 (make-temp-file "hypb" nil ".md"
+                                   (hyrolo-tests--gen-outline ?# "heading-md" 1 "body-md" 1)))
+         (otl-file1 (make-temp-file "hypb" nil ".otl"
+                                    (hyrolo-tests--gen-outline ?* "heading-otl" 1 "body-otl" 1)))
+         (kotl-file1 (hyrolo-tests--gen-kotl-outline "heading-kotl" "body-kotl"))
+         (hyrolo-file-list (list org-file1 md-file1 otl-file1 kotl-file1)))
+    (unwind-protect
+        (progn
+          (hyrolo-grep "body")
+          (should (string= hyrolo-display-buffer (buffer-name)))
+
+          ;; Move forward
+          (dolist (v '("===" "^\\* heading-org 1$" "===" "^# heading-md 1$"
+                       "===" "^\\* heading-otl 1$" "===" "^ +1\\. heading-kotl$"))
+            (should (and (looking-at-p v) (hact 'kbd-key "f"))))
+          (should (looking-at-p "^ +1\\. heading-kotl$")) ; When on last match do not move further
+
+          ;; Move backward
+          (dolist (v '("===" "^\\* heading-otl 1$" "===" "^# heading-md 1$"
+                       "===" "^\\* heading-org 1$" "==="))
+            (should (and (hact 'kbd-key "b") (looking-at-p v))))
+          (should (= 1 (line-number-at-pos))))
+      (kill-buffer hyrolo-display-buffer)
+      (hy-delete-files-and-buffers hyrolo-file-list))))
+
+(ert-deftest hyrolo-tests--forward-same-level-org-level2 ()
+  "Verify forward and backward to second level headers with org files."
+  (let* ((content
+          "\
+* h-org 1
+body
+** h-org 1.1
+body
+** h-org 1.2
+body
+*** h-org 1.2.1
+body
+* h-org 2
+body
+** h-org-2.1
+body
+")
+         (org-file1 (make-temp-file "hypb" nil ".org" content))
+         (org-file2 (make-temp-file "hypb" nil ".org" content))
+         (hyrolo-file-list (list org-file1 org-file2)))
+    (unwind-protect
+        (progn
+          (hyrolo-grep "body")
+          (should (string= hyrolo-display-buffer (buffer-name)))
+
+          ;; Move to first second level header
+          (search-forward "** h-org 1.1")
+          (beginning-of-line)
+          (should (looking-at-p "^\\*\\* h-org 1\\.1"))
+
+          ;; Move forward same level
+          (should (and (hact 'kbd-key "f") (looking-at-p "^\\*\\* h-org 1\\.2")))
+
+          ;; Multiple times does not move point when there are no more headers at the same level
+          (should (and (hact 'kbd-key "f") (looking-at-p "^\\*\\* h-org 1\\.2")))
+          (should (and (hact 'kbd-key "f") (looking-at-p "^\\*\\* h-org 1\\.2")))
+
+          ;; Move back on same level
+          (should (and (hact 'kbd-key "b") (looking-at-p "\\*\\* h-org 1\\.1")))
+
+          ;; Moving up from first header on a level errors, also when repeated.
+          (should-error (and (hact 'kbd-key "b") (looking-at-p "^\\*\\* h-org 1\\.1")))
+          (should-error (and (hact 'kbd-key "b") (looking-at-p "^\\*\\* h-org 1\\.1"))))
       (kill-buffer hyrolo-display-buffer)
       (hy-delete-files-and-buffers hyrolo-file-list))))
 


### PR DESCRIPTION
# What

Matsl rsw forward backward same level tests.

# Note

While cleaning up I noticed this branch with tests for moving forward and backwards at the same level. One of the tests fail due to point jumping over a few lines. Added it as "expected-result failed."

Here are the details. The \*HyRolo\* file.

```
===============================================================================
@loc> "/tmp/hypbVG9ksf.org"
===============================================================================
* heading-org 1
body-org 1
===============================================================================
@loc> "/tmp/hypbOQBeuv.md"
===============================================================================
# heading-md 1
body-md 1
===============================================================================
@loc> "/tmp/hypbrGtujm.otl"
===============================================================================
* heading-otl 1
body-otl 1
===============================================================================
@loc> "/tmp/hypbDIK8zl.kotl"
===============================================================================
   1. heading-kotl
      body-kotl
```
When pressing 'f' on "* heading-org 1" point moved immediately down to "* heading-otl 1". Should it not land on the next "===" line? (And next go to "# heading-md 1" etc...) 

On the way up with 'b' it also does not go to the top. It stays at line 2. "@loc> "/tmp/hypbVG9ksf.org"".

I might be confused here since I thought this was solved. But there has been multiple PRs and I think I just communicated this problem without sharing test case and with no PR.