### PR TITLE
Matsl rsw make hide show test accept different section headings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2024-02-08  Mats Lidell  <matsl@gnu.org>
+
+* test/hyrolo-tests.el: Make hide tests more forgiving about hiding
+    section headers. Allows test cases to be used with different versions
+    of org.
+    Expand test verification strings so it is easier to view the expected
+    outcome.
+
 2024-02-05  Bob Weiner  <rsw@gnu.org>
 
 * Makefile (README.md.html): Rewrote to use md_toc and pandoc programs for greater

--- a/test/hyrolo-tests.el
+++ b/test/hyrolo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    19-Jun-21 at 22:42:00
-;; Last-Mod:      1-Feb-24 at 23:47:50 by Mats Lidell
+;; Last-Mod:      5-Feb-24 at 00:04:01 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1093,7 +1093,6 @@ optional BEGIN and END only return that part of the buffer."
 
 (ert-deftest hyrolo-tests--outline-hide-other ()
   "Verify `hyrolo-outline-hide-other' hides except current body, parent and top-level headings."
-  (skip-unless (< 28 emacs-major-version)) ;; Different behavior in older Emacs versions
   (let* ((org-file1 (make-temp-file "hypb" nil ".org" hyrolo-tests--outline-content-org))
          (hyrolo-file-list (list org-file1)))
     (unwind-protect
@@ -1104,7 +1103,8 @@ optional BEGIN and END only return that part of the buffer."
           (should (= (point) 1))
           (hyrolo-outline-hide-other)
           (should (string-match-p
-                   (concat "^===+" (regexp-quote "...\n* h-org 1...\n* h-org 2...\n") "$")
+                   (concat "^\\(===+.*[^*]\\|" (regexp-quote "...\n") "\\)"
+                           (regexp-quote "* h-org 1...\n* h-org 2...\n") "$")
                    (hyrolo-tests--outline-as-string)))
 
           ;; On first header
@@ -1113,8 +1113,6 @@ optional BEGIN and END only return that part of the buffer."
           (search-forward "* h-org 1")
           (beginning-of-line)
           (hyrolo-outline-hide-other)
-          (should (string= "...\n* h-org 1\nbody...\n* h-org 2...\n"
-                           (hyrolo-tests--outline-as-string)))
           (should (string= "* h-org 1\nbody...\n* h-org 2...\n"
                            (hyrolo-tests--outline-as-string (point))))
 
@@ -1124,8 +1122,6 @@ optional BEGIN and END only return that part of the buffer."
           (search-forward "** h-org 1.1")
           (beginning-of-line)
           (hyrolo-outline-hide-other)
-          (should (string= "...\n* h-org 1\n...\n** h-org 1.1\nbody...\n* h-org 2...\n"
-                           (hyrolo-tests--outline-as-string)))
           (should (string= "** h-org 1.1\nbody...\n* h-org 2...\n"
                            (hyrolo-tests--outline-as-string (point)))))
       (kill-buffer hyrolo-display-buffer)
@@ -1134,7 +1130,6 @@ optional BEGIN and END only return that part of the buffer."
 
 (ert-deftest hyrolo-tests--outline-hide-sublevels ()
   "Verify `hyrolo-outline-hide-sublevels' hides everything but the top levels."
-    (skip-unless (< 28 emacs-major-version)) ;; Different behavior in older Emacs versions
   (let* ((org-file1 (make-temp-file "hypb" nil ".org" hyrolo-tests--outline-content-org))
          (hyrolo-file-list (list org-file1)))
     (unwind-protect
@@ -1145,8 +1140,10 @@ optional BEGIN and END only return that part of the buffer."
           (should (= (point) 1))
           (hyrolo-outline-hide-sublevels 1)
           (should (= (point) 1))
-          (should (string= "...\n* h-org 1...\n* h-org 2...\n"
-                           (hyrolo-tests--outline-as-string)))
+          (should (string-match-p
+                   (concat "^\\(===+.*[^*]\\|" (regexp-quote "...\n") "\\)"
+                           (regexp-quote "* h-org 1...\n* h-org 2...\n") "$")
+                   (hyrolo-tests--outline-as-string)))
 
           ;; On first header
           (goto-char (point-min))
@@ -1154,8 +1151,6 @@ optional BEGIN and END only return that part of the buffer."
           (search-forward "* h-org 1")
           (beginning-of-line)
           (hyrolo-outline-hide-sublevels 1)
-          (should (string= "...\n* h-org 1...\n* h-org 2...\n"
-                           (hyrolo-tests--outline-as-string)))
           (should (string= "* h-org 1...\n* h-org 2...\n"
                            (hyrolo-tests--outline-as-string (point))))
 
@@ -1165,8 +1160,6 @@ optional BEGIN and END only return that part of the buffer."
           (search-forward "** h-org 1.1")
           (beginning-of-line)
           (hyrolo-outline-hide-sublevels 1)
-          (should (string= "...\n* h-org 1...\n* h-org 2...\n"
-                           (hyrolo-tests--outline-as-string)))
           (should (string= "1...\n* h-org 2...\n"
                            (hyrolo-tests--outline-as-string (point))))
 
@@ -1175,8 +1168,10 @@ optional BEGIN and END only return that part of the buffer."
           (should (= (point) 1))
           (hyrolo-outline-hide-sublevels 2)
           (should (= (point) 1))
-          (should (string= "...\n* h-org 1...\n** h-org 1.1...\n** h-org 1.2...\n* h-org 2...\n** h-org-2.1...\n"
-                           (hyrolo-tests--outline-as-string)))
+          (should (string-match-p
+                   (concat "^\\(===+.*[^*]\\|" (regexp-quote "...\n") "\\)"
+                           (regexp-quote "* h-org 1...\n** h-org 1.1...\n** h-org 1.2...\n* h-org 2...\n** h-org-2.1...\n") "$")
+                   (hyrolo-tests--outline-as-string)))
 
           ;; On first header - 2 levels
           (goto-char (point-min))
@@ -1184,8 +1179,6 @@ optional BEGIN and END only return that part of the buffer."
           (search-forward "* h-org 1")
           (beginning-of-line)
           (hyrolo-outline-hide-sublevels 2)
-          (should (string= "...\n* h-org 1...\n** h-org 1.1...\n** h-org 1.2...\n* h-org 2...\n** h-org-2.1...\n"
-                           (hyrolo-tests--outline-as-string)))
           (should (string= "* h-org 1...\n** h-org 1.1...\n** h-org 1.2...\n* h-org 2...\n** h-org-2.1...\n"
                            (hyrolo-tests--outline-as-string (point))))
 
@@ -1195,9 +1188,6 @@ optional BEGIN and END only return that part of the buffer."
           (search-forward "** h-org 1.1")
           (beginning-of-line)
           (hyrolo-outline-hide-sublevels 2)
-          (should (string=
-                   "...\n* h-org 1...\n** h-org 1.1...\n** h-org 1.2...\n* h-org 2...\n** h-org-2.1...\n"
-                   (hyrolo-tests--outline-as-string)))
           (should (string= "** h-org 1.1...\n** h-org 1.2...\n* h-org 2...\n** h-org-2.1...\n"
                            (hyrolo-tests--outline-as-string (point)))))
       (kill-buffer hyrolo-display-buffer)
@@ -1205,7 +1195,6 @@ optional BEGIN and END only return that part of the buffer."
 
 (ert-deftest hyrolo-tests--hyrolo-outline-show-subtree ()
   "Verify `hyrolo-hyrolo-outline-show-subtree' shows everything after heading at deeper levels."
-  (skip-unless (< 28 emacs-major-version)) ;; Different behavior in older Emacs versions
   (let* ((org-file1 (make-temp-file "hypb" nil ".org" hyrolo-tests--outline-content-org))
          (hyrolo-file-list (list org-file1)))
     (unwind-protect
@@ -1230,8 +1219,6 @@ optional BEGIN and END only return that part of the buffer."
           (beginning-of-line)
           (let ((original-look (hyrolo-tests--outline-as-string)))
             (hyrolo-outline-show-subtree)
-            (should (string= "...\n* h-org 1\nbody\n** h-org 1.1\nbody\n** h-org 1.2\nbody\n*** h-org 1.2.1\nbody\n* h-org 2...\n"
-                             (hyrolo-tests--outline-as-string)))
             (should (string= "* h-org 1\nbody\n** h-org 1.1\nbody\n** h-org 1.2\nbody\n*** h-org 1.2.1\nbody\n* h-org 2...\n"
                              (hyrolo-tests--outline-as-string (point))))
             ;; Hide it again
@@ -1246,8 +1233,6 @@ optional BEGIN and END only return that part of the buffer."
           (beginning-of-line)
           (let ((original-look (hyrolo-tests--outline-as-string)))
             (hyrolo-outline-show-subtree)
-            (should (string= "...\n* h-org 1...\n** h-org 1.1...\n** h-org 1.2\nbody\n*** h-org 1.2.1\nbody\n* h-org 2...\n** h-org-2.1...\n"
-                             (hyrolo-tests--outline-as-string)))
             (should (string= "** h-org 1.2\nbody\n*** h-org 1.2.1\nbody\n* h-org 2...\n** h-org-2.1...\n"
                              (hyrolo-tests--outline-as-string (point))))
             ;; Hide it again

--- a/test/hyrolo-tests.el
+++ b/test/hyrolo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    19-Jun-21 at 22:42:00
-;; Last-Mod:      5-Feb-24 at 00:04:01 by Mats Lidell
+;; Last-Mod:      8-Feb-24 at 13:57:13 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1104,7 +1104,11 @@ optional BEGIN and END only return that part of the buffer."
           (hyrolo-outline-hide-other)
           (should (string-match-p
                    (concat "^\\(===+.*[^*]\\|" (regexp-quote "...\n") "\\)"
-                           (regexp-quote "* h-org 1...\n* h-org 2...\n") "$")
+                           (regexp-quote "\
+* h-org 1...
+* h-org 2...
+"
+                                         ) "$")
                    (hyrolo-tests--outline-as-string)))
 
           ;; On first header
@@ -1113,7 +1117,11 @@ optional BEGIN and END only return that part of the buffer."
           (search-forward "* h-org 1")
           (beginning-of-line)
           (hyrolo-outline-hide-other)
-          (should (string= "* h-org 1\nbody...\n* h-org 2...\n"
+          (should (string= "\
+* h-org 1
+body...
+* h-org 2...
+"
                            (hyrolo-tests--outline-as-string (point))))
 
           ;; On second header
@@ -1122,7 +1130,11 @@ optional BEGIN and END only return that part of the buffer."
           (search-forward "** h-org 1.1")
           (beginning-of-line)
           (hyrolo-outline-hide-other)
-          (should (string= "** h-org 1.1\nbody...\n* h-org 2...\n"
+          (should (string= "\
+** h-org 1.1
+body...
+* h-org 2...
+"
                            (hyrolo-tests--outline-as-string (point)))))
       (kill-buffer hyrolo-display-buffer)
       (hy-delete-files-and-buffers hyrolo-file-list))))
@@ -1142,7 +1154,11 @@ optional BEGIN and END only return that part of the buffer."
           (should (= (point) 1))
           (should (string-match-p
                    (concat "^\\(===+.*[^*]\\|" (regexp-quote "...\n") "\\)"
-                           (regexp-quote "* h-org 1...\n* h-org 2...\n") "$")
+                           (regexp-quote "\
+* h-org 1...
+* h-org 2...
+"
+                                         ) "$")
                    (hyrolo-tests--outline-as-string)))
 
           ;; On first header
@@ -1151,7 +1167,10 @@ optional BEGIN and END only return that part of the buffer."
           (search-forward "* h-org 1")
           (beginning-of-line)
           (hyrolo-outline-hide-sublevels 1)
-          (should (string= "* h-org 1...\n* h-org 2...\n"
+          (should (string= "\
+* h-org 1...
+* h-org 2...
+"
                            (hyrolo-tests--outline-as-string (point))))
 
           ;; On second header
@@ -1160,7 +1179,10 @@ optional BEGIN and END only return that part of the buffer."
           (search-forward "** h-org 1.1")
           (beginning-of-line)
           (hyrolo-outline-hide-sublevels 1)
-          (should (string= "1...\n* h-org 2...\n"
+          (should (string= "\
+1...
+* h-org 2...
+"
                            (hyrolo-tests--outline-as-string (point))))
 
           ;; First line - 2 levels
@@ -1170,7 +1192,14 @@ optional BEGIN and END only return that part of the buffer."
           (should (= (point) 1))
           (should (string-match-p
                    (concat "^\\(===+.*[^*]\\|" (regexp-quote "...\n") "\\)"
-                           (regexp-quote "* h-org 1...\n** h-org 1.1...\n** h-org 1.2...\n* h-org 2...\n** h-org-2.1...\n") "$")
+                           (regexp-quote "\
+* h-org 1...
+** h-org 1.1...
+** h-org 1.2...
+* h-org 2...
+** h-org-2.1...
+"
+                                         ) "$")
                    (hyrolo-tests--outline-as-string)))
 
           ;; On first header - 2 levels
@@ -1179,7 +1208,13 @@ optional BEGIN and END only return that part of the buffer."
           (search-forward "* h-org 1")
           (beginning-of-line)
           (hyrolo-outline-hide-sublevels 2)
-          (should (string= "* h-org 1...\n** h-org 1.1...\n** h-org 1.2...\n* h-org 2...\n** h-org-2.1...\n"
+          (should (string= "\
+* h-org 1...
+** h-org 1.1...
+** h-org 1.2...
+* h-org 2...
+** h-org-2.1...
+"
                            (hyrolo-tests--outline-as-string (point))))
 
           ;; On second header - 2 levels
@@ -1188,7 +1223,12 @@ optional BEGIN and END only return that part of the buffer."
           (search-forward "** h-org 1.1")
           (beginning-of-line)
           (hyrolo-outline-hide-sublevels 2)
-          (should (string= "** h-org 1.1...\n** h-org 1.2...\n* h-org 2...\n** h-org-2.1...\n"
+          (should (string= "\
+** h-org 1.1...
+** h-org 1.2...
+* h-org 2...
+** h-org-2.1...
+"
                            (hyrolo-tests--outline-as-string (point)))))
       (kill-buffer hyrolo-display-buffer)
       (hy-delete-files-and-buffers hyrolo-file-list))))
@@ -1219,7 +1259,17 @@ optional BEGIN and END only return that part of the buffer."
           (beginning-of-line)
           (let ((original-look (hyrolo-tests--outline-as-string)))
             (hyrolo-outline-show-subtree)
-            (should (string= "* h-org 1\nbody\n** h-org 1.1\nbody\n** h-org 1.2\nbody\n*** h-org 1.2.1\nbody\n* h-org 2...\n"
+            (should (string= "\
+* h-org 1
+body
+** h-org 1.1
+body
+** h-org 1.2
+body
+*** h-org 1.2.1
+body
+* h-org 2...
+"
                              (hyrolo-tests--outline-as-string (point))))
             ;; Hide it again
             (hyrolo-outline-hide-subtree)
@@ -1233,7 +1283,14 @@ optional BEGIN and END only return that part of the buffer."
           (beginning-of-line)
           (let ((original-look (hyrolo-tests--outline-as-string)))
             (hyrolo-outline-show-subtree)
-            (should (string= "** h-org 1.2\nbody\n*** h-org 1.2.1\nbody\n* h-org 2...\n** h-org-2.1...\n"
+            (should (string= "\
+** h-org 1.2
+body
+*** h-org 1.2.1
+body
+* h-org 2...
+** h-org-2.1...
+"
                              (hyrolo-tests--outline-as-string (point))))
             ;; Hide it again
             (hyrolo-outline-hide-subtree)


### PR DESCRIPTION
# What

 Make hide show test accept different section headings

# Why

Different version of org-mode give different behavior on hiding of section headings. It is out of our control and the difference is not critical for the user.

# Note

Also adds expanding on the verification string for easier inspection of the desired outcome. 