### PR TITLE
Remove package-lint dependency and string-replace compatibility code

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,18 @@
+2024-01-20  Mats Lidell  <matsl@gnu.org>
+
+* Makefile (package-lint): Add explicit loading of package-lint from Melpa
+    for this target. Only needed there.
+
+* test/hy-test-dependencies.el: Do not load package-lint for running
+    tests.
+
+* test/hy-test-dependencies.el (string-replace): Remove not needed
+    compatibility code.
+
+* test/hyrolo-tests.el (hyrolo-tests--outline-content-otl)
+    (hyrolo-tests--outline-content-md): Use replace-regexp-in-string for
+    compatibility with old Emacs versions.
+
 2024-01-17  Bob Weiner  <rsw@gnu.org>
 
 * test/hy-test-dependencies.el (org-reloaded): Show Org src dir.

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:     17-Jan-24 at 14:57:57 by Mats Lidell
+# Last-Mod:     20-Jan-24 at 10:07:54 by Mats Lidell
 #
 # Copyright (C) 1994-2023  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -535,5 +535,7 @@ package-lint:
 	$(EMACS_BATCH) \
 	--eval "(setq package-lint-main-file \"hyperbole.el\")" \
 	--eval "(load-file \"test/hy-test-dependencies.el\")" \
+	--eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\"))" \
+	--eval "(hy-test-ensure-package-installed 'package-lint)" \
 	-l package-lint.el -f package-lint-batch-and-exit \
 	$(EL_KOTL) $(EL_SRC)

--- a/test/hy-test-dependencies.el
+++ b/test/hy-test-dependencies.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    20-Feb-21 at 23:16:00
-;; Last-Mod:     17-Jan-24 at 23:32:33 by Bob Weiner
+;; Last-Mod:     20-Jan-24 at 09:56:08 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -31,22 +31,10 @@
     (package-install pkg-symbol)))
 
 (mapc (lambda (sym) (hy-test-ensure-package-installed sym))
-      '(el-mock package-lint with-simulated-input))
+      '(el-mock with-simulated-input))
 
 ;; Needed when `hypb:display-file-with-logo' uses `org-mode'.
 (setq hsys-org-enable-smart-keys t)
-
-;; From compat.el package
-(unless (fboundp 'string-replace)
-(defun string-replace (fromstring tostring instring)
-  "Replace FROMSTRING with TOSTRING in INSTRING each time it occurs."
-  (when (equal fromstring "")
-    (signal 'wrong-length-argument '(0)))
-  (let ((case-fold-search nil))
-    (replace-regexp-in-string
-     (regexp-quote fromstring)
-     tostring instring
-     t t))))
 
 (require 'pp)
 (terpri)

--- a/test/hyrolo-tests.el
+++ b/test/hyrolo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    19-Jun-21 at 22:42:00
-;; Last-Mod:     15-Jan-24 at 22:15:11 by Bob Weiner
+;; Last-Mod:     20-Jan-24 at 10:03:01 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -989,12 +989,13 @@ body
   "Outline content for org files.")
 
 (defconst hyrolo-tests--outline-content-otl
-  (string-replace "org" "otl" hyrolo-tests--outline-content-org)
+  (replace-regexp-in-string "org" "otl" hyrolo-tests--outline-content-org)
   "Outline content for otl files.")
 
 (defconst hyrolo-tests--outline-content-md
-  (string-replace "*" "#"
-                  (string-replace "org" "md" hyrolo-tests--outline-content-org))
+  (replace-regexp-in-string
+   (regexp-quote "*") "#"
+   (replace-regexp-in-string "org" "md" hyrolo-tests--outline-content-org))
   "Outline content for markdown files.")
 
 (ert-deftest hyrolo-tests--forward-same-level-org-level2 ()


### PR DESCRIPTION
# What

Remove package-lint dependency and string-replace compatibility code.

Only require package-lint in the package-lint target.

The compat library that was dragged in due to package-lint resolved backwards compatibility for string-replace for older Emacs versions. Solved here by using older replace-regexp-in-string.

# Why

* Cleanup to not use newer code in tests. (Until we have resolved how to deal with compat code.)
* Only require package-lint where it is really used.
* Speedier build times in CI/CD and local docker runs when we do not install not needed external packages as part of the build. (Package-lint has its own dependencies that are dragged in too which takes additional time.)