### PR TITLE
Revert "Remove skip guard on test that works in batch mode"

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,11 +11,6 @@
               (hsys-org-get-libraries-to-reload): Add to compute wrong
     Org libraries loaded and use in above function.
 
-2024-01-17  Mats Lidell  <matsl@gnu.org>
-
-* test/hui-select-tests.el (hui-select--thing): Remove not interactive
-    guard.
-
 2024-01-16  Mats Lidell  <matsl@gnu.org>
 
 * Makefile (eln): Use echo target for showing build info as part of the

--- a/test/hui-select-tests.el
+++ b/test/hui-select-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    14-Apr-22 at 23:45:52
-;; Last-Mod:     16-Jan-24 at 17:57:01 by Mats Lidell
+;; Last-Mod:     23-Nov-23 at 02:12:38 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -82,6 +82,7 @@
 
 (ert-deftest hui-select--thing ()
   "`hui-select-thing' selects bigger sections of text when called repeatedly."
+  (skip-unless (not noninteractive))
   (hui-select-reset)
   (with-temp-buffer
     (insert "Buffer\n\nParagraph\nline.  One word.")


### PR DESCRIPTION
# What

Revert bad not interactive change.

# Why

The change broke CI/CD. My bad. Local "make test" works but not in docker nor at github. So reverting to keep rsw branch healthy. 

Yet another reason to get back to normal procedures where PR builds will catch this before merging.