### PR TITLE
Use actionv4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     container: silex/emacs:${{ matrix.version }}-ci
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Clean
         run: make clean


### PR DESCRIPTION
Node16 is deprecated and we are requested by Github to move over to using actions using Node20.

See https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

This can be merged to rsw-branch instead but trying it against master to get a PR build that verifies that change works and the deprecation warning is removed.