### PR TITLE
Skip test if apropos command is not available

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2024-02-03  Mats Lidell  <matsl@gnu.org>
+
+* test/demo-tests.el (fast-demo-key-series-shell-apropos): Skip test if
+    apropos command is not available. Useful for running test-all using
+    silex docker-emacs images.
+
 2024-02-01  Mats Lidell  <matsl@gnu.org>
 
 * test/hyrolo-tests.el (hyrolo-tests--hyrolo-section-header): Helper that

--- a/test/demo-tests.el
+++ b/test/demo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     20-Jan-24 at 15:43:39 by Mats Lidell
+;; Last-Mod:      3-Feb-24 at 23:32:21 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -657,7 +657,8 @@ enough files with matching mode loaded."
 
 (ert-deftest fast-demo-key-series-shell-apropos ()
   "Action key executes apropos shell command."
-  (skip-unless (not noninteractive))
+  (skip-unless (and (not noninteractive)
+                    (executable-find "apropos")))
   (let* ((shell-file-name (executable-find "sh"))
          (shell-buffer-name "*shell*")
 	 (existing-shell-flag (get-buffer-process shell-buffer-name)))


### PR DESCRIPTION
# What

Useful for running test-all using silex docker-emacs images where the apropos command is not installed.

# Why

This disables the apropos test when running on machines that does not have apropos installed.

# Note

https://github.com/silex/docker-emacs images does not contain the apropos command. When running local `test-all` checks using docker it is useful to not try to run the apropos test since it can't succeed.