### PR TITLE
Add tests with more file types and outline structure depth

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,16 @@
+2024-01-16  Mats Lidell  <matsl@gnu.org>
+
+* test/hyrolo-tests.el
+    (hyrolo-tests--forward-same-level-all-file-types-level1-depth2)
+    (hyrolo-tests--forward-same-level-all-file-types-level2): Add test
+    with more file types and second level headings.
+
+    (hyrolo-tests--outline-content-org, hyrolo-tests--outline-content-otl)
+    (hyrolo-tests--outline-content-md); Add test content constants.
+
+    (hyrolo-tests--gen-kotl-outline): Add depth arg to kotl to generate
+    child cells in test data.
+
 2024-01-15  Mats Lidell  <matsl@gnu.org>
 
 * test/hyrolo-tests.el (hyrolo-tests--forward-same-level-all-file-types-level1)


### PR DESCRIPTION
# What

Matsl rsw add tests for forward and backwards using multi file and depth structure.

# Why

We need to have more variations on the files and more depth to the outline structure to catch all cases.

# Note

Quick copy of old test cases and small refactoring to provide some variations on the setup of file types and outline structure with depth.  