### PR TITLE
Use actionv4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     container: silex/emacs:${{ matrix.version }}-ci
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Clean
         run: make clean


### PR DESCRIPTION
Node16 is deprecated and we are requested by Github to move over to using actions using Node20.

Merge to rsw. See #460 for merge to master PR.