### PR TITLE
Print build environment info when using eln target

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2024-01-16  Mats Lidell  <matsl@gnu.org>
+
+* Makefile (eln): Use echo target for showing build info as part of the
+    eln build.
+    (echo): Show Emacs location and version in build environment info.
+
 2024-01-15  Bob Weiner  <rsw@gnu.org>
 
 * hyrolo.el (hyrolo-to-entry-beginning): Rewrite to move properly.

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:     15-Jan-24 at 08:28:48 by Mats Lidell
+# Last-Mod:     16-Jan-24 at 11:26:22 by Mats Lidell
 #
 # Copyright (C) 1994-2023  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -260,7 +260,10 @@ help:
 all: help
 
 echo:
-	which emacs; echo $(TERM); echo "$(DISPLAY)"
+	@echo "Emacs: $(shell which emacs)"
+	@echo "Version: $(shell emacs --version)"
+	@echo "TERM: $(TERM)"
+	@echo "DISPLAY: $(DISPLAY)"
 
 install: elc install-info install-html $(data_dir)/hkey-help.txt
 
@@ -325,7 +328,7 @@ remove-elc:
 bin: src remove-elc new-bin
 
 # Native compilation (Requires Emacs built with native compilation support.)
-eln: src
+eln: echo src
 	HYPB_NATIVE_COMP=yes make new-bin
 
 tags: TAGS


### PR DESCRIPTION
# What

Matsl rsw echo emacs and env info

# Why

We need to show emacs version when compiling natively to make it easier to see that the proper version is used.

# Note

Reuses the echo target for printing the environment and added emacs version info to echo target as well.