### PR TITLE
Add hsettings tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2024-01-20  Mats Lidell  <matsl@gnu.org>
+
+* test/hsettings-test.el: New test file for hsettings.
+    (hsettings-test--hyperbole-web-search): Test hyperbole-web-search.
+
 2024-01-17  Bob Weiner  <rsw@gnu.org>
 
 * test/hy-test-dependencies.el (org-reloaded): Show Org src dir.

--- a/test/MANIFEST
+++ b/test/MANIFEST
@@ -9,6 +9,7 @@ hibtypes-tests.el       - unit test for hib-kbd
 hmouse-drv-tests.el     - hmouse-drv unit tests
 hmouse-info-tests.el    - hmouse-info unit tests
 hpath-tests.el          - unit tests for hpath
+hsettings-test.el       - unit tests for hsettings
 hsys-org-tests.el       - hsys-org tests
 hui-register-tests.el   - test for hui-register
 hui-select-tests.el     - hui-select tests

--- a/test/hsettings-test.el
+++ b/test/hsettings-test.el
@@ -1,0 +1,46 @@
+;;; hsettings-test.el --- one line summary                -*- lexical-binding: t; -*-
+;;
+;; Author:       Mats Lidell
+;;
+;; Orig-Date:    20-Jan-24 at 12:28:01
+;; Last-Mod:     20-Jan-24 at 14:25:44 by Mats Lidell
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
+;; Copyright (C) 2024  Free Software Foundation, Inc.
+;; See the "HY-COPY" file for license information.
+;;
+;; This file is part of GNU Hyperbole.
+
+;;; Commentary:
+;;
+
+;;; Code:
+
+(require 'ert)
+(require 'el-mock)
+(require 'hsettings)
+
+(ert-deftest hsettings-test--hyperbole-web-search ()
+  "Verify `hyperbole-web-search´."
+  (mocklet (((browse-url "http://www.google.com/search?q=hyperbole") => "return"))
+    (should (string= (hyperbole-web-search "google" "hyperbole" nil) "return")))
+  (should (string= (hyperbole-web-search "google" "hyperbole" t) "http://www.google.com/search?q=hyperbole"))
+  (should-error (hyperbole-web-search "unknown" "hyperbole" nil))
+  (should-error (hyperbole-web-search "unknown" "hyperbole" t))
+
+  ;; Jump
+  ;; Fails due to being called with argument: See test below.
+  ;; (mocklet (((webjump) => "return"))
+  ;;   (should (string= (hyperbole-web-search "Jump" "arg" nil) "return")))
+  (should (equal (hyperbole-web-search "Jump" "arg" t) '(webjump "arg"))))
+
+(ert-deftest hsettings-test--hyperbole-web-search-webjump-called-with-arg ()
+  "Verify `hyperbole-web-search´."
+  :expected-result :failed
+  ;; Jump
+  (mocklet (((webjump) => "return"))
+    (should (string= (hyperbole-web-search "Jump" "arg" nil) "return"))))
+
+(provide 'hsettings-test)
+;;; hsettings-test.el ends here


### PR DESCRIPTION
# What

Show problem with `hyperbole-web-search` and `webjump`.

# Why

Webjump is called with search term but takes no arguments so it fails.

# Discussion

Not sure what the proper solution should be hence the discussion here.

- One solution would be to drop the argument to the search performed by a "function" as opposed to web search using browse-url. That seems to be in agreement with the docs of `hyperbole-web-search-alist` that can be interpreted as when a function is selected it should itself prompt for its arguments. That would make sense for functions like webjump that requires multiple prompts for it to do its job.
- On the other hand it could make sense to keep the prompt for the search string so it will be easier for user supplied search functions that takes one argument. In that case an alternative would be to define a webjump that takes one argument (but that would mean that it would rather clumsy prompt user for a param that will not be used unless it can be fed to webjump some how!?)
- More functionality could be added to the framework so that functions can specify if they want to be fed an argument or not and `hyperbole-web-search` could handle that.
- Lastly, this is for web-search, so adding to much additional nice to have things might be taking it to far? So maybe webjump in itself does not belong here?
