### PR TITLE
Matsl rsw silence warnings again

### DIFF
--- a/hib-debbugs.el
+++ b/hib-debbugs.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Jun-16 at 14:24:53
-;; Last-Mod:     21-Jan-24 at 10:32:46 by Bob Weiner
+;; Last-Mod:      2-Feb-24 at 22:44:22 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -90,8 +90,10 @@
 ;;; ************************************************************************
 
 (eval-after-load "debbugs-gnu"
-  '(progn (push "hyperbole"  debbugs-gnu-all-packages)
-	  (push "oo-browser" debbugs-gnu-all-packages)))
+  '(progn
+     (defvar debbugs-gnu-all-packages)
+     (push "hyperbole"  debbugs-gnu-all-packages)
+     (push "oo-browser" debbugs-gnu-all-packages)))
 
 ;;; ************************************************************************
 ;;; Public implicit button types

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -1560,7 +1560,7 @@ Return number of matching entries found."
       (insert "No result.")
     (print contacts (get-buffer-create "*contacts-data*"))
     (dolist (contact contacts)
-      (let* (
+      (let* ((child nil)
 	     (name-value (nth 0 (xml-get-children contact 'gd:name)))
              (fullname (xml-node-child-string (nth 0 (xml-get-children name-value 'gd:fullName))))
              (givenname (xml-node-child-string (nth 0 (xml-get-children name-value 'gd:givenName))))

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Jun-89 at 22:08:29
-;; Last-Mod:      4-Feb-24 at 14:00:36 by Bob Weiner
+;; Last-Mod:      4-Feb-24 at 22:42:01 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -113,9 +113,32 @@
 (defvar org-mode-syntax-table)          ; "org.el"
 (defvar org-outline-regexp)             ; "org.el"
 (defvar org-outline-regexp-bol)         ; "org.el"
-(defvar markdown-regex-header)          ; "markdown-mode.el"
 (defvar google-contacts-buffer-name)    ; "ext:google-contacts.el"
 (defvar hbut:source-prefix)             ; "hbut.el"
+
+;; markdown-mode.el
+(defvar markdown-regex-header)
+(defvar markdown-hide-markup)
+(defvar markdown-nested-imenu-heading-index)
+(defvar markdown-indent-function)
+(defvar markdown-make-gfm-checkboxes-buttons)
+(declare-function markdown--edit-indirect-after-commit-function "ext:markdown-mode")
+(declare-function markdown--indent-region "ext:markdown-mode")
+(declare-function markdown--inhibit-electric-quote "ext:markdown-mode")
+(declare-function markdown-adaptive-fill-function "ext:markdown-mode")
+(declare-function markdown-beginning-of-defun "ext:markdown-mode")
+(declare-function markdown-end-of-defun "ext:markdown-mode")
+(declare-function markdown-fill-forward-paragraph "ext:markdown-mode")
+(declare-function markdown-fill-paragraph "ext:markdown-mode")
+(declare-function markdown-gfm-checkbox-after-change-function "ext:markdown-mode")
+(declare-function markdown-imenu-create-flat-index "ext:markdown-mode")
+(declare-function markdown-imenu-create-nested-index "ext:markdown-mode")
+(declare-function markdown-line-is-reference-definition-p "ext:markdown-mode")
+(declare-function markdown-live-preview-if-markdown "ext:markdown-mode")
+(declare-function markdown-live-preview-remove-on-kill "ext:markdown-mode")
+(declare-function markdown-make-gfm-checkboxes-buttons "ext:markdown-mode")
+(declare-function markdown-pipe-at-bol-p "ext:markdown-mode")
+(declare-function markdown-remove-gfm-checkbox-overlays "ext:markdown-mode")
 
 ;; Forward declarations
 (defvar hyrolo--wconfig)
@@ -128,6 +151,7 @@
 (defvar hyrolo-mode-map)
 (defvar hyrolo-mode-prefix-map)
 (defvar hyrolo-mode-syntax-table)
+(defvar hyrolo-reveal-ignore-this-command)
 
 ;;; ************************************************************************
 ;;; Public variables

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -2730,7 +2730,7 @@ Entry is inserted before point.  The region is between START to END."
   "Return t if any file from `hyrolo-file-list' has an unusable format.
 
 The list of unusable files is displayed in a HyRolo error window
-unless 'hyrolo-boolean-only-flag' is set to t (used for testing).
+unless `hyrolo-boolean-only-flag' is set to t (used for testing).
 
 This will install `markdown-mode' if any Markdown files are specified and the
 package is not installed."


### PR DESCRIPTION
# What

Silences some compiler warnings.

# Why

Work with markdown has introduced a few vars and functions that needs to be declared to silence byte compiler. Plus some other small things.