### PR TITLE
Cleanup of flycheck/flymake info and warning messages

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 2024-01-20  Mats Lidell  <matsl@gnu.org>
 
+* Cleanup using flycheck resolving info and warning messages.
+
 * Update copyright date of latest updated version to be 2024 for all files
     with copyright string that so far have been updated in git under 2024.
 

--- a/hbdata.el
+++ b/hbdata.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Apr-91
-;; Last-Mod:      3-Jan-24 at 02:27:47 by Bob Weiner
+;; Last-Mod:     17-Jan-24 at 23:07:53 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -88,7 +88,7 @@
 ;;; Button data accessor functions
 ;;; ------------------------------------------------------------------------
 (defun hbdata:action (hbdata)
-  "[Hyp V2] Return action overriding button's action type or nil."
+  "[Hyp V2] Return action overriding button's action type or nil from HBDATA."
   (nth 1 hbdata))
 
 (defun hbdata:actype (hbdata)

--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:     14-Jan-24 at 11:55:14 by Bob Weiner
+;; Last-Mod:     20-Jan-24 at 00:21:10 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -196,7 +196,9 @@ Do not save button data buffer."
 
 (defun    ebut:get (&optional lbl-key buffer key-src start-delim end-delim)
   "Return explicit Hyperbole button symbol given by LBL-KEY and BUFFER.
-KEY-SRC is given when retrieving global buttons and is the full source pathname.
+KEY-SRC is given when retrieving global buttons and is the full
+source pathname.  START-DELIM and END-DELIM are strings that
+override default button delimiters.
 
 Retrieve button data, convert into a button object and return a symbol
 which references the button.
@@ -2610,7 +2612,7 @@ Summary of operations based on inputs (name arg from \\='hbut:current attrs):
 	 (insert (format "<%s \"%s\" %d \"%s\">" (actype:def-symbol actype) arg1 arg2
 			 (hpath:shorten arg3)))))
       ('nil (error "(ibut:insert-text): actype must be a Hyperbole actype or Lisp function symbol, not '%s'" orig-actype))
-      ;; Generic action button type						      
+      ;; Generic action button type
       (_ (insert (format "<%s%s%s>" (actype:def-symbol actype) (if args " " "")
 			 (if args (hypb:format-args args) "")))))
     (unless (looking-at "\\s-\\|\\'")
@@ -2695,7 +2697,7 @@ the existing point."
 	   (save-excursion (insert new-lbl ibut:label-end))
 	   (hattr:clear 'hbut:current)
            t))
-	(t (error "(ibut:rename): Button '%s' not found in visible portion of buffer." old-lbl))))
+	(t (error "(ibut:rename): Button '%s' not found in visible portion of buffer" old-lbl))))
 
 (defalias 'ibut:summarize #'hbut:report)
 
@@ -3116,3 +3118,4 @@ Return TYPE's symbol if it existed, else nil."
     (and elisp-sym (funcall elisp-sym) t)))
 
 (provide 'hbut)
+;;; hbut.el ends here

--- a/hib-debbugs.el
+++ b/hib-debbugs.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Jun-16 at 14:24:53
-;; Last-Mod:     20-Jan-24 at 15:38:32 by Mats Lidell
+;; Last-Mod:     20-Jan-24 at 20:15:21 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -154,9 +154,9 @@ Ignore other types of GNU debbugs query strings."
 ;;; ************************************************************************
 
 (defun debbugs-gnu-show-discussion ()
+  "Display the 2nd message which is the initial bug report.
+This may be in Gnus or Rmail summary mode."
     (debbugs-gnu-select-report)
-    ;; Display the 2nd message which is the initial bug report.  This
-    ;; may be in Gnus or Rmail summary mode.
     (goto-char (point-min))
     (forward-line 1)
     (call-interactively (key-binding "\C-m")))
@@ -219,7 +219,7 @@ When the Action Key is pressed on a Gnu Debbugs listing entry."
   "Return t if point appears to be within a debbugs id.
 Id number is (match-string 2).  If this is a query with attributes,
 then (match-string 3) = \"?\" and (match-string 4) is the query
-attributes." 
+attributes."
   ;; Point must be before one of the bug#222 characters to match.
   (let ((case-fold-search t))
     (when (string-match "[bugise#0-9]" (char-to-string (following-char)))

--- a/hib-kbd.el
+++ b/hib-kbd.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    22-Nov-91 at 01:37:57
-;; Last-Mod:     23-Nov-23 at 01:51:41 by Bob Weiner
+;; Last-Mod:     17-Jan-24 at 23:47:04 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -77,10 +77,10 @@ the unmodified key.")
 
 (defconst kbd-key:extended-command-prefix "\\_<M-x\\_>"
   "Normalized prefix regular expression that invokes an extended command.
-Default is M-x.")
+Default is \\`M-x'.")
 
 (defconst kbd-key:extended-command-binding-list '(execute-extended-command helm-M-x counsel-M-x)
-  "List of commands that may be bound to M-x to invoke extended/named commands.")
+  "List of commands that may be bound to \\`M-x' to invoke extended/named commands.")
 
 (defvar kbd-key:mini-menu-key nil
   "The key sequence that invokes the Hyperbole minibuffer menu.")
@@ -189,7 +189,7 @@ Return t if KEY-SERIES is a valid key series that is executed, else nil."
     (hact #'kbd-key:act key-series)))
 
 (defun kbd-key:execute-special-series (key-series)
-  "Execute key series."
+  "Execute KEY-SERIES."
   (if (memq (key-binding [?\M-x]) '(execute-extended-command counsel-M-x))
       (kbd-key:key-series-to-events key-series)
     ;; Disable helm while processing M-x commands; helm
@@ -208,12 +208,12 @@ Return t if KEY-SERIES is a valid key series that is executed, else nil."
 
 (defun kbd-key:maybe-enable-helm (helm-flag orig-M-x-binding)
   "Enable helm-mode if HELM-FLAG is non-nil.
-Restore M-x binding to ORIG-M-X-BINDING."
+Restore \\`M-x' binding to ORIG-M-X-BINDING."
   (when helm-flag (helm-mode 1))
   (global-set-key [?\M-x] orig-M-x-binding))
 
 (defun kbd-key:key-series-to-events (key-series)
-  "Insert the key-series as a series of keyboard events.
+  "Insert the KEY-SERIES as a series of keyboard events.
 The events are inserted into Emacs unread input stream.  Emacs
 then executes them when its command-loop regains control."
   (setq unread-command-events (nconc unread-command-events
@@ -259,7 +259,7 @@ With optional prefix arg FULL, display full documentation for command."
   "Return the non-delimited, normalized form, of a delimited key series, STR.
 When STR is a curly-brace {} delimited key series, a
 non-delimited, normalized form is returned, else nil.  Key
-sequences should be in human readable form, e.g. {C-x C-b}, or
+sequences should be in human readable form, e.g. {\\`C-x' \\`C-b'}, or
 what `key-description' returns.  Forms such as {\C-b}, {\^b}, and
 {^M} will not be recognized.
 
@@ -380,6 +380,7 @@ For an approximate inverse of this, see `key-description'."
 ;; try to parse <event> strings nor does it have optional second
 ;; parameter, need-vector.
 (defun kbd-key:parse (string)
+  "Parse STRING for keys."
   (let ((case-fold-search nil)
 	(len (length string)) ; We won't alter string in the loop below.
 	(pos 0)
@@ -535,7 +536,7 @@ KEY-SERIES can have following interactive arguments."
   "Return non-nil if normalized KEY-SERIES string is one of the following:
 a Hyperbole minibuffer menu item key sequence,
 a HyControl key sequence,
-a M-x extended command,
+a \\`M-x' extended command,
   or a valid key sequence together with its interactive arguments."
   (or (kbd-key:hyperbole-mini-menu-key-p key-series)
       (kbd-key:hyperbole-hycontrol-key-p key-series)

--- a/hib-social.el
+++ b/hib-social.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    20-Jul-16 at 22:41:34
-;; Last-Mod:     28-Oct-23 at 12:27:26 by Bob Weiner
+;; Last-Mod:     17-Jan-24 at 23:48:46 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -645,6 +645,7 @@ Then an Action Key displays the associated changeset."
   "Filename of cache of local git repository directories found by `locate-command'.")
 
 (defun hibtypes-git-get-locate-command ()
+  "Get the locate command."
   (require 'locate)
   (let ((cmd (if (string-match "locate" locate-command) locate-command "locate")))
     (if (executable-find cmd)

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:     20-Jan-24 at 15:38:00 by Mats Lidell
+;; Last-Mod:     20-Jan-24 at 20:15:45 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -643,7 +643,7 @@ line."
                (save-excursion
                  (beginning-of-line)
                  ;; Entry line within a TOC
-                 (when (and (or 
+                 (when (and (or
 			     ;; Next line is typically in RFCs,
 			     ;; e.g. "1.1.  Scope ..... 1"
 			     (looking-at "^[ \t]*\\([0-9.]+\\([ \t]+[^ \t\n\r]+\\)+\\) \\.+")

--- a/hmoccur.el
+++ b/hmoccur.el
@@ -3,7 +3,7 @@
 ;; Author:       Markus Freericks <Mfx@cs.tu-berlin.de> / Bob Weiner
 ;;
 ;; Orig-Date:     1-Aug-91
-;; Last-Mod:     25-Dec-23 at 01:58:55 by Bob Weiner
+;; Last-Mod:     17-Jan-24 at 23:57:46 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -76,6 +76,7 @@ With optional FILE-REGEXP (a pattern which matches to files in a
 single directory), search matching files rather than current
 buffers.  The lines are shown in a buffer named *Moccur* which
 serves as a menu to find any of the occurrences in this buffer.
+With optional NO-FOLD-SEARCH non-nil do case sensitive search.
 
 \\{moccur-mode-map}"
   (interactive "sRegexp to find occurrences of: \nsFiles to search (default current file buffers): ")

--- a/hmouse-drv.el
+++ b/hmouse-drv.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-90
-;; Last-Mod:     20-Jan-24 at 15:38:45 by Mats Lidell
+;; Last-Mod:     20-Jan-24 at 20:15:55 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -88,8 +88,8 @@ that the release point was in its frame.
 
 See function `hmouse-window-at-absolute-pixel-position' for more details.")
 
-(defvar action-key-depressed-flag nil "t while Action Key is depressed.")
-(defvar assist-key-depressed-flag nil "t while Assist Key is depressed.")
+(defvar action-key-depressed-flag nil "Non-nil means Action Key is depressed.")
+(defvar assist-key-depressed-flag nil "Non-nil means Assist Key is depressed.")
 (defvar action-key-depress-args nil
   "List of event args from most recent depress of the Action Mouse Key.")
 (defvar assist-key-depress-args nil
@@ -151,12 +151,12 @@ Note that this may be a buffer different than where the release occurs.")
   "When non-nil, cancels last Assist Key depress.")
 
 (defvar action-key-help-flag nil
-  "When non-nil, forces display of help for next Action Key release.")
+  "Non-nil means it forces display of help for next Action Key release.")
 (defvar assist-key-help-flag nil
-  "When non-nil, forces display of help for next Assist Key release.")
+  "Non-nil means it forces display of help for next Assist Key release.")
 
 (defvar assist-flag nil
-  "Non-nil when Hyperbole's Assist Key is in use rather than the Action Key.
+  "Non-nil means Hyperbole's Assist Key is in use rather than the Action Key.
 Never set directly.  Bound as a parameter when `hkey-execute' is called
 and then used as a free variable.")
 
@@ -246,12 +246,12 @@ This permits the Smart Keys to behave as paste keys.")
   (run-hooks 'assist-key-depress-hook))
 
 (defun action-key-depress-emacs (event)
-  "Handle depress event of the Hyperbole Action Mouse Key."
+  "Handle depress EVENT of the Hyperbole Action Mouse Key."
   (interactive "e")
   (action-key-depress event))
 
 (defun assist-key-depress-emacs (event)
-  "Handle depress event of the Hyperbole Assist Mouse Key."
+  "Handle depress EVENT of the Hyperbole Assist Mouse Key."
   (interactive "e")
   (assist-key-depress event))
 
@@ -359,6 +359,7 @@ a valid function."
     (setq action-key-depressed-flag nil)))
 
 (defun action-key-internal ()
+  "Action key internal."
   (setq action-key-depressed-flag t)
   (when action-key-cancelled
     (setq action-key-cancelled nil
@@ -382,6 +383,7 @@ bound to a valid function."
     (setq assist-key-depressed-flag nil)))
 
 (defun assist-key-internal ()
+  "Assist key internal."
   (setq assist-key-depressed-flag t)
   (when assist-key-cancelled
     (setq assist-key-cancelled nil
@@ -420,7 +422,7 @@ The ace-window package, (see \"https://elpa.gnu.org/packages/ace-window.html\"),
 assigns short ids to each Emacs window and lets you jump to or
 operate upon a specific window by giving its letter.  Hyperbole
 can insert an operation into ace-window that allows you to
-display items such as dired or buffer menu items in a specific
+display items such as Dired or buffer menu items in a specific
 window.
 
 To enable this feature, in your Emacs initialization file after
@@ -429,13 +431,13 @@ ace-window, then call:
 
  (hkey-ace-window-setup)
 
-otherwise, choose a binding like {M-o} and send it to the same
+otherwise, choose a binding like {\\`M-o'} and send it to the same
 function to bind it:
 
  (hkey-ace-window-setup \"\M-o\")
 
 Then whenever point is on an item you want displayed in another
-window, use {M-o i <id-of-window-to-display-item-in>} and watch the
+window, use {\\`M-o' i <id-of-window-to-display-item-in>} and watch the
 magic happen."
   (require 'ace-window)
   (when key (hkey-set-key key 'ace-window))
@@ -652,7 +654,7 @@ RELEASE-WINDOW is interactively selected via the `ace-window' command.
 The selected window does not change.
 
 With no prefix argument, create an unnamed implicit button.
-With a single C-u \\='(4) prefix argument, create an explicit button.
+With a single \\`C-u' \\='(4) prefix argument, create an explicit button.
 With any other prefix argument, like M-1, create an named implicit button."
   (interactive
    (list (let ((mode-line-text (concat " Ace - Hyperbole: " (nth 2 (assq ?w aw-dispatch-alist)))))
@@ -753,7 +755,7 @@ The selected window does not change."
 ;;;###autoload
 (defun hmouse-click-to-drag-item ()
   "Mouse click on start and end windows for use with `hkey-drag-item'.
-Emulate {M-o i} from start window to end window.
+Emulate {\\`M-o' i} from start window to end window.
 After the drag, the end window is the selected window."
   (interactive)
   (hmouse-choose-windows #'hkey-drag-item))
@@ -861,7 +863,7 @@ hkey-replace, hkey-swap and hkey-throw."
 (defun hmouse-keyboard-choose-windows (func)
   "Press Return in start and end windows which are then applied to FUNC.
 With the start window temporarily selected, run FUNC with the end
-window as an argument. 
+window as an argument.
 
 Appropriate FUNCs include: hkey-drag, hkey-drag-to, hkey-link,
 hkey-replace, hkey-swap and hkey-throw."
@@ -984,6 +986,7 @@ frame instead."
         (mouse-drag-frame start-event 'move))))))
 
 (defun hkey-debug (pred pred-value hkey-action)
+  "Display a message with the context and values from Smart Key activation."
   (message (concat "(HyDebug) %sContext: %s; %s: %s; Buf: %s; Mode: %s; MinibufDepth: %s\n"
 		   "  action-depress: %s; action-release: %s\n"
 		   "  assist-depress: %s; assist-release: %s")
@@ -1388,7 +1391,7 @@ the current window.  By default, it is displayed in another window."
 
 (defun hkey-toggle-debug (&optional arg)
   "Toggle whether Hyperbole logs Smart Key events.
-Key events can be used later for analysis/submission using {C-h h m c}.
+Key events can be used later for analysis/submission using {\\`C-h' h m c}.
 With optional ARG, enable iff ARG is positive."
   (interactive "P")
   (if (or (and arg (<= (prefix-numeric-value arg) 0))
@@ -1412,7 +1415,7 @@ and it was inactive, return its window, else nil."
 
 ;; Based on code from subr.el.
 (defun hmouse-vertical-line-spacing (frame)
-  "Return any extra vertical spacing in pixels between text lines or 0 if none."
+  "Return FRAME extra vertical spacing in pixels between text lines or 0 if none."
   (let ((spacing (when (display-graphic-p frame)
                    (or (with-current-buffer (window-buffer (frame-selected-window frame))
                          line-spacing)

--- a/hmouse-info.el
+++ b/hmouse-info.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Apr-89
-;; Last-Mod:      3-Oct-23 at 17:48:46 by Mats Lidell
+;; Last-Mod:     18-Jan-24 at 19:08:48 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -163,9 +163,9 @@ or a Menu; otherwise returns nil."
 ;;; ************************************************************************
 
 (defun Info-handle-in-node-hdr ()
-  "If within an Info node header, move to <FILE>Top, <Up>, <Previous>, or
-<Next> node, depending on which label point is on, and return t.
-Otherwise, return nil."
+  "If within an Info node header on a label move to the corresponding node.
+Move to <FILE>Top, <Up>, <Previous>, or <Next> node, depending on
+which label point is on, and return t.  Otherwise, return nil."
   ;;
   ;; Test if on 1st line of node, i.e. node header
   ;;
@@ -193,10 +193,11 @@ Otherwise, return nil."
       t)))
 
 (defun Info-handle-in-node-hdr-assist ()
-  "If within an Info node header when the `smart-info-assist' command is
-executed, when within the <FILE> header go to the DIR `top-level node'.  When
-within any other header (<Up>, <Previous>, or <Next>) go to last node from
-history list.  Return t if in Info node header.  Otherwise return nil."
+  "When `smart-info-assist' command is executed on an Info node header, go to node.
+When within the <FILE> header go to the DIR `top-level node'.
+When within any other header (<Up>, <Previous>, or <Next>) go to
+last node from history list.  Return t if in Info node header.
+Otherwise return nil."
   ;;
   ;; Test if on 1st line of node, i.e. node header
   ;;

--- a/hmouse-key.el
+++ b/hmouse-key.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    30-May-94 at 00:11:57
-;; Last-Mod:     20-Jan-24 at 15:38:58 by Mats Lidell
+;; Last-Mod:     20-Jan-24 at 20:16:44 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -51,7 +51,7 @@
   "List of (key . binding) pairs for Hyperbole mouse keys.")
 
 (defvar hmouse-bindings-flag nil
-  "True if Hyperbole mouse bindings are in use, else nil.")
+  "Non-nil means Hyperbole mouse bindings are in use, else nil.")
 
 (defvar hmouse-previous-bindings nil
   "List of prior (key . binding) pairs for mouse keys rebound by Hyperbole.")
@@ -120,7 +120,7 @@ Assist Key = shift-right mouse key."
 		 "{Shift-Mouse-2} invokes"))))
 
 (defun hmouse-add-unshifted-smart-keys ()
-  "Bind mouse-2 to the Action Key and mouse-3 to the Assist Key."
+  "Bind \\`mouse-2' to the Action Key and \\`mouse-3' to the Assist Key."
   (interactive)
   (require 'hyperbole)
   (hmouse-unshifted-setup))
@@ -163,19 +163,6 @@ Use after any programmatic change is made."
 	  ftrs)
     (mapc #'require ftrs)
     (message "Hyperbole Smart Keys and menus have been updated")))
-
-;;; ************************************************************************
-;;; Private variables
-;;; ************************************************************************
-
-(defvar hmouse-bindings nil
-  "List of (key . binding) pairs for Hyperbole mouse keys.")
-
-(defvar hmouse-bindings-flag nil
-  "True if Hyperbole mouse bindings are in use, else nil.")
-
-(defvar hmouse-previous-bindings nil
-  "List of prior (key . binding) pairs for mouse keys rebound by Hyperbole.")
 
 (provide 'hmouse-key)
 

--- a/hmouse-mod.el
+++ b/hmouse-mod.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     8-Oct-92 at 19:08:31
-;; Last-Mod:     20-Jan-24 at 15:39:09 by Mats Lidell
+;; Last-Mod:     20-Jan-24 at 20:16:52 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -168,7 +168,9 @@ Second argument COUNT is used as a prefix argument to the command."
 	   (message "(HyDebug): hmouse-mod-execute-command - `%s' invalid key" key)))))
 
 (defun hmouse-mod-insert-command (count)
-  "Surrogate function for `self-insert-command'.  Accounts for modifier Smart Keys."
+  "Surrogate function for `self-insert-command'.
+Accounts for modifier Smart Keys.  COUNT is used as a prefix
+argument to the command."
   (interactive "p")
   (if (and (boundp 'action-key-depressed-flag)
 	   (boundp 'assist-key-depressed-flag))
@@ -204,7 +206,8 @@ Second argument COUNT is used as a prefix argument to the command."
   (keyboard-quit))
 
 (defun hmouse-mod-last-char ()
-  (when (characterp last-command-event)
+  "When last command was a character return the event."
+(when (characterp last-command-event)
     last-command-event))
 
 (provide 'hmouse-mod)

--- a/hmouse-sh.el
+++ b/hmouse-sh.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     3-Sep-91 at 21:40:58
-;; Last-Mod:     18-Jan-24 at 19:06:51 by Mats Lidell
+;; Last-Mod:     20-Jan-24 at 19:54:28 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -486,6 +486,9 @@ point determined by `mouse-select-region-move-to-beginning'."
 	      (hmouse-posn-set-point (event-end event))
 	    (error (when (window-valid-p end-w-or-f)
 		     (select-frame (window-frame end-w-or-f))))))))))
+
+(defun hmouse-move-point-eterm (arg-list)
+  (apply 'mouse-move-point arg-list))
 
 (defun hmouse-set-key-list (binding key-list)
   "Define a Hyperbole global minor mode key from KEY-LIST bound to BINDING."

--- a/hmouse-sh.el
+++ b/hmouse-sh.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     3-Sep-91 at 21:40:58
-;; Last-Mod:      3-Oct-23 at 22:50:40 by Mats Lidell
+;; Last-Mod:     18-Jan-24 at 19:06:51 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -69,7 +69,7 @@
 
 (defun hmouse-bind-key-emacs (mouse-key-number depress-cmd release-cmd)
   "Ensure MOUSE-KEY-NUMBER (1-5) is bound to DEPRESS-CMD and RELEASE-CMD.
-This includes depresses and drags.  Mouse key 1 is [mouse-1], etc.
+This includes depresses and drags.  Mouse key 1 is [\\`mouse-1'], etc.
 Use nil as cmd value to unbind a key."
   (hmouse-set-key-list
    depress-cmd
@@ -434,7 +434,7 @@ This must be bound to a button-down mouse event.
 In Transient Mark mode, the highlighting remains as long as the mark
 remains active.  Otherwise, it remains until the next input event.
 
-When the region already exists and `mouse-drag-and-drop-region'
+When the region already exists and variable `mouse-drag-and-drop-region'
 is non-nil, this moves the entire region of text to where mouse
 is dragged over to."
   (interactive "e")
@@ -487,15 +487,15 @@ point determined by `mouse-select-region-move-to-beginning'."
 	    (error (when (window-valid-p end-w-or-f)
 		     (select-frame (window-frame end-w-or-f))))))))))
 
-(defun hmouse-move-point-eterm (arg-list)
-  (apply 'mouse-move-point arg-list))
-
 (defun hmouse-set-key-list (binding key-list)
+  "Define a Hyperbole global minor mode key from KEY-LIST bound to BINDING."
   (mapc (lambda (key) (hkey-set-key key binding)) key-list)
   nil)
 
 (defun hmouse-shifted-setup (middle-flag)
-  "Call `hmouse-install' instead of this and see its documentation."
+  "Call `hmouse-install' instead of this and see its documentation.
+When non-nil MIDDLE-FLAG bind the middle and right mouse keys as
+Action and Assist Keys, respectively."
   (interactive)
   ;; Do nothing when running in batch mode.
   (unless noninteractive

--- a/hmouse-tag.el
+++ b/hmouse-tag.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    24-Aug-91
-;; Last-Mod:     20-Jan-24 at 20:17:05 by Mats Lidell
+;; Last-Mod:     20-Jan-24 at 20:21:57 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -181,7 +181,7 @@ Keyword matched is grouping 1.  Referent is grouping 2.")
 ;;; ************************************************************************
 
 (defun smart-asm (&optional identifier next)
-  "Jumps to the definition of optional assembly IDENTIFIER or the one at point.
+  "Jump to the definition of optional assembly IDENTIFIER or the one at point.
 Optional second arg NEXT means jump to next matching assembly tag.
 
 It assumes that its caller has already checked that the key was pressed in an
@@ -222,7 +222,7 @@ When optional NO-FLASH, do not flash."
 
 ;;;###autoload
 (defun smart-c++ (&optional identifier next)
-  "Jumps to the definition of optional C++ IDENTIFIER or the one at point.
+  "Jump to the definition of optional C++ IDENTIFIER or the one at point.
 Optional second arg NEXT means jump to next matching C++ tag.
 
 It assumes that its caller has already checked that the key was pressed in an
@@ -250,7 +250,7 @@ Otherwise:
 
 ;;;###autoload
 (defun smart-c++-tag (&optional identifier next)
-  "Jumps to the definition of optional C++ IDENTIFIER or the one at point.
+  "Jump to the definition of optional C++ IDENTIFIER or the one at point.
 Optional second arg NEXT means jump to next matching C++ tag."
   (let ((tag (or identifier (smart-c++-at-tag-p))))
     (message "Looking for `%s'..." tag)
@@ -396,7 +396,7 @@ When optional NO-FLASH, do not flash."
   nil)
 
 (defun smart-emacs-lisp-mode-p ()
-  "Return non-nil if in a mode which use Emacs Lisp symbols."
+  "Return non-nil if in a mode using Emacs Lisp symbols."
   ;; Beyond Lisp files, Emacs Lisp symbols appear frequently in Byte-Compiled
   ;; buffers, debugger buffers, program ChangeLog buffers, Help buffers,
   ;; *Warnings*, *Flymake log* and *Flymake diagnostics... buffers.
@@ -410,7 +410,7 @@ When optional NO-FLASH, do not flash."
 	   (smart-lisp-at-known-identifier-p))))
 
 (defun smart-fortran (&optional identifier next)
-  "Jumps to the definition of optional Fortran IDENTIFIER or the one at point.
+  "Jump to the definition of optional Fortran IDENTIFIER or the one at point.
 Optional second arg NEXT means jump to next matching Fortran tag.
 
 It assumes that its caller has already checked that the key was pressed in an
@@ -466,7 +466,7 @@ When optional NO-FLASH, do not flash."
 
 ;;;###autoload
 (defun smart-java (&optional identifier next)
-  "Jumps to the definition of optional Java IDENTIFIER or the one at point.
+  "Jump to the definition of optional Java IDENTIFIER or the one at point.
 Optional second arg NEXT means jump to next matching Java tag.
 
 It assumes that its caller has already checked that the key was pressed in an
@@ -491,7 +491,7 @@ Otherwise:
 
 ;;;###autoload
 (defun smart-java-tag (&optional identifier next)
-  "Jumps to the definition of optional Java IDENTIFIER or the one at point.
+  "Jump to the definition of optional Java IDENTIFIER or the one at point.
 Optional second arg NEXT means jump to next matching Java tag."
   (let ((tag (or identifier (smart-java-at-tag-p t))))
     (message "Looking for `%s'..." tag)
@@ -504,7 +504,7 @@ Optional second arg NEXT means jump to next matching Java tag."
 
 ;;; The following should be called only if the OO-Browser is available.
 (defun smart-java-oo-browser (&optional _junk)
-  "Jumps to the definition of selected Java construct via OO-Browser support.
+  "Jump to the definition of selected Java construct via OO-Browser support.
 Optional JUNK is ignored.  Does nothing if the OO-Browser is not available.
 
 It assumes that its caller has already checked that the key was pressed in an
@@ -968,7 +968,7 @@ See https://tkf.github.io/emacs-jedi/latest/."
 
 ;;;###autoload
 (defun smart-python (&optional identifier next)
-  "Jumps to the definition of optional Python IDENTIFIER or the one at point.
+  "Jump to the definition of optional Python IDENTIFIER or the one at point.
 Optional second arg NEXT means jump to next matching Python tag.
 
 It assumes that its caller has already checked that the key was pressed in an
@@ -993,7 +993,7 @@ in the current directory or any of its ancestor directories."
 
 ;;;###autoload
 (defun smart-python-tag (&optional identifier next)
-  "Jumps to the definition of optional Python IDENTIFIER or the one at point.
+  "Jump to the definition of optional Python IDENTIFIER or the one at point.
 Optional second arg NEXT means jump to next matching Python tag."
   (let ((tag (or identifier (smart-python-at-tag-p t))))
     (message "Looking for `%s'..." tag)
@@ -1006,7 +1006,7 @@ Optional second arg NEXT means jump to next matching Python tag."
 
 ;;; The following should be called only if the OO-Browser is available.
 (defun smart-python-oo-browser (&optional _junk)
-  "Jumps to the definition of selected Python construct via OO-Browser support.
+  "Jump to the definition of selected Python construct via OO-Browser support.
 Optional JUNK is ignored.  Does nothing if the OO-Browser is not available.
 
 It assumes that its caller has already checked that the key was pressed in an

--- a/hmouse-tag.el
+++ b/hmouse-tag.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    24-Aug-91
-;; Last-Mod:     20-Jan-24 at 15:39:18 by Mats Lidell
+;; Last-Mod:     20-Jan-24 at 20:17:05 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -207,7 +207,8 @@ If:
 
 ;;;###autoload
 (defun smart-asm-at-tag-p (&optional no-flash)
-  "Return assembly tag name that point is within, else nil."
+  "Return assembly tag name that point is within, else nil.
+When optional NO-FLASH, do not flash."
   (let* ((identifier-chars "_.$a-zA-Z0-9")
 	 (identifier (concat "[_.$a-zA-Z][" identifier-chars "]*")))
     (save-excursion
@@ -249,6 +250,8 @@ Otherwise:
 
 ;;;###autoload
 (defun smart-c++-tag (&optional identifier next)
+  "Jumps to the definition of optional C++ IDENTIFIER or the one at point.
+Optional second arg NEXT means jump to next matching C++ tag."
   (let ((tag (or identifier (smart-c++-at-tag-p))))
     (message "Looking for `%s'..." tag)
     (condition-case ()
@@ -372,7 +375,8 @@ If:
 
 ;;;###autoload
 (defun smart-c-at-tag-p (&optional no-flash)
-  "Return C tag name that point is within, else nil."
+  "Return C tag name that point is within, else nil.
+When optional NO-FLASH, do not flash."
   (let* ((identifier-chars "_a-zA-Z0-9")
 	 (identifier (concat "[_a-zA-Z][" identifier-chars "]*")))
     (save-excursion
@@ -392,7 +396,7 @@ If:
   nil)
 
 (defun smart-emacs-lisp-mode-p ()
-  "Return non-nil if in a mode which uses Emacs Lisp symbols."
+  "Return non-nil if in a mode which use Emacs Lisp symbols."
   ;; Beyond Lisp files, Emacs Lisp symbols appear frequently in Byte-Compiled
   ;; buffers, debugger buffers, program ChangeLog buffers, Help buffers,
   ;; *Warnings*, *Flymake log* and *Flymake diagnostics... buffers.
@@ -447,7 +451,8 @@ in the current directory or any of its ancestor directories."
 
 ;;;###autoload
 (defun smart-fortran-at-tag-p (&optional no-flash)
-  "Return Fortran tag name that point is within, else nil."
+  "Return Fortran tag name that point is within, else nil.
+When optional NO-FLASH, do not flash."
   (let* ((identifier-chars "_a-zA-Z0-9")
 	 (identifier (concat "[_a-zA-Z][" identifier-chars "]*")))
     (save-excursion
@@ -486,6 +491,8 @@ Otherwise:
 
 ;;;###autoload
 (defun smart-java-tag (&optional identifier next)
+  "Jumps to the definition of optional Java IDENTIFIER or the one at point.
+Optional second arg NEXT means jump to next matching Java tag."
   (let ((tag (or identifier (smart-java-at-tag-p t))))
     (message "Looking for `%s'..." tag)
     (condition-case ()
@@ -528,7 +535,8 @@ If key is pressed:
 
 ;;;###autoload
 (defun smart-java-at-tag-p (&optional no-flash)
-  "Return Java tag name that point is within, else nil."
+  "Return Java tag name that point is within, else nil.
+When optional NO-FLASH, do not flash."
   (let* ((identifier-chars "_$.a-zA-Z0-9")
 	 (identifier
 	  (concat "[_$a-zA-Z][" identifier-chars "]*")))
@@ -574,7 +582,8 @@ in the current directory or any of its ancestor directories."
 
 ;;;###autoload
 (defun smart-javascript-at-tag-p (&optional no-flash)
-  "Return JavaScript tag name that point is within, else nil."
+  "Return JavaScript tag name that point is within, else nil.
+When optional NO-FLASH, do not flash."
   (if (if (memq major-mode '(html-mode web-mode))
 	  ;; Must be within a <script> tag or this predicate function
 	  ;; fails (returns nil).
@@ -780,7 +789,8 @@ Return matching Elisp tag name that point is within, else nil."
 
 (defun smart-lisp-at-tag-p (&optional no-flash)
   "Return possibly non-existent Lisp tag name that point is within, else nil.
-Return nil when point is on the first line of a non-alias Lisp definition.
+When optional NO-FLASH, do not flash.  Return nil when point is
+on the first line of a non-alias Lisp definition.
 
 Resolve Hyperbole implicit button type and action type references."
   (smart-lisp-htype-tag
@@ -788,7 +798,8 @@ Resolve Hyperbole implicit button type and action type references."
 
 (defun smart-lisp-at-non-htype-tag-p (&optional no-flash)
   "Return possibly non-existent Lisp tag name that point is within, else nil.
-Return nil when point is on the first line of a non-alias Lisp definition."
+When optional NO-FLASH, do not flash.  Return nil when point is
+on the first line of a non-alias Lisp definition."
   (unless (smart-lisp-at-definition-p)
     (save-excursion
       (skip-chars-backward smart-lisp-identifier-chars)
@@ -898,7 +909,7 @@ If key is pressed:
  (4) on a global variable or function identifier, its definition is shown.
 
  (2) and (3) require that an OO-Browser Environment has been loaded with
-     the {M-x br-env-load RET} command."
+     the {\\`M-x' br-env-load RET} command."
 
   (interactive)
   (objc-to-definition t))
@@ -909,7 +920,8 @@ If key is pressed:
   "Sorted list of Objective-C keywords, all in lowercase.")
 
 (defun smart-objc-at-tag-p (&optional no-flash)
-  "Return Objective-C tag name that point is within, else nil."
+  "Return Objective-C tag name that point is within, else nil.
+When optional NO-FLASH, do not flash."
   (let* ((identifier-chars "_a-zA-Z0-9")
 	 (identifier
 	  (concat "\\([-+][ \t]*\\)?\\([_a-zA-Z][" identifier-chars "]*\\)")))
@@ -981,6 +993,8 @@ in the current directory or any of its ancestor directories."
 
 ;;;###autoload
 (defun smart-python-tag (&optional identifier next)
+  "Jumps to the definition of optional Python IDENTIFIER or the one at point.
+Optional second arg NEXT means jump to next matching Python tag."
   (let ((tag (or identifier (smart-python-at-tag-p t))))
     (message "Looking for `%s'..." tag)
     (condition-case ()
@@ -1016,7 +1030,8 @@ If key is pressed:
 
 ;;;###autoload
 (defun smart-python-at-tag-p (&optional no-flash)
-  "Return Python tag name that point is within, else nil."
+  "Return Python tag name that point is within, else nil.
+When optional NO-FLASH, do not flash."
   (let* ((identifier-chars "a-zA-Z0-9_")
 	 (identifier-fragment (concat "[a-zA-Z_][" identifier-chars "]*"))
 	 (identifier (concat identifier-fragment "\\(\\."

--- a/hpath.el
+++ b/hpath.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Nov-91 at 00:44:23
-;; Last-Mod:     20-Jan-24 at 15:39:28 by Mats Lidell
+;; Last-Mod:     20-Jan-24 at 20:17:17 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -445,10 +445,10 @@ format documentation."
 		  (error "Invalid file"))))))
 
     '("\\.rdb\\'" . rdb:initialize)))
-  "*Alist of (FILENAME-REGEXP . EDIT-FUNCTION) elements for calling special
-functions to display particular file types within Emacs.  See
-also the function (hpath:get-external-display-alist) for external
-display program settings."
+  "*Alist for calling special functions to display file types in Emacs.
+The alist consists of (FILENAME-REGEXP . EDIT-FUNCTION) elements.
+See also the function (hpath:get-external-display-alist) for
+external display program settings."
   :type '(alist :key-type regexp :value-type sexp)
   :group 'hyperbole-commands)
 
@@ -707,8 +707,9 @@ Contains a %s for replacement of a specific section name.")
 ;;; ************************************************************************
 
 (defun hpath:abbreviate-file-name (path)
-  "Same as `abbreviate-file-name' but disables tramp-mode.
-This prevents improper processing of hargs with colons in them,
+  "Return a version of PATH shortened using `directory-abbrev-alist'.
+Same as `abbreviate-file-name' but disables `tramp-mode'.  This
+prevents improper processing of hargs with colons in them,
 e.g. `actypes::link-to-file'."
   (let (tramp-mode)
     (abbreviate-file-name path)))
@@ -792,7 +793,7 @@ match to empty string if present."
 
 (defun hpath:remote-at-p ()
   "Return a remote pathname that point is within or nil.
-See the `(emacs)Remote Files' info documentation for pathname format details.
+See the `(Emacs)Remote Files' info documentation for pathname format details.
 Always returns nil if (hpath:remote-available-p) returns nil."
   (let ((remote-package (hpath:remote-available-p))
 	(user (hpath:remote-default-user))
@@ -1641,7 +1642,7 @@ Move point to beginning of buffer if HASH is non-nil and ANCHOR is null."
 	(narrow-to-region omin omax)))))
 
 (defun hpath:find-executable (executable-list)
-  "Return first executable string from EXECUTABLE-LIST found in `exec-path'.
+  "Return first executable string from EXECUTABLE-LIST in variable `exec-path'.
 Return nil if none are found."
   (catch 'found
     (mapc
@@ -1713,7 +1714,7 @@ programs, such as a pdf reader.  The cdr of each element may be:
   a list of executable names \(the first valid one is used);
   or a function of one filename argument.
 See also `hpath:internal-display-alist' for internal,
-`window-system' independent display settings."
+window-system independent display settings."
   (cond ((memq window-system '(mac dps ns))
 	 hpath:external-display-alist-macos)
 	(hyperb:microsoft-os-p
@@ -1724,9 +1725,10 @@ See also `hpath:internal-display-alist' for internal,
 
 (defun hpath:is-p (path &optional type non-exist)
   "Return normalized PATH if PATH is a Posix or MSWindows path, else nil.
-If optional TYPE is the symbol \\='file or \\='directory, then only that path type
-is accepted as a match.  The existence of the path is checked only for
-locally reachable paths (Info paths are not checked).
+If optional TYPE is the symbol \\='file or \\='directory, then
+only that path type is accepted as a match.  The existence of the
+path is checked only for locally reachable paths (Info paths are
+not checked).
 
 Single spaces are permitted in the middle of existing pathnames, but not at
 the start or end.  With optional NON-EXIST equal to t, nonexistent local
@@ -2160,7 +2162,7 @@ Default-directory should be equal to the current Hyperbole button
 source directory when called, so that PATH is expanded relative
 to it."
   (unless (stringp path)
-    (error "(hpath:validate): \"%s\" is not a pathname." path))
+    (error "(hpath:validate): \"%s\" is not a pathname" path))
   (setq path (hpath:mswindows-to-posix path))
   (cond ((or (string-match "[()]" path) (hpath:remote-p path))
 	 ;; info or remote path, so don't validate
@@ -2460,9 +2462,12 @@ function (hpath:get-external-display-alist) and the variable
 
 (defun hpath:match (filename regexp-alist)
   "If FILENAME matches the car of any element in REGEXP-ALIST, return its cdr.
-REGEXP-ALIST elements must be of the form (<filename-regexp>
-. <command-to-display-file>).  <command-to-display-file> may be a string
-representing an external `window-system' command to run or it may be a Lisp
+REGEXP-ALIST elements must be of the form
+
+    (<filename-regexp> . <command-to-display-file>).
+
+<command-to-display-file> may be a string representing an
+external window-system command to run or it may be a Lisp
 function to call with FILENAME as its single argument."
   (let ((cmd)
 	elt)

--- a/hrmail.el
+++ b/hrmail.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     9-May-91 at 04:22:02
-;; Last-Mod:      3-Oct-23 at 23:29:21 by Mats Lidell
+;; Last-Mod:     18-Jan-24 at 19:53:39 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -96,7 +96,9 @@ This includes Hyperbole button data."
 	(end (rmail-msgend rmail-current-message)))
     (narrow-to-region beg end)))
 
-(defun Rmail-msg-next ()        (rmail-next-undeleted-message 1))
+(defun Rmail-msg-next ()
+  "Go to next message."
+  (rmail-next-undeleted-message 1))
 
 (defun Rmail-msg-num ()
   "Return number of Rmail message that point is within."
@@ -111,7 +113,9 @@ This includes Hyperbole button data."
 	 (setq count (1+ count)))))
     count))
 
-(defun Rmail-msg-prev ()        (rmail-previous-undeleted-message 1))
+(defun Rmail-msg-prev ()
+  "Go to previous message."
+  (rmail-previous-undeleted-message 1))
 
 (defun Rmail-msg-to-p (mail-msg-id mail-file)
   "Set current buffer to start of msg with MAIL-MSG-ID in MAIL-FILE.
@@ -331,6 +335,7 @@ see the documentation of `rmail-resend'."
 ;;
 
 (defun hrmail--show-msg-and-buttons (&rest _)
+  "Show message and buttons."
   (if (fboundp 'hproperty:but-create)
       (progn (widen) (hproperty:but-create)
 	     (rmail-show-message))))
@@ -343,6 +348,7 @@ see the documentation of `rmail-resend'."
 ;; highlight Hyperbole buttons when possible.
 ;;
 (defun hrmail--highlight-buttons (&rest _)
+  "Highlight buttons."
   (if (fboundp 'hproperty:but-create) (hproperty:but-create)))
 (if (boundp 'rmail-summary-create-post-hook) ;FIXME: Doesn't exist.  XEmacs?
     (add-hook 'rmail-summary-create-post-hook 'hrmail--highlight-buttons)

--- a/hsettings.el
+++ b/hsettings.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Apr-91 at 00:48:49
-;; Last-Mod:     20-Jan-24 at 15:39:36 by Mats Lidell
+;; Last-Mod:     20-Jan-24 at 20:18:53 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -101,8 +101,7 @@ The Smart Menu system must have already been loaded.  If a Smart
 Menu is already displayed, perform another Action or Assist Key function.")
 
 (defcustom hmouse-middle-flag (and (boundp 'infodock-version) infodock-version t)
-  "*Under InfoDock or when t, additionally bind the middle mouse button as an
-Action Key."
+  "*Non-nil means additionally bind the middle mouse button as an Action Key."
   :type 'boolean
   :group 'hyperbole-keys)
 
@@ -146,9 +145,7 @@ ignores current line and always scrolls up or down a windowful."
   (hyperbole-minibuffer-menu))
 
 (defcustom hyperbole-default-web-search-term-max-lines 2
-  "Provide a default search term using the selected text if the
-active region contains less than or equal to this number of
-lines"
+  "Provide a default search term from max this number of lines from selected text."
   :type 'integer
   :group 'hyperbole-commands)
 
@@ -175,6 +172,7 @@ use those instead of reading from the keyboard."
 (defun hyperbole-web-search (&optional service-name search-term return-search-expr-flag)
   "Search web SERVICE-NAME for SEARCH-TERM.
 Both arguments are optional and are prompted for when not given or when null.
+With optional RETURN-SEARCH-EXPR-FLAG return the search expression.
 Uses `hyperbole-web-search-alist' to match each service to its search url.
 Uses `hyperbole-web-search-browser-function' and the `browse-url'
 package to display search results."
@@ -285,7 +283,8 @@ then runs the search."
 ;;; ************************************************************************
 
 ;; No-op unless set by one of the conditionals below.
-(defun hui:but-flash ())
+(defun hui:but-flash ()
+  "Button flash No-op.")
 
 (cond ((not noninteractive)
        (require 'hui-em-but)

--- a/hsys-org.el
+++ b/hsys-org.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Jul-16 at 14:54:14
-;; Last-Mod:     20-Jan-24 at 15:40:12 by Mats Lidell
+;; Last-Mod:     20-Jan-24 at 20:19:11 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -307,7 +307,7 @@ Return t if Org is reloaded, else nil."
 
 ;;;###autoload
 (defun hsys-org-consult-grep ()
-  "Prompt for search terms and run consult grep over `org-directory'
+  "Prompt for search terms and run consult grep over `org-directory'.
 Actual grep function used is given by the variable,
 `hsys-org-consult-grep-func'."
   (interactive)

--- a/hsys-www.el
+++ b/hsys-www.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Apr-94 at 17:17:39 by Bob Weiner
-;; Last-Mod:      3-Oct-23 at 17:46:21 by Mats Lidell
+;; Last-Mod:     18-Jan-24 at 23:59:15 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -148,7 +148,10 @@ Return http urls unchanged.  Normalize remote paths."
 
 ;;;###autoload
 (defun www-url-find-file-noselect (path &rest args)
-  "Find PATH without selecting its buffer.  Handle http urls."
+  "Find PATH without selecting its buffer.
+Handle http urls.  ARGS is the optional arguments to
+`find-file-noselect'.  If PATH is a list ARGS is set to remainder
+after that the first element is extracted as the PATH."
   (if (listp path)
       (setq args (cdr path)
 	    path (car path)))

--- a/hsys-xref.el
+++ b/hsys-xref.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    24-Aug-91
-;; Last-Mod:     20-Jan-24 at 15:40:22 by Mats Lidell
+;; Last-Mod:     20-Jan-24 at 20:19:45 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -60,8 +60,8 @@
 ;;; Private functions
 ;;; ************************************************************************
 
-;; Fix next xref function to handle when called at beginning of buffer
 (defun xref--item-at-point ()
+  "Fix next xref function to handle when called at beginning of buffer."
   (get-text-property
    (max (point-min) (if (eolp) (1- (point)) (point)))
    'xref-item))

--- a/hsys-youtube.el
+++ b/hsys-youtube.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    10-Jul-22 at 18:10:56
-;; Last-Mod:     14-May-23 at 11:27:53 by Bob Weiner
+;; Last-Mod:     19-Jan-24 at 12:11:07 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -67,7 +67,7 @@ The first %s is where the video id string is inserted; the second %s is
 where the start time string in seconds is inserted; the third %s is
 where the end time string in seconds is inserted.  The time strings
 must be in colon-separated hours:minutes:seconds format, e.g. 1:2:44
-(1 hour, two minutes, 45 seconds), where the hours and minutes are
+\(1 hour, two minutes, 45 seconds), where the hours and minutes are
 optional.")
 
 ;;; ************************************************************************
@@ -205,7 +205,7 @@ format is invalid, return it unchanged."
 	   (string-match-p ":" start-time-string))
       (let* ((time-parts (split-string start-time-string "[:hmsHMS]" t))
              (num-of-parts (length time-parts))
-	     (part1 (nth 0 time-parts)) 
+	     (part1 (nth 0 time-parts))
 	     (part2 (nth 1 time-parts))
 	     (part3 (nth 2 time-parts)))
         (cond ((zerop num-of-parts)
@@ -229,7 +229,7 @@ START-TIME-STRING format is invalid, return it unchanged."
 	   (string-match-p "[:hmsHMS]" start-time-string))
       (let* ((time-parts (split-string start-time-string "[:hmsHMS]" t))
              (num-of-parts (length time-parts))
-	     (part1 (nth 0 time-parts)) 
+	     (part1 (nth 0 time-parts))
 	     (part2 (nth 1 time-parts))
 	     (part3 (nth 2 time-parts)))
         (cond ((zerop num-of-parts)
@@ -246,3 +246,5 @@ START-TIME-STRING format is invalid, return it unchanged."
     start-time-string))
 
 (provide 'hsys-youtube)
+;;; hsys-youtube.el ends here
+

--- a/htz.el
+++ b/htz.el
@@ -3,7 +3,7 @@
 ;; Author:       Masanobu Umeda             / Bob Weiner
 ;;
 ;; Orig-Date:    14-Oct-91 at 07:22:08
-;; Last-Mod:      2-Dec-23 at 23:27:40 by Bob Weiner
+;; Last-Mod:     19-Jan-24 at 12:13:19 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -363,7 +363,7 @@ Optional argument TIMEZONE specifies a time zone."
       (zerop (% year 400))))
 
 (defun htz:time-fix (year month day hour minute second)
-  "Fix date and time."
+  "Fix date and time given by YEAR, MONTH, DAY, HOUR, MINUTE and SECOND."
   (cond ((<= 24 hour)			; 24 -> 00
 	 (setq hour (- hour 24))
 	 (setq day  (1+ day))

--- a/hui-dired-sidebar.el
+++ b/hui-dired-sidebar.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    25-Jul-20
-;; Last-Mod:      3-Oct-23 at 17:42:21 by Mats Lidell
+;; Last-Mod:     19-Jan-24 at 12:13:30 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -60,7 +60,7 @@ If key is pressed:
      `assist-key-eol-function', typically to scroll down proportionally,
      if an Asisst Key press;
  (3) on the first line of the buffer (other than the end of line),
-     dired is run on the current directory of this dired-sidebar;
+     Dired is run on the current directory of this dired-sidebar;
  (4) at the end of the first or last line of the buffer,
      this dired-sidebar invocation is hidden."
 

--- a/hui-em-but.el
+++ b/hui-em-but.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Aug-92
-;; Last-Mod:     29-Oct-23 at 10:13:42 by Bob Weiner
+;; Last-Mod:     19-Jan-24 at 12:39:25 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -42,7 +42,7 @@
 ;;; ************************************************************************
 
 (defcustom hproperty:but-highlight-flag t
-  "*Non-nil applies `hproperty:but-face' highlight to labeled Hyperbole buttons."
+  "*Non-nil means `hproperty:but-face' highlight to labeled Hyperbole buttons."
   :type 'boolean
   :group 'hyperbole-buttons)
 
@@ -212,6 +212,7 @@ moves over it."
 	      regexp-match 'include-delims)))
 
 (defun hproperty:but-create-on-yank (_prop-value start end)
+  "Used in `yank-handled-properties' called with START and END pos of the text."
   (save-restriction
     (narrow-to-region start end)
     (hproperty:but-create-all)))
@@ -223,6 +224,7 @@ moves over it."
 ;;; ************************************************************************
 
 (defun hproperty:but-get (&optional pos)
+  "Get button property at optional POS or point."
   (car (delq nil
 	     (mapcar (lambda (props)
 		       (if (memq (overlay-get props 'face)
@@ -284,6 +286,7 @@ hproperty:color-ptr."
 		  (overlays-at (or pos (point))))))
 
 (defun hproperty:set-but-face (pos face)
+  "Set button face at POS to FACE."
   (let ((but (hproperty:but-get pos)))
     (when but (overlay-put but 'face face))))
 
@@ -295,7 +298,7 @@ hproperty:color-ptr."
 	 (end   (hattr:get 'hbut:current 'lbl-end))
 	 (ibut)
 	 (prev)
-	 (categ-face)) 
+	 (categ-face))
     (if (eq categ 'explicit)
 	(setq categ-face hproperty:but-face)
       (setq categ-face hproperty:ibut-face

--- a/hui-em-but.el
+++ b/hui-em-but.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Aug-92
-;; Last-Mod:     19-Jan-24 at 12:39:25 by Mats Lidell
+;; Last-Mod:     20-Jan-24 at 20:09:40 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -42,7 +42,7 @@
 ;;; ************************************************************************
 
 (defcustom hproperty:but-highlight-flag t
-  "*Non-nil means `hproperty:but-face' highlight to labeled Hyperbole buttons."
+  "*Non-nil means highlight named Hyperbole buttons with `hproperty:but-face'."
   :type 'boolean
   :group 'hyperbole-buttons)
 

--- a/hui-jmenu.el
+++ b/hui-jmenu.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     9-Mar-94 at 23:37:28
-;; Last-Mod:     24-Dec-23 at 00:06:07 by Bob Weiner
+;; Last-Mod:     19-Jan-24 at 14:09:51 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -60,6 +60,7 @@
 
 ;;;###autoload
 (defun hui-menu-of-buffers ()
+  "Buffer menu."
   (let* ((buf-name)
 	 (buffer-and-mode-name-list
 	  ;; Remove internal buffers whose names begin with a space
@@ -160,6 +161,7 @@ Jump to chosen buffer."
 ;;; ************************************************************************
 
 (defun hui-menu-buffer-mode-name (buffer)
+  "Return the mode name for BUFFER."
   (let ((mname (buffer-local-value 'mode-name buffer)))
     (if mname
 	;; Next line needed to ensure mode name is always formatted as
@@ -173,6 +175,7 @@ Jump to chosen buffer."
   (frame-parameter frame 'name))
 
 (defun hui-menu-modeline (_ignore)
+  "Return a modeline menu."
   (list
    ["Control-Frames"  hycontrol-enable-frames-mode t]
    ["Control-Windows" hycontrol-enable-windows-mode t]
@@ -204,10 +207,12 @@ Jump to chosen buffer."
    ;;  ["Raise-Frame"               raise-frame                    t])
 
 (defun hui-menu-to-frame (frame)
+  "Raise FRAME."
   (make-frame-visible frame)
   (raise-frame (select-frame frame)))
   
 (defun hui-menu-to-window (window)
+  "Go to WINDOW."
   (if (window-live-p window)
       (let ((frame (window-frame window)))
 	(make-frame-visible frame)
@@ -240,6 +245,7 @@ Reverse sort elements by `mode-name' and then by `buffer-name'."
     (read (current-buffer))))
 
 (defun hui-menu-of-frames ()
+  "Return a menu of frames."
   (let ((frames (copy-sequence (frame-list))))
     (hui-menu-cutoff-list frames)
     (cons "Frames"
@@ -253,6 +259,7 @@ Reverse sort elements by `mode-name' and then by `buffer-name'."
 					(hui-menu-frame-name fm2))))))))
 
 (defun hui-menu-of-windows ()
+  "Return a menu of windows."
   (let ((windows (hui-menu-window-list-all-frames 'nomini)))
     (hui-menu-cutoff-list windows)
     (cons "Windows"
@@ -268,7 +275,7 @@ Reverse sort elements by `mode-name' and then by `buffer-name'."
 
 (defun hui-menu-program-path (exe &optional insert-flag)
   "Return the full path name of the executable named by EXE.
-This command searches the directories in `exec-path'.
+This command searches the directories in variable `exec-path'.
 With optional prefix arg INSERT-FLAG, inserts the pathname at point."
   (interactive "sGet pathname of executable: \nP")
   (catch 'answer
@@ -334,6 +341,7 @@ frame.  The current buffer is buried in the old frame's buffer list."
        t))
 
 (defun hui-menu-edit-server-finish ()
+  "If current buffer is an edit server buffer, signal edit is done and delete it."
   (if (hui-menu-server-buffer-p)
       ;; If this buffer is the result of an edit request from an external
       ;; application, signal that edit is done and delete frame.

--- a/hui-menu.el
+++ b/hui-menu.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    28-Oct-94 at 10:59:44
-;; Last-Mod:      3-Oct-23 at 23:29:46 by Mats Lidell
+;; Last-Mod:     19-Jan-24 at 14:19:19 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -45,6 +45,8 @@ the current buffer.")
 ;;; ************************************************************************
 
 (defmacro hui-menu-browser (title browser-option)
+  "Browser menu with a TITLE.
+BROWSER-OPTION marks current active menu option as selected."
   `(list
     (list ,title
 	  ["Chrome (Google)"
@@ -88,6 +90,7 @@ the current buffer.")
 
 ;; List explicit buttons in the current buffer for menu activation.
 (defun hui-menu-explicit-buttons (rest-of-menu)
+  "Explicit button menu to go before REST-OF-MENU."
   (delq nil
 	(append
 	 '(["Manual"   (id-info "(hyperbole)Explicit Buttons") t]
@@ -125,6 +128,7 @@ Return t if cutoff, else nil."
 
 ;; List existing global buttons for menu activation.
 (defun hui-menu-global-buttons (rest-of-menu)
+  "Global button menu to go before REST-OF-MENU."
   (delq nil
 	(append
 	 '(["Manual" (id-info "(hyperbole)Global Buttons") t]
@@ -148,6 +152,7 @@ Return t if cutoff, else nil."
 		      (format "(%s)" (key-description (where-is-internal command nil t))))))
 
 (defun hui-menu-key-bindings (rest-of-menu)
+  "Key binding menu to go before REST-OF-MENU."
   (nconc
    (list
     (vector (hui-menu-key-binding-item "Action-Key          \t\t\t" 'hkey-either)                        '(hui:bind-key #'hkey-either) t)                    ;; {M-RET}
@@ -164,6 +169,7 @@ Return t if cutoff, else nil."
 
 ;; Dynamically compute submenus for Screen menu
 (defun hui-menu-screen (_ignored)
+  "Screen menu."
   (list
    ["Manual" (id-info "(hyperbole)HyControl") t]
    "----"
@@ -175,7 +181,7 @@ Return t if cutoff, else nil."
    (hui-menu-of-windows)))
 
 (defun hui-menu-web-search ()
-  ;; Pulldown menu
+  "Web search pulldown menu."
   (let* (service
 	 action)
     (mapcar (lambda (service-and-action)
@@ -322,7 +328,8 @@ Return t if cutoff, else nil."
   (force-mode-line-update))
 
 (defun hyperbole-popup-menu (&optional rebuild-flag)
-  "Popup the Hyperbole menubar menu."
+  "Popup the Hyperbole menubar menu.
+With optional REBUILD-FLAG rebuild the menu."
   (interactive "P")
   (popup-menu (infodock-hyperbole-menu rebuild-flag)))
 

--- a/hui-mini.el
+++ b/hui-mini.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Oct-91 at 20:13:17
-;; Last-Mod:     21-Nov-23 at 02:42:53 by Bob Weiner
+;; Last-Mod:     19-Jan-24 at 17:48:25 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -111,7 +111,7 @@ documentation, not the full text."
 ;;;###autoload
 (defun hyperbole-demo (&optional arg)
   "Display the Hyperbole FAST-DEMO.
-With a prefix arg, display the older, more extensive DEMO file."
+With a prefix ARG, display the older, more extensive DEMO file."
   (interactive "P")
   (hypb:display-file-with-logo (if arg "DEMO" "FAST-DEMO")))
 
@@ -375,7 +375,7 @@ If on the menu name prefix or the last item, move to the first item."
 
 (defun hui:menu-item-key (item)
   "Return ordered list of keys that activate Hypb minibuffer MENU-ALIST items.
-For each item, the key is either the first capital letter in item
+For each item, the key is either the first capital letter in ITEM
 or if there are none, then its first character."
   ;; Return either the first capital letter in item or if
   ;; none, then its first character.
@@ -567,7 +567,7 @@ The menu is a menu of commands from MENU-ALIST."
 	 (max-item-len
 	  (when menu-strings (+ 1 (apply 'max (mapcar #'length menu-strings))))))
     (unless menu-strings
-      (error "(hui:menu-multi-line): Invalid menu specified, '%s'." menu-alist))
+      (error "(hui:menu-multi-line): Invalid menu specified, '%s'" menu-alist))
     (with-temp-buffer
       (let (indent-tabs-mode)
 	(mapc
@@ -615,7 +615,7 @@ The menu is a menu of commands from MENU-ALIST."
 
 If the key that invokes this command in `hyperbole-minor-mode' is also
 bound in the current major mode map, then interactively invoke that
-command instead.  Typically prevents clashes over {C-c /}."
+command instead.  Typically prevents clashes over {\\`C-c' /}."
   (interactive)
   (let* ((key (hypb:cmd-key-vector #'hui-search-web hyperbole-mode-map))
 	 (major-mode-binding (lookup-key (current-local-map) key))

--- a/hui-mini.el
+++ b/hui-mini.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Oct-91 at 20:13:17
-;; Last-Mod:     19-Jan-24 at 17:48:25 by Mats Lidell
+;; Last-Mod:     20-Jan-24 at 20:01:18 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -111,7 +111,7 @@ documentation, not the full text."
 ;;;###autoload
 (defun hyperbole-demo (&optional arg)
   "Display the Hyperbole FAST-DEMO.
-With a prefix ARG, display the older, more extensive DEMO file."
+With a prefix ARG, display the older, more extensive \"DEMO\" file."
   (interactive "P")
   (hypb:display-file-with-logo (if arg "DEMO" "FAST-DEMO")))
 

--- a/hui-mouse.el
+++ b/hui-mouse.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-89
-;; Last-Mod:     20-Jan-24 at 15:41:03 by Mats Lidell
+;; Last-Mod:     20-Jan-24 at 20:19:54 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -902,7 +902,7 @@ Use left mouse key, RET or TAB key to select a completion and exit."
 (defun smart-dired-pathname-up-to-point (&optional no-default)
   "Return the part of the pathname up through point, else current directory.
 Use for direct selection of an ancestor directory of the
-dired directory at point, if any.
+Dired directory at point, if any.
 
 With optional NO-DEFAULT, do not default to current directory
 path; instead return nil."
@@ -936,15 +936,15 @@ If key is pressed:
      for display in another window, then this entry is displayed in the current
      window (DisplayHere minor mode is shown in the mode-line; use {g}
      to disable it)
- (2) on a dired header line (other than the end of line):
+ (2) on a Dired header line (other than the end of line):
      (a) within the leading whitespace, then if any deletes are to be
          performed, they are executed after user verification; otherwise,
          nothing is done;
-     (b) otherwise, dired is run in another window on the ancestor directory
+     (b) otherwise, Dired is run in another window on the ancestor directory
          of the current directory path up through the location of point;
          if point is on the first character, then the / root directory
          is used.
- (3) on or after the last line in the buffer, this dired invocation is quit."
+ (3) on or after the last line in the buffer, this Dired invocation is quit."
 
   (interactive)
   (cond ((save-excursion
@@ -1542,7 +1542,7 @@ NO-RECURSE-FLAG non-nil prevents infinite recursions."
 ;;; ************************************************************************
 
 (defun smart-magit-display-file (return-command)
-  "Execute `magit' cmd bound to return, possibly using `hpath:display-buffer'."
+  "Execute `magit' RETURN-COMMAND possibly using `hpath:display-buffer'."
   (cond ((eq return-command #'magit-diff-visit-file)
 	 ;; Use Hyperbole display variable to determine where
 	 ;; to display the file of the diff.
@@ -1803,7 +1803,7 @@ When the Action Key is pressed:
 
   8. With point on any #+BEGIN_SRC, #+END_SRC, #+RESULTS, #+begin_example
      or #+end_example header, execute the code block via the Org mode
-     standard binding of {C-c C-c}, (org-ctrl-c-ctrl-c).
+     standard binding of {\\`C-c' \\`C-c'}, (org-ctrl-c-ctrl-c).
   
   9. When point is on an Org mode heading, cycle the view of the subtree
      at point.
@@ -1934,7 +1934,7 @@ handled by the separate implicit button type, `org-link-outside-org-mode'."
        buffer-file-name
        (derived-mode-p 'org-mode)
        (not (org-at-heading-p))
-       (member buffer-file-name 
+       (member buffer-file-name
 	       (hpath:expand-list hsys-org-cycle-bob-file-list))))
 
 ;;; ************************************************************************

--- a/hui-select.el
+++ b/hui-select.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Oct-96 at 02:25:27
-;; Last-Mod:     26-Dec-23 at 21:57:18 by Bob Weiner
+;; Last-Mod:     19-Jan-24 at 18:17:28 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -53,7 +53,7 @@
 ;;   for how this is done).
 ;;
 ;;   The command, `hui-select-thing', may be bound to a key to provide the same
-;;   syntax-driven region selection functionality. {C-c RETURN} is a
+;;   syntax-driven region selection functionality.  {C-c RETURN} is a
 ;;   reasonable site-wide choice since this key is seldom used and it
 ;;   mnemonically indicates marking something; Hyperbole typically
 ;;   binds this key for you.  {C-c s} may be preferred as a personal binding.
@@ -358,7 +358,7 @@ returned is the function to call to select that syntactic unit."
 If the key that invokes this command in `hyperbole-minor-mode' is
 also bound in the current major mode map, then interactively
 invoke that command instead.  Typically prevents clashes over
-{C-c .}."
+{\\`C-c' .}."
   (interactive)
   (if (memq major-mode hui-select-markup-modes)
       (hui-select-goto-matching-tag)
@@ -480,7 +480,7 @@ interactively, the type of selection is displayed in the minibuffer.
 If the key that invokes this command in `hyperbole-minor-mode' is
 also bound in the current major mode map, then interactively
 invoke that command instead.  Typically prevents clashes over
-{C-c RET}, {C-c C-m}."
+{\\`C-c' RET}, {\\`C-c´ \\`C-m'}."
   (interactive
    (cond ((and (fboundp 'use-region-p) (use-region-p))
 	  nil)
@@ -730,9 +730,10 @@ The character at POS is selected if no other thing is matched."
 ;;;###autoload
 (defun hui-select-double-click-hook (event click-count)
   "Select region based on the character syntax where the mouse is double-clicked.
-If the double-click occurs at the same point as the last double-click, select
-the next larger syntactic structure.  If `hui-select-display-type' is non-nil,
-the type of selection is displayed in the minibuffer."
+If the double-click EVENT occurs at the same point as the last
+double-click, select the next larger syntactic structure.  If
+`hui-select-display-type' is non-nil, the type of selection is
+displayed in the minibuffer."
   (cond ((/= click-count 2)
 	 ;; Return nil so any other hooks are performed.
 	 nil)
@@ -807,6 +808,7 @@ Return t if selected, else nil."
 	  (goto-char (match-end 0)))))))
 
 (defun hui-select-at-delimited-sexp-p ()
+  "Select a delimited sexp."
   (unless (eolp)
     (let ((syn-before (if (char-before) (char-syntax (char-before)) 0))
 	  (syn-after  (if (char-after)  (char-syntax (char-after)) 0)))
@@ -921,7 +923,7 @@ partially overlaps OLD-REGION, or if OLD-REGION is uninitialized."
 		      (max (cdr old-region) (car old-region))))))))
 
 (defun hui-select-reset ()
-  ;; Reset syntactic selection.
+  "Reset syntactic selection."
   (setq hui-select-prior-point (point)
 	hui-select-prior-buffer (current-buffer)
 	hui-select-previous 'char)
@@ -1359,7 +1361,7 @@ Delimiters may be single, double or open and close quotes."
 			     (progn (forward-sentence) (point))))))
 
 (defun hui-select-whitespace (pos)
-  "Return (start . end) of all whitespace at POS,
+  "Return (start . end) of all whitespace at POS.
 Return all whitespace, unless there is only one character of
 whitespace or this is leading whitespace on the line."
   (setq hui-select-previous 'whitespace)

--- a/hui-treemacs.el
+++ b/hui-treemacs.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Nov-17
-;; Last-Mod:     20-Jan-24 at 15:41:11 by Mats Lidell
+;; Last-Mod:     20-Jan-24 at 20:20:00 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -86,7 +86,7 @@ If key is pressed:
      `assist-key-eol-function', typically to scroll down proportionally,
      if an Asisst Key press;
  (4) on the first line of the buffer (other than the end of line),
-     dired is run on the current directory of this Treemacs;
+     Dired is run on the current directory of this Treemacs;
  (5) at the end of the first or last line of the buffer,
      this Treemacs invocation is quit."
 

--- a/hui-window.el
+++ b/hui-window.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Sep-92
-;; Last-Mod:     20-Jan-24 at 15:41:21 by Mats Lidell
+;; Last-Mod:     20-Jan-24 at 20:20:09 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -275,7 +275,7 @@ and release to register a diagonal drag.")
 
 (defun hmouse-at-item-p (start-window)
   "Return t if point is on an item draggable by Hyperbole, otherwise nil.
-Draggable items include Hyperbole buttons, dired items, buffer/ibuffer
+Draggable items include Hyperbole buttons, Dired items, buffer/ibuffer
 menu items."
   (let* ((buf (when (window-live-p start-window)
 		(window-buffer start-window)))
@@ -340,22 +340,22 @@ part of InfoDock and not a part of Hyperbole)."
 	     t)))))
 
 (defun hmouse-dired-readin-hook ()
-  "Remove local `hpath:display-where' setting whenever re-read a dired directory.
+  "Remove local `hpath:display-where' setting whenever re-read a Dired directory.
 See `hmouse-dired-item-dragged' for use."
   (hmouse-dired-display-here-mode 0))
 
 (define-minor-mode hmouse-dired-display-here-mode
-  "Display item here on key press after dired item drag.
-Once a dired buffer item has been dragged, make next Action Key
-press on an item display it in the same dired window.
+  "Display item here on key press after Dired item drag.
+Once a Dired buffer item has been dragged, make next Action Key
+press on an item display it in the same Dired window.
 
-By default an Action Key press on a dired item displays it in another
+By default an Action Key press on a Dired item displays it in another
 window.   But once a Dired item is dragged to another window, the next
-Action Key press should display it in the dired window so that the
+Action Key press should display it in the Dired window so that the
 behavior matches that of Buffer Menu and allows for setting what is
-displayed in all windows on screen, including the dired window.
+displayed in all windows on screen, including the Dired window.
 
-If the directory is re-read into the dired buffer with {g}, then Action
+If the directory is re-read into the Dired buffer with {g}, then Action
 Key behavior reverts to as though no items have been dragged."
   :lighter " DisplayHere"
   (if hmouse-dired-display-here-mode
@@ -545,7 +545,7 @@ If free variable `assist-flag' is non-nil, uses Assist Key."
 
 (defun hmouse-drag-item-to-display (&optional new-window-flag)
   "Drag an item and release where it is to be displayed.
-Draggable items include Hyperbole buttons, dired items, buffer/ibuffer
+Draggable items include Hyperbole buttons, Dired items, buffer/ibuffer
 menu items.
 
 Depress on the item and release where the item is to be displayed.
@@ -688,7 +688,7 @@ If free variable `assist-flag' is non-nil, uses Assist Key."
 		    hmouse-side-sensitivity))))))
 
 (defun hmouse-read-only-toggle-key ()
-  "Return the first key binding that toggles read-only mode, or nil if none."
+  "Return the first key binding that toggle read-only mode, or nil if none."
   (key-description (where-is-internal #'read-only-mode nil t)))
 
 (defun hmouse-vertical-action-drag ()
@@ -808,6 +808,7 @@ buffer."
   (error "(hmouse-drag-region-active): Region is active; use a Smart Key press/click within a window, not a drag"))
 
 (defun hmouse-set-buffer-and-point (buffer point)
+  "Set BUFFER and POINT."
   (when buffer
     (set-buffer buffer)
     (when point (goto-char point))))
@@ -870,7 +871,7 @@ Return t if such a point is saved, else nil."
       (pulse-momentary-highlight-one-line (point) 'next-error))))
 
 (defun hmouse-pulse-region (start end)
-  "When `hmouse-pulse-flag' is non-nil, display can pulse, pulse the region."
+  "When `hmouse-pulse-flag' is non-nil pulse the region between START and END."
   (when (and hmouse-pulse-flag (featurep 'pulse) pulse-flag (pulse-available-p))
     (let ((pulse-iterations hmouse-pulse-iterations))
       (pulse-momentary-highlight-region start end 'next-error))))
@@ -955,7 +956,7 @@ If the Action Key is:
      the Info buffer is displayed, or if already displayed and the
      modeline clicked belongs to a window displaying Info, the Info
      buffer is hidden;
- (3) clicked on the buffer id of a window's modeline, dired is run
+ (3) clicked on the buffer id of a window's modeline, Dired is run
      on the current directory, replacing the window's buffer;
      successive clicks walk up the directory tree
  (4) clicked anywhere in the middle of a window's modeline,
@@ -1106,6 +1107,7 @@ of the Smart Key."
 	       (set-buffer obuf)))))))
 
 (defun hmouse-clone-window-to-frame (&optional _always-delete-flag)
+  "Clone window to frame."
   (let ((hycontrol-keep-window-flag t))
     (hmouse-move-window-to-frame)))
 

--- a/hui-window.el
+++ b/hui-window.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Sep-92
-;; Last-Mod:     20-Jan-24 at 20:20:09 by Mats Lidell
+;; Last-Mod:     20-Jan-24 at 20:22:03 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -688,7 +688,7 @@ If free variable `assist-flag' is non-nil, uses Assist Key."
 		    hmouse-side-sensitivity))))))
 
 (defun hmouse-read-only-toggle-key ()
-  "Return the first key binding that toggle read-only mode, or nil if none."
+  "Return the first toggle read-only mode key binding, or nil if none."
   (key-description (where-is-internal #'read-only-mode nil t)))
 
 (defun hmouse-vertical-action-drag ()
@@ -871,7 +871,7 @@ Return t if such a point is saved, else nil."
       (pulse-momentary-highlight-one-line (point) 'next-error))))
 
 (defun hmouse-pulse-region (start end)
-  "When `hmouse-pulse-flag' is non-nil pulse the region between START and END."
+  "When `hmouse-pulse-flag' is non-nil, pulse the region between START and END."
   (when (and hmouse-pulse-flag (featurep 'pulse) pulse-flag (pulse-available-p))
     (let ((pulse-iterations hmouse-pulse-iterations))
       (pulse-momentary-highlight-region start end 'next-error))))

--- a/hui.el
+++ b/hui.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 21:42:03
-;; Last-Mod:     20-Jan-24 at 15:41:32 by Mats Lidell
+;; Last-Mod:     20-Jan-24 at 20:20:21 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -295,7 +295,7 @@ Default is the current button."
 			(hargs:read-match "Activate explicit button: " lst nil t
 					  (ebut:label-p 'as-label) 'ebut))))
 	    (t
-	     (hypb:error "(ebut-act): No explicit buttons in buffer."))))))
+	     (hypb:error "(ebut-act): No explicit buttons in buffer"))))))
   (hui:hbut-operate #'hbut:act "Activate explicit button: " but))
 
 (defun hui:ebut-create (&optional start end)
@@ -761,7 +761,7 @@ The default is the current button."
   (hui:hbut-operate #'hbut:act "Activate Hyperbole button: " but))
 
 (defun hui:hbut-buf (&optional prompt)
-  "Prompt for and return a buffer in which to place a button."
+  "PROMPT for and return a buffer in which to place a button."
   (let ((buf-name))
     (while
 	(progn
@@ -941,7 +941,7 @@ Default is any implicit button at point."
 			(hargs:read-match "Activate named implicit button: " lst nil t
 					  (ibut:label-p 'as-label) 'ibut))))
 	    (t
-	     (hypb:error "(ibut-act): No named implicit buttons in buffer."))))))
+	     (hypb:error "(ibut-act): No named implicit buttons in buffer"))))))
   (hui:hbut-operate #'hbut:act "Activate named implicit button: " ibut))
 
 (defun hui:ibut-create (&optional start end)
@@ -1241,7 +1241,7 @@ from those instead.  See also documentation for
 `hui:link-possible-types'.
 
 With optional NAME-ARG-FLAG (interactively, the prefix argument set to
-anything other than a single C-u (list 4)), prompt for a name to precede
+anything other than a single \\`C-u' (list 4)), prompt for a name to precede
 the implicit button.
 
 An Action Mouse Key drag between windows (when not on an item)
@@ -1347,7 +1347,7 @@ runs this command."
 ;;; ************************************************************************
 
 (defun hui:action (actype &optional prompt)
-  "Prompt for and return an action to override action from ACTYPE."
+  "PROMPT for and return an action to override action from ACTYPE."
   (and actype
        (let* ((act) (act-str)
 	      (params (actype:params actype))
@@ -1468,6 +1468,8 @@ from the button that point is within."
       (hypb:error "(ebut-delete): You may not delete buttons from this buffer"))))
 
 (defun hui:ebut-message (but-edit-flag)
+  "Display message about the ebut execution.
+With BUT-EDIT-FLAG non-nil message about ebut being edited."
   (let ((actype (symbol-name (hattr:get 'hbut:current 'actype)))
 	(args (hattr:get 'hbut:current 'args)))
     (setq actype (actype:def-symbol actype))
@@ -1549,8 +1551,9 @@ With a prefix argument, also delete the button text between the delimiters."
 
 (defun hui:hbut-operate (operation operation-str &optional but)
   "Execute OPERATION func described by OPERATION-STR action on a Hyperbole button.
-Either the button at point is used or if none, then one is prompted
-for with completion of all labeled buttons within the current buffer."
+With optional BUT use that.  If none then either the button at
+point is used or if none, then one is prompted for with
+completion of all labeled buttons within the current buffer."
   (unless (or but (setq but (hbut:at-p)))
     (let (lst)
       (cond ((setq lst (nconc (ebut:alist) (ibut:alist)))
@@ -1560,7 +1563,7 @@ for with completion of all labeled buttons within the current buffer."
 						    (hbut:label-p 'as-label) 'hbut)))))
 	    (t (hypb:error "(hbut-operate): No labeled buttons in buffer")))))
   (cond ((and (called-interactively-p 'interactive) (null but))
-	 (hypb:error "(hbut-operate): No current button upon which to operate."))
+	 (hypb:error "(hbut-operate): No current button upon which to operate"))
 	((progn (unless but (setq but 'hbut:current))
 		(hbut:is-p but))
 	 ;; Temporarily move point to start of the button text for flashing and activation.
@@ -1715,6 +1718,8 @@ within."
       (hypb:error "(ibut-delete): You may not delete buttons from this buffer"))))
 
 (defun hui:ibut-message (but-edit-flag)
+  "Display message about the ibut execution.
+With BUT-EDIT-FLAG non-nil message about ibut being edited."
   (let ((actype (symbol-name (hattr:get 'hbut:current 'actype)))
 	(args (hattr:get 'hbut:current 'args)))
     (setq actype (actype:def-symbol actype))
@@ -1828,7 +1833,7 @@ File Name                link-to-file
 Koutline Cell            link-to-kcell
 Outline Heading          link-to-string-match
 Buffer attached to File  link-to-file
-EOL in Dired Buffer      link-to-directory (dired dir)
+EOL in Dired Buffer      link-to-directory (Dired dir)
 Buffer without File      link-to-buffer-tmp"
 ;; Elisp Buffer at Start
 ;; or End of Sexpression    eval-elisp

--- a/hversion.el
+++ b/hversion.el
@@ -4,7 +4,7 @@
 ;; Maintainer:   Bob Weiner, Mats Lidell
 ;;
 ;; Orig-Date:     1-Jan-94
-;; Last-Mod:      3-Dec-23 at 09:43:50 by Bob Weiner
+;; Last-Mod:     19-Jan-24 at 23:13:33 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -58,9 +58,10 @@ your specific mouse.")
 ;; Called in hyperbole.el.
 (defun hyperb:stack-frame (function-list &optional debug-flag)
   "Return the nearest Elisp stack frame that called a function from FUNCTION-LIST.
-Return nil if there is no match.  FUNCTION-LIST entries must be symbols.
-If FUNCTION-LIST contains \\='load, \\='autoload or \\='require, detect autoloads
-not visible within the Lisp level stack frames.
+Return nil if there is no match.  FUNCTION-LIST entries must be
+symbols.  If FUNCTION-LIST contains \\='load, \\='autoload or
+\\='require, detect autoloads not visible within the Lisp level
+stack frames.
 
 With optional DEBUG-FLAG non-nil, if no matching frame is found, return list
 of stack frames (from innermost to outermost)."

--- a/hypb.el
+++ b/hypb.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     6-Oct-91 at 03:42:38
-;; Last-Mod:     20-Jan-24 at 20:20:28 by Mats Lidell
+;; Last-Mod:     20-Jan-24 at 20:22:08 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -444,7 +444,8 @@ This will install the Emacs devdocs package if not yet installed."
 
 (defun hypb:error (&rest args)
   "Signal an error typically to be caught by `hyperbole'.
-The error message is formatted passing ARGS to the function `format'."
+The error message is formatted passing the rest of the ARGS to
+the `format' function."
   (let ((msg (if (< (length args) 2)
 		 (car args)
 	       (apply 'format (cons (car args)

--- a/hypb.el
+++ b/hypb.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     6-Oct-91 at 03:42:38
-;; Last-Mod:     20-Jan-24 at 15:42:04 by Mats Lidell
+;; Last-Mod:     20-Jan-24 at 20:20:28 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -443,7 +443,8 @@ This will install the Emacs devdocs package if not yet installed."
       (concat "@" dname))))
 
 (defun hypb:error (&rest args)
-  "Signal an error typically to be caught by `hyperbole'."
+  "Signal an error typically to be caught by `hyperbole'.
+The error message is formatted passing ARGS to the function `format'."
   (let ((msg (if (< (length args) 2)
 		 (car args)
 	       (apply 'format (cons (car args)
@@ -544,7 +545,7 @@ Use the current syntax table or optional SYNTAX-TABLE."
   (aref (or syntax-table (syntax-table)) char))
 
 (defun hypb:glob-to-regexp (str)
-  "Convert any file glob syntax to Emacs regexp syntax."
+  "Convert any file glob syntax in STR to Emacs regexp syntax."
   (when (stringp str)
     (setq str (replace-regexp-in-string "\\`\\*" ".*" str nil t)
 	  str (replace-regexp-in-string "\\([^\\.]\\)\\*" "\\1.*" str))
@@ -894,7 +895,7 @@ Removes any trailing newline at the end of the output."
   "Recursively grep with symbol at point or PATTERN.
 Grep over all non-backup and non-autosave files in the current
 directory tree.  If in an Emacs Lisp mode buffer and no optional
-PREFIX-ARG is given, limit search to only .el and .el.gz files."
+PREFX-ARG is given, limit search to only .el and .el.gz files."
   (interactive (list (if (and (not current-prefix-arg) (equal (buffer-name) "*Locate*"))
 			 (read-string "Grep files listed here for: ")
 		       (let ((default (symbol-at-point)))
@@ -953,7 +954,7 @@ Set in the current syntax table or optional SYNTAX-TABLE.  Return
 the RAW-DESCRIPTOR.  Use the `syntax-after' function to retrieve
 the raw descriptor for a buffer position.
 
-Similar to modify-syntax-entry but uses a raw descriptor
+Similar to `modify-syntax-entry' but uses a raw descriptor
 previously extracted from a syntax table to set the value rather
 than a string.
 
@@ -1127,9 +1128,10 @@ If FILE is not an absolute path, expand it relative to `hyperb:dir'."
       (setq-local org-cycle-global-at-bob t)
       (view-mode)
       ;; Ensure no initial folding of the buffer, possibly from a hook
-      (if (fboundp 'org-fold-show-all)
-	  (org-fold-show-all)
-	(org-show-all))
+      (with-suppressed-warnings ((obsolete org-show-all))
+        (if (fboundp 'org-fold-show-all)
+	    (org-fold-show-all)
+	  (org-show-all)))
       ;; On some versions of Emacs like Emacs28, need a slight delay
       ;; for file loading before searches will work properly.
       ;; Otherwise, "test/demo-tests.el" may fail.

--- a/hyperbole.el
+++ b/hyperbole.el
@@ -8,7 +8,7 @@
 ;; Maintainer:   Mats Lidell <matsl@gnu.org>
 ;; Maintainers:  Robert Weiner <rsw@gnu.org>, Mats Lidell <matsl@gnu.org>
 ;; Created:      06-Oct-92 at 11:52:51
-;; Last-Mod:     20-Jan-24 at 15:42:11 by Mats Lidell
+;; Last-Mod:     20-Jan-24 at 20:20:34 by Mats Lidell
 ;; Released:     03-Dec-23
 ;; Version:      9.0.0
 ;; Keywords:     comm, convenience, files, frames, hypermedia, languages, mail, matching, mouse, multimedia, outlines, tools, wp
@@ -134,7 +134,7 @@ See `hkey-initialize'.")
 
 (defcustom hyperbole-mode-lighter " Hypb"
   "String to display in mode line when the Hyperbole global minor mode is enabled.
-  Use nil for no Hyperbole mode indicator."
+Use nil for no Hyperbole mode indicator."
   :type 'string
   :group 'hyperbole)
 
@@ -194,9 +194,9 @@ Info documentation at \"(hyperbole)Top\".
   "*A non-nil value (default) at system load time binds Hyperbole keys.
 Keys bound are the Action and Assist Keyboard Keys, as well as
 other keys.  {\\[hkey-either]} invokes the Action Key and
-{C-u \\[hkey-either]} invokes the Assist Key.  Additionally,
+{\\`C-u' \\[hkey-either]} invokes the Assist Key.  Additionally,
 {\\[hkey-help]} shows what the Action Key will do in the current
-context (wherever point is).  {C-u \\[hkey-help]} shows what the
+context (wherever point is).  {\\`C-u' \\[hkey-help]} shows what the
 Assist Key will do."
   :type 'boolean
   :group 'hyperbole-keys)
@@ -406,7 +406,7 @@ frame, those functions by default still return the prior frame."
     "Return t if there is an invisible character between BEG and END, else nil."
     (catch 'result
       (let ((p beg))
-	(while (< p end) 
+	(while (< p end)
 	  (when (eq (get-char-property p 'invisible) 'outline)
 	    (throw 'result t))
 	  (setq p (1+ p))))

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Jun-89 at 22:08:29
-;; Last-Mod:     20-Jan-24 at 20:20:45 by Mats Lidell
+;; Last-Mod:     20-Jan-24 at 20:22:18 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1264,9 +1264,9 @@ Return number of matching entries found."
 	 (not (get-file-buffer (expand-file-name bbdb-file)))))
     (hyrolo-grep-file hyrolo-file-or-buf regexp max-matches count-only)))
 
-(defun hyrolo-bbdb-entry-format (entry)
-  "Format for a BBDB ENTRY."
-  (let ((v (read entry)))
+(defun hyrolo-bbdb-entry-format (bbdb-entry)
+  "Format for a BBDB-ENTRY."
+  (let ((v (read bbdb-entry)))
     (format "* %s: %s: <%s>\n" (elt v 1) (elt v 0) (car (elt v 7)))))
 
 ;;; ************************************************************************

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Jun-89 at 22:08:29
-;; Last-Mod:     20-Jan-24 at 15:42:34 by Mats Lidell
+;; Last-Mod:     20-Jan-24 at 20:20:45 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -147,7 +147,7 @@ executable must be found as well (for Oauth security)."
 The first file should be a user-specific hyrolo file, typically in the home
 directory and must have a suffix of either .org (Org mode) or .otl (Emacs
 Outline mode).  Other files in the list may use suffixes of .org, .otl, .md
-(Markdown mode) or .kotl (Koutline mode).
+\(Markdown mode) or .kotl (Koutline mode).
 
 A hyrolo-file consists of:
    (1) an optional header beginning with and ending with a line which matches
@@ -160,6 +160,8 @@ A hyrolo-file consists of:
   :group 'hyperbole-hyrolo)
 
 (defun hyrolo-file-list-changed (symbol set-to-value operation _where)
+  "Watch function for variable `hyrolo-file-list'.
+Function is called with 4 arguments: (SYMBOL SET-TO-VALUE OPERATION WHERE)."
   (if (memq operation '(let unlet)) ;; not setting global value
       (hyrolo-let-file-list symbol set-to-value)
     (hyrolo-set-file-list symbol set-to-value)))
@@ -174,8 +176,8 @@ A hyrolo-file consists of:
    "===============================================================================\n"
    "%s\n"
    "===============================================================================\n")
-  "Header to insert preceding a file's first HyRolo entry match when
-file has none of its own.  Used with one argument, the file name.")
+  "Header to insert before a file's first entry match when file has no header.
+Used with one argument, the file name.")
 
 (defconst hyrolo-hdr-regexp "^==="
   "Regular expression to match the first and last lines of hyrolo file headers.
@@ -379,7 +381,7 @@ String search expressions are converted to regular expressions.")
   "Keymap for the hyrolo display match buffer.")
 
 (defvar hyrolo-mode-prefix-map nil
-  "Keymap for hyrolo display match buffer bindings with a prefix, typically C-c.")
+  "Keymap for hyrolo display match buffer bindings with a prefix, typically \\`C-c'.")
 
 ;;; ************************************************************************
 ;;; Commands
@@ -995,6 +997,7 @@ Raise an error if a match is not found."
 		      new-file))))
 
 (defun hyrolo-set-display-buffer ()
+  "Set display buffer."
   (prog1 (set-buffer (get-buffer-create hyrolo-display-buffer))
     (unless (eq major-mode 'hyrolo-mode)
       (hyrolo-mode))
@@ -1262,6 +1265,7 @@ Return number of matching entries found."
     (hyrolo-grep-file hyrolo-file-or-buf regexp max-matches count-only)))
 
 (defun hyrolo-bbdb-entry-format (entry)
+  "Format for a BBDB ENTRY."
   (let ((v (read entry)))
     (format "* %s: %s: <%s>\n" (elt v 1) (elt v 0) (car (elt v 7)))))
 
@@ -1316,6 +1320,7 @@ Return number of matching entries found."
 
 ;; Derived from google-contacts.el.
 (defun hyrolo-google-contacts-insert-data (contacts _token contact-prefix-string)
+  "Insert google CONTACTS data."
   (if (not contacts)
       ;; No contacts, insert a string and return nil
       (insert "No result.")
@@ -2079,7 +2084,7 @@ of the current heading, or to 1 if the current line is not a heading."
   "Move back to the start of current subtree and hide everything after the heading.
 If within a file header, hide the whole file after the end of the current line.
 
-Necessary, since with reveal-mode active, `outline-hide-subtree' works
+Necessary, since with `reveal-mode' active, `outline-hide-subtree' works
 only if on the heading line of the subtree."
   (interactive)
   (if (and (hyrolo-hdr-in-p)
@@ -2571,7 +2576,8 @@ a default of MM/DD/YYYY."
 
 (defun hyrolo-isearch-for-regexp (regexp fold-search-flag)
   "Interactively search forward for the next occurrence of REGEXP.
-Then add characters to further narrow the search."
+When FOLD-SEARCH-FLAG is non-nil search ignores case.  Then add
+characters to further narrow the search."
   (hyrolo-verify)
   (if (stringp regexp)
       (progn (setq unread-command-events
@@ -2751,7 +2757,7 @@ The date format is determined by the setting, `hyrolo-date-format'."
       min-level)))
 
 (defun hyrolo-search-directories (search-cmd file-regexp &rest dirs)
-  "Search HyRolo over files matching FILE-REGEXP in rest of DIRS."
+  "Search HyRolo over files using SEARCH-CMD matching FILE-REGEXP in rest of DIRS."
   (when (or (null file-regexp) (string-empty-p file-regexp))
     (setq file-regexp hyrolo-file-suffix-regexp))
   (let ((hyrolo-file-list (hypb:filter-directories file-regexp dirs)))
@@ -2799,7 +2805,9 @@ Any call to this function should be wrapped in a call to
 	    (min desired-shrinkage (- height window-min-height)))))))
 
 (defun hyrolo-to-buffer (buffer &optional other-window-flag _frame)
-  "Pop to BUFFER."
+  "Pop to BUFFER.
+With optional OTHER-WINDOW-FLAG non-nil, pop to a window other
+than the selected one."
   (pop-to-buffer buffer other-window-flag))
 
 (defun hyrolo-move-forward (func &rest args)
@@ -3046,7 +3054,7 @@ Push (point-max) of `hyrolo-display-buffer' onto
 	(setq-local hyrolo--cache-major-mode-index (1+ hyrolo--cache-major-mode-index))))))
 
 (defun hyrolo--cache-post-display-buffer ()
-  "Cache updates to make after display buffer modifications are finished."
+  "Cache update to make after display buffer modifications are finished."
   ;; Reverse both of the above lists to order them properly.
   (with-current-buffer hyrolo-display-buffer
     (setq-local hyrolo--cache-loc-match-bounds   (nreverse hyrolo--cache-loc-match-bounds)

--- a/hywconfig.el
+++ b/hywconfig.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Mar-89
-;; Last-Mod:     20-Jan-24 at 15:42:45 by Mats Lidell
+;; Last-Mod:     20-Jan-24 at 20:20:58 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -216,7 +216,7 @@ oldest one comes the newest one."
   (frame-parameter (selected-frame) 'named-hywconfigs))
 
 (defun hywconfig-named-put (name wconfig)
-  "Add NAMEd WCONFIG to selected frame's plist of named window configurations."
+  "Add WCONFIG with NAME to selected frame's plist of named window configurations."
   (hywconfig-named-set-entries
    (with-suppressed-warnings ((obsolete lax-plist-put)) ;; Obsolete since 29.1, use plist-get
      (lax-plist-put (hywconfig-named-get-entries) name wconfig))))


### PR DESCRIPTION
# What

Cleanup of flycheck/flymake info and warning messages.

# Why

We should keep the code base as clean as possible.

# Note

This is a more or less mechanical go through of all info and warnings produce by flycheck and trying to resolve them. (I hope and think that flycheck uses the same backbone functions to check for problems as flymake so this work would cover for a similar exercise using flymake.)

I know you are not a big fan of these huge PRs but it is mostly small changes affecting docstrings. There are a few code changes but should not affect execution.

Common things that are fixed are:
1. Error message shall not end in a period.
2. There shall be no extra whitespace at end of line.
3. Docstring is missing.
4. Docstring is missing arg in capital letters.
5. Key control sequence is not properly escaped and quoted.
6. Dired should be written as Dired, with a capital first letter, everywhere in docstrings.
7. ...

Not all of these are fixed either. Not all functions have been given docstrings. Not all parameters have been added in capital letters.I might have missed something. Anyway -- I have tried fix that but given up due to it either does not make sense to add it or most often, I could not come up with something decent enough so juts left it as is.

There is no Changelog for this work either. If it gets accepted I can add a Changelog item covering the whole initiative.