### PR TITLE
Remove skip guard on test that works in batch mode

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2024-01-17  Mats Lidell  <matsl@gnu.org>
+
+* test/hui-select-tests.el (hui-select--thing): Remove not interactive
+    guard.
+
 2024-01-16  Mats Lidell  <matsl@gnu.org>
 
 * Makefile (eln): Use echo target for showing build info as part of the

--- a/test/hui-select-tests.el
+++ b/test/hui-select-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    14-Apr-22 at 23:45:52
-;; Last-Mod:     23-Nov-23 at 02:12:38 by Bob Weiner
+;; Last-Mod:     16-Jan-24 at 17:57:01 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -82,7 +82,6 @@
 
 (ert-deftest hui-select--thing ()
   "`hui-select-thing' selects bigger sections of text when called repeatedly."
-  (skip-unless (not noninteractive))
   (hui-select-reset)
   (with-temp-buffer
     (insert "Buffer\n\nParagraph\nline.  One word.")


### PR DESCRIPTION
# What

Remove skip guard on test that works in batch mode.

# Why

Try to run as many tests as possible in batch mode.

# Note 1

It seems most tests that has the guard for not running them in batch mode actually requires that. I only found one test.

I have not tested to run all with skip guards in batch mode. Instead I have tested a few and if they failed to run I have looked for calling patterns in related test cases. If they use the same setup I have concluded that they probably not will work in batch mode either.

# Note 2 

I have some good thing to mention now though. While working on the presentation I found a hack that we might be able to use to run the interactive tests in the CI/CD. It passes my first limited test anyway. It is on my todo to play more with that. I think it is post 9.0 release though. We can run the interactive tests locally using docker if we want to sanity check before the release.