### PR TITLE
Add single file match tests for some hyrolo hide and show commands

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2024-01-30  Mats Lidell  <matsl@gnu.org>
+
+* test/hyrolo-tests.el (hyrolo-tests--outline-as-string): Add helper that
+    returns how the buffer looks to the eye.
+    (hyrolo-tests--outline-hide-other)
+    (hyrolo-tests--outline-hide-sublevels)
+    (hyrolo-tests--hyrolo-outline-show-subtree): Add tests for hyrolo
+    outline show and hide commands.
+
 2024-01-28  Bob Weiner  <rsw@gnu.org>
 
 * hyrolo.el (hyrolo-org-outline-level): Fix to not move point; was causing errors


### PR DESCRIPTION
# What

Add single file match tests for some hyrolo hide and show commands.

Includes helper method for turning a buffer with invisible regions into a plain string with the ellipses indicating where the invisible portions for the file are.

# Why

Hyrolo needs a lot of testing.

# Note

These tests are designed to succeed, Whether the HyRolo buffer looks right is another issue and will require a review. 

Maybe not helpful in this respect the matching string is written as a one line string for making the size of the test cases smaller.  Maybe it would make sense for these types of tests, with visual impact, to write the matching string out as a multi line string in the code. What do you think?

There are likely more tests cases around these functions like having matches in multiple files and multiple file types etc but will add those separately and as we feel are required.