### PR TITLE
Matsl rsw fix ebut act

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2024-02-08  Mats Lidell  <matsl@gnu.org>
 
+* hbut.el (ibut:act-label): Rename ibut:act to ibut:act-label, it takes a
+    label as arg.
+
 * hui-menu.el (hui-menu-explicit-buttons): Use ebut:act-label.
 
 * hbut.el (ebut:act-label): Rename ebut:act to ebut:act-label, it takes a

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 2024-02-08  Mats Lidell  <matsl@gnu.org>
 
+* hui-menu.el (hui-menu-explicit-buttons): Use ebut:act-label.
+
+* hbut.el (ebut:act-label): Rename ebut:act to ebut:act-label, it takes a
+    label as arg.
+
 * test/hyrolo-tests.el: Make hide tests more forgiving about hiding
     section headers. Allows test cases to be used with different versions
     of org.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,13 +1,17 @@
 2024-02-08  Mats Lidell  <matsl@gnu.org>
 
 * test/hbut-tests.el (hbut-tests--ebut-act-calls-hbut-act)
-    (hbut-tests--ibut-act-calls-hbut-act): Add test for new act functions.
+    (hbut-tests--ibut-act-calls-hbut-act): Add test for new act functions
+    with error cases.
 
 * hui-menu.el (hui-menu-explicit-buttons): Use ebut:act-label.
 
 * hbut.el (ibut:act-label, ebut:act-label): Rename ebut:act and ibut:act
     since they take a label as arg.
-    (ebut:act, ibut:act): Add new act functions taking a hbut as arg.
+    (ebut:act, ibut:act): Add new act functions taking a hbut as
+    arg. Allow only to be called with ebut or ibut respectively. If
+    falling back on hbut:current check that it is of the same type as the
+    call.
 
 * test/hyrolo-tests.el: Make hide tests more forgiving about hiding
     section headers. Allows test cases to be used with different versions

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,12 +1,13 @@
 2024-02-08  Mats Lidell  <matsl@gnu.org>
 
-* hbut.el (ibut:act-label): Rename ibut:act to ibut:act-label, it takes a
-    label as arg.
+* test/hbut-tests.el (hbut-tests--ebut-act-calls-hbut-act)
+    (hbut-tests--ibut-act-calls-hbut-act): Add test for new act functions.
 
 * hui-menu.el (hui-menu-explicit-buttons): Use ebut:act-label.
 
-* hbut.el (ebut:act-label): Rename ebut:act to ebut:act-label, it takes a
-    label as arg.
+* hbut.el (ibut:act-label, ebut:act-label): Rename ebut:act and ibut:act
+    since they take a label as arg.
+    (ebut:act, ibut:act): Add new act functions taking a hbut as arg.
 
 * test/hyrolo-tests.el: Make hide tests more forgiving about hiding
     section headers. Allows test cases to be used with different versions

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-2024-02-08  Mats Lidell  <matsl@gnu.org>
+2024-02-11  Mats Lidell  <matsl@gnu.org>
 
 * test/hbut-tests.el (hbut-tests--ebut-act-calls-hbut-act)
     (hbut-tests--ibut-act-calls-hbut-act): Add test for new act functions
@@ -12,6 +12,8 @@
     arg. Allow only to be called with ebut or ibut respectively. If
     falling back on hbut:current check that it is of the same type as the
     call.
+
+2024-02-08  Mats Lidell  <matsl@gnu.org>
 
 * test/hyrolo-tests.el: Make hide tests more forgiving about hiding
     section headers. Allows test cases to be used with different versions

--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:      2-Feb-24 at 22:11:13 by Mats Lidell
+;; Last-Mod:      8-Feb-24 at 15:39:49 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -128,7 +128,11 @@ Default is the symbol hbut:current."
   (interactive (list (hbut:get (hargs:read-match "Activate labeled Hyperbole button: "
 						 (ebut:alist)
 						 nil t nil 'hbut))))
-  (hbut:act hbut))
+  (unless hbut
+    (setq hbut 'hbut:current))
+  (if (ebut:is-p hbut)
+      (hbut:act hbut)
+    (error "(ebut:act): Must be called with an ebut or hbut:current must be an ebut")))
 
 (defun    ebut:act-label (label)
   "Activate Hyperbole explicit button with LABEL from the current buffer."
@@ -1706,7 +1710,11 @@ Default is the symbol hbut:current."
   (interactive (list (hbut:get (hargs:read-match "Activate labeled Hyperbole button: "
 						 (ibut:alist)
 						 nil t nil 'hbut))))
-  (hbut:act hbut))
+  (unless hbut
+    (setq hbut 'hbut:current))
+  (if (ibut:is-p hbut)
+      (hbut:act hbut)
+    (error "(ibut:act): Must be called with an ibut or hbut:current must be an ibut")))
 
 (defun    ibut:act-label (label)
   "Activate Hyperbole implicit button with <[LABEL]> from the current buffer."

--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:      2-Feb-24 at 21:41:12 by Mats Lidell
+;; Last-Mod:      2-Feb-24 at 21:47:24 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1693,7 +1693,7 @@ Keys in optional KEY-SRC or the current buffer."
 ;;; ========================================================================
 
 
-(defun    ibut:act (label)
+(defun    ibut:act-label (label)
   "Activate Hyperbole implicit button with <[LABEL]> from the current buffer."
   (interactive (list (hargs:read-match "Activate implicit button labeled: "
 				       (ibut:alist)
@@ -1702,7 +1702,7 @@ Keys in optional KEY-SRC or the current buffer."
 	 (but (ibut:get lbl-key)))
     (if but
 	(hbut:act but)
-      (error "(ibut:act): No implicit button labeled: %s" label))))
+      (error "(ibut:act-label): No implicit button labeled: %s" label))))
 
 (defun    ibut:alist (&optional file)
   "Return alist of labeled ibuts in FILE or the current buffer.

--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:      8-Feb-24 at 15:39:49 by Mats Lidell
+;; Last-Mod:     11-Feb-24 at 23:43:08 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -122,17 +122,17 @@ indicating the source of any of its Hyperbole buttons.")
   "*Non-nil value saves button data when button source is saved.
 Nil disables saving.")
 
-(defun    ebut:act (&optional hbut)
-  "Perform action for optional explicit Hyperbole button symbol HBUT.
+(defun    ebut:act (&optional ebut)
+  "Perform action for optional explicit Hyperbole button symbol EBUT.
 Default is the symbol hbut:current."
   (interactive (list (hbut:get (hargs:read-match "Activate labeled Hyperbole button: "
 						 (ebut:alist)
-						 nil t nil 'hbut))))
-  (unless hbut
-    (setq hbut 'hbut:current))
-  (if (ebut:is-p hbut)
-      (hbut:act hbut)
-    (error "(ebut:act): Must be called with an ebut or hbut:current must be an ebut")))
+						 nil t nil 'ebut))))
+  (unless ebut
+    (setq ebut 'hbut:current))
+  (if (ebut:is-p ebut)
+      (hbut:act ebut)
+    (error "(ebut:act): Expected an ebut but got a but of type %s" (hattr:get ebut 'categ))))
 
 (defun    ebut:act-label (label)
   "Activate Hyperbole explicit button with LABEL from the current buffer."
@@ -1704,17 +1704,17 @@ Keys in optional KEY-SRC or the current buffer."
 ;;; ibut class - Implicit Hyperbole Buttons
 ;;; ========================================================================
 
-(defun    ibut:act (&optional hbut)
-  "Perform action for optional implicit Hyperbole button symbol HBUT.
+(defun    ibut:act (&optional ibut)
+  "Perform action for optional implicit Hyperbole button symbol IBUT.
 Default is the symbol hbut:current."
   (interactive (list (hbut:get (hargs:read-match "Activate labeled Hyperbole button: "
 						 (ibut:alist)
-						 nil t nil 'hbut))))
-  (unless hbut
-    (setq hbut 'hbut:current))
-  (if (ibut:is-p hbut)
-      (hbut:act hbut)
-    (error "(ibut:act): Must be called with an ibut or hbut:current must be an ibut")))
+						 nil t nil 'ibut))))
+  (unless ibut
+    (setq ibut 'hbut:current))
+  (if (ibut:is-p ibut)
+      (hbut:act ibut)
+    (error "(ebut:act): Expected an ibut but got a but of type %s" (hattr:get ibut 'categ))))
 
 (defun    ibut:act-label (label)
   "Activate Hyperbole implicit button with <[LABEL]> from the current buffer."

--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:      2-Feb-24 at 21:47:24 by Mats Lidell
+;; Last-Mod:      2-Feb-24 at 22:11:13 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -121,6 +121,14 @@ indicating the source of any of its Hyperbole buttons.")
 (defvar   ebut:hattr-save t
   "*Non-nil value saves button data when button source is saved.
 Nil disables saving.")
+
+(defun    ebut:act (&optional hbut)
+  "Perform action for optional explicit Hyperbole button symbol HBUT.
+Default is the symbol hbut:current."
+  (interactive (list (hbut:get (hargs:read-match "Activate labeled Hyperbole button: "
+						 (ebut:alist)
+						 nil t nil 'hbut))))
+  (hbut:act hbut))
 
 (defun    ebut:act-label (label)
   "Activate Hyperbole explicit button with LABEL from the current buffer."
@@ -1692,6 +1700,13 @@ Keys in optional KEY-SRC or the current buffer."
 ;;; ibut class - Implicit Hyperbole Buttons
 ;;; ========================================================================
 
+(defun    ibut:act (&optional hbut)
+  "Perform action for optional implicit Hyperbole button symbol HBUT.
+Default is the symbol hbut:current."
+  (interactive (list (hbut:get (hargs:read-match "Activate labeled Hyperbole button: "
+						 (ibut:alist)
+						 nil t nil 'hbut))))
+  (hbut:act hbut))
 
 (defun    ibut:act-label (label)
   "Activate Hyperbole implicit button with <[LABEL]> from the current buffer."

--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:     21-Jan-24 at 10:31:14 by Bob Weiner
+;; Last-Mod:      2-Feb-24 at 21:41:12 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -122,7 +122,7 @@ indicating the source of any of its Hyperbole buttons.")
   "*Non-nil value saves button data when button source is saved.
 Nil disables saving.")
 
-(defun    ebut:act (label)
+(defun    ebut:act-label (label)
   "Activate Hyperbole explicit button with LABEL from the current buffer."
   (interactive (list (hargs:read-match "Activate explicit button labeled: "
 				       (ebut:alist)
@@ -131,7 +131,7 @@ Nil disables saving.")
 	 (but (ebut:get lbl-key)))
     (if but
 	(hbut:act but)
-      (error "(ebut:act): No explicit button labeled: %s" label))))
+      (error "(ebut:act-label): No explicit button labeled: %s" label))))
 
 (defun    ebut:alist (&optional file)
   "Return alist of ebuts in FILE or the current buffer.

--- a/hui-menu.el
+++ b/hui-menu.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    28-Oct-94 at 10:59:44
-;; Last-Mod:     21-Jan-24 at 10:31:58 by Bob Weiner
+;; Last-Mod:      2-Feb-24 at 21:41:16 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -110,7 +110,7 @@ BROWSER-OPTION marks current active menu option as selected."
 				 (not hui-menu-order-explicit-buttons))
 			   :style toggle :selected hui-menu-order-explicit-buttons]
 			  "Activate:")
-			(mapcar (lambda (label) (vector label `(ebut:act ,label) t))
+			(mapcar (lambda (label) (vector label `(ebut:act-label ,label) t))
 				(if hui-menu-order-explicit-buttons
 				    (sort labels #'string-lessp)
 				  labels))

--- a/test/hbut-tests.el
+++ b/test/hbut-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-may-21 at 09:33:00
-;; Last-Mod:      8-Feb-24 at 15:38:21 by Mats Lidell
+;; Last-Mod:     11-Feb-24 at 23:35:14 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -748,6 +748,9 @@ See #10 for the proper way to add an ibutton name.
     (should (ebut:act)))
   (mocklet ((ebut:is-p => nil))
     (should-error (ebut:act 'button))
+    (should-error (ebut:act)))
+  (progn
+    (hattr:clear 'hbut:current)
     (should-error (ebut:act))))
 
 (ert-deftest hbut-tests--ibut-act-calls-hbut-act ()
@@ -760,6 +763,9 @@ See #10 for the proper way to add an ibutton name.
     (should (ibut:act)))
   (mocklet ((ibut:is-p => nil))
     (should-error (ibut:act 'button))
+    (should-error (ibut:act)))
+  (progn
+    (hattr:clear 'hbut:current)
     (should-error (ibut:act))))
 
 ;; This file can't be byte-compiled without the `el-mock' package (because of

--- a/test/hbut-tests.el
+++ b/test/hbut-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-may-21 at 09:33:00
-;; Last-Mod:      2-Feb-24 at 22:16:49 by Mats Lidell
+;; Last-Mod:      8-Feb-24 at 15:38:21 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -740,13 +740,27 @@ See #10 for the proper way to add an ibutton name.
 
 (ert-deftest hbut-tests--ebut-act-calls-hbut-act ()
   "Verify `ebut:act' calls `hbut:act'."
-  (mocklet (((hbut:act 'button) => t))
-    (should (ebut:act 'button))))
+  (mocklet (((hbut:act 'button) => t)
+            ((ebut:is-p 'button) => t))
+    (should (ebut:act 'button)))
+  (mocklet (((hbut:act 'hbut:current) => t)
+            ((ebut:is-p 'hbut:current) => t))
+    (should (ebut:act)))
+  (mocklet ((ebut:is-p => nil))
+    (should-error (ebut:act 'button))
+    (should-error (ebut:act))))
 
 (ert-deftest hbut-tests--ibut-act-calls-hbut-act ()
   "Verify `ibut:act' calls `hbut:act'."
-  (mocklet (((hbut:act 'button) => t))
-    (should (ibut:act 'button))))
+  (mocklet (((hbut:act 'button) => t)
+            ((ibut:is-p 'button) => t))
+    (should (ibut:act 'button)))
+  (mocklet (((hbut:act 'hbut:current) => t)
+            ((ibut:is-p 'hbut:current) => t))
+    (should (ibut:act)))
+  (mocklet ((ibut:is-p => nil))
+    (should-error (ibut:act 'button))
+    (should-error (ibut:act))))
 
 ;; This file can't be byte-compiled without the `el-mock' package (because of
 ;; the use of the `with-mock' macro), which is not a dependency of Hyperbole.

--- a/test/hbut-tests.el
+++ b/test/hbut-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-may-21 at 09:33:00
-;; Last-Mod:     20-Jan-24 at 15:43:50 by Mats Lidell
+;; Last-Mod:      2-Feb-24 at 22:16:49 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -737,6 +737,16 @@ See #10 for the proper way to add an ibutton name.
       (message buf-str)
       (hbut-tests:should-match-tmp-folder buf-str)
       (should (null (hattr:get 'hbut:current 'name))))))
+
+(ert-deftest hbut-tests--ebut-act-calls-hbut-act ()
+  "Verify `ebut:act' calls `hbut:act'."
+  (mocklet (((hbut:act 'button) => t))
+    (should (ebut:act 'button))))
+
+(ert-deftest hbut-tests--ibut-act-calls-hbut-act ()
+  "Verify `ibut:act' calls `hbut:act'."
+  (mocklet (((hbut:act 'button) => t))
+    (should (ibut:act 'button))))
 
 ;; This file can't be byte-compiled without the `el-mock' package (because of
 ;; the use of the `with-mock' macro), which is not a dependency of Hyperbole.


### PR DESCRIPTION
# What

Rename i- ebut:act to act-label and create new act functions.

# Why

The old functions takes a label and to be more align with the hbut:act they should take a button. So the old functions have been moved away and new ones have been created. Two very simple tests have been added.

# Note

These function are not used a lot. The work horse is hbut:act that centralizes button action. So I'm not sure how well used these will be since you can call hbut:act in most cases just as well. In fact it its current version there is no check that hbut:current  actually is of the right type. Should that be added? Anyway, not sure the use case adds that much, but makes the API more complete. 