### PR TITLE
Remove unused function

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,8 @@
 
 2024-01-20  Mats Lidell  <matsl@gnu.org>
 
+* hmouse-sh.el (hmouse-move-point-eterm): Remove unused function.
+
 * Cleanup using flycheck resolving info and warning messages.
 
 * Update copyright date of latest updated version to be 2024 for all files

--- a/hmouse-sh.el
+++ b/hmouse-sh.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     3-Sep-91 at 21:40:58
-;; Last-Mod:     20-Jan-24 at 19:54:28 by Mats Lidell
+;; Last-Mod:     20-Jan-24 at 20:52:12 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -486,9 +486,6 @@ point determined by `mouse-select-region-move-to-beginning'."
 	      (hmouse-posn-set-point (event-end event))
 	    (error (when (window-valid-p end-w-or-f)
 		     (select-frame (window-frame end-w-or-f))))))))))
-
-(defun hmouse-move-point-eterm (arg-list)
-  (apply 'mouse-move-point arg-list))
 
 (defun hmouse-set-key-list (binding key-list)
   "Define a Hyperbole global minor mode key from KEY-LIST bound to BINDING."


### PR DESCRIPTION
# What

Remove unused function

# Why

Extracted into a separate commit and PR for observability and easier traceability.