### PR TITLE
Remove ad hoc flycheck warnings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2024-02-18  Mats Lidell  <matsl@gnu.org>
+
+* Fix flycheck/flymake warnings.
+
 2024-02-18  Bob Weiner  <rsw@gnu.org>
 
 * test/hyrolo-tests.el (hyrolo-demo-show-overview,

--- a/hact.el
+++ b/hact.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:      9-Jan-24 at 03:31:53 by Bob Weiner
+;; Last-Mod:     18-Feb-24 at 11:27:01 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -521,7 +521,7 @@ Return symbol created when successful, else nil."
 
 (defun    actype:doc (but &optional full)
   "Return first line of action doc for BUT.
-BUT should be a Hyperbole button symbol or an Emacs push-button.
+BUT should be a Hyperbole button symbol or an Emacs push button.
 With optional FULL, returns full documentation string.
 Return nil when no documentation."
   (let* ((is-hbut (hbut:is-p but))

--- a/hbdata.el
+++ b/hbdata.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Apr-91
-;; Last-Mod:     17-Jan-24 at 23:07:53 by Mats Lidell
+;; Last-Mod:     18-Feb-24 at 11:32:03 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -203,6 +203,7 @@ If the hbdata buffer is blank/empty, kill it and remove the associated file."
    lbl-key key-src directory))
 
 (defun hbdata:delete-entry-at-point ()
+  "Delete the hbdata entry at point."
   (delete-region (point) (progn (forward-line 1) (point))))
 
 (defun hbdata:ebut-build (&optional mod-lbl-key but-sym new-lbl-key)

--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:     12-Feb-24 at 22:12:59 by Bob Weiner
+;; Last-Mod:     18-Feb-24 at 11:37:11 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -2705,7 +2705,7 @@ For interactive creation, use `hui:ibut-create' instead."
 	(if (or (and actype-sym (fboundp actype-sym))
 		(functionp actype))
 	    (hattr:set 'hbut:current 'actype actype)
-	  (error "actype arg must be a bound symbol (not a string): %S" actype))
+	  (error "Actype arg must be a bound symbol (not a string): %S" actype))
 	(hattr:set 'hbut:current 'args args)
 	(condition-case err
 	    (ibut:operate)

--- a/hib-kbd.el
+++ b/hib-kbd.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    22-Nov-91 at 01:37:57
-;; Last-Mod:     17-Jan-24 at 23:47:04 by Mats Lidell
+;; Last-Mod:     18-Feb-24 at 11:39:41 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -260,13 +260,13 @@ With optional prefix arg FULL, display full documentation for command."
 When STR is a curly-brace {} delimited key series, a
 non-delimited, normalized form is returned, else nil.  Key
 sequences should be in human readable form, e.g. {\\`C-x' \\`C-b'}, or
-what `key-description' returns.  Forms such as {\C-b}, {\^b}, and
+what `key-description' returns.  Forms such as {\\`C-b'}, {\^b}, and
 {^M} will not be recognized.
 
 Any key sequence within the series must be a string of one of the following:
   a Hyperbole minibuffer menu item key sequence,
   a HyControl key sequence,
-  a M-x extended command,
+  a \\`M-x' extended command,
   or a valid key sequence together with its interactive arguments."
   ;; Handle long series, e.g. eval-elisp actions
   (let* ((hbut:max-len (max 3000 (hbut:max-len)))

--- a/hpath.el
+++ b/hpath.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Nov-91 at 00:44:23
-;; Last-Mod:     20-Jan-24 at 20:17:17 by Mats Lidell
+;; Last-Mod:     18-Feb-24 at 12:20:15 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -2176,12 +2176,13 @@ to it."
 
 ;;; URL Handling
 (defun hpath:find-file-urls-p ()
+  "Return t when file finding commands can handle remote urls."
   (and (boundp 'file-name-handler-alist) (hpath:remote-available-p) t))
 
-;; Partial setup which makes file finding commands recognize full and
-;; abbreviated ftp and www URLs when a remote file access library is
-;; available.
 (defun hpath:handle-urls ()
+  "Partially configure file finding commands to recognize ftp and www URLs.
+Recognizes full and abbreviated ftp and www URLs when a remote file
+access library is available."
   (let ((remote-fs-package (hpath:remote-available-p)))
     ;; www-url functions are defined in "hsys-www.el".
     (put 'expand-file-name   remote-fs-package   'www-url-expand-file-name)

--- a/hsys-org.el
+++ b/hsys-org.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Jul-16 at 14:54:14
-;; Last-Mod:     18-Feb-24 at 11:25:39 by Mats Lidell
+;; Last-Mod:     18-Feb-24 at 23:44:42 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -213,7 +213,7 @@ Return t if Org is reloaded, else nil."
 	     t)))))
 
 (defun hsys-org-get-libraries-to-reload ()
-  "Return all org libraries that needs to be reloaded to avoid mixed versions."
+  "Return all org libraries that need to be reloaded to avoid mixed versions."
   (interactive)
   (let* ((builtin-org-dir (expand-file-name "../lisp/org/" data-directory))
 	 (default-directory builtin-org-dir)

--- a/hsys-org.el
+++ b/hsys-org.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Jul-16 at 14:54:14
-;; Last-Mod:     12-Feb-24 at 22:30:23 by Bob Weiner
+;; Last-Mod:     18-Feb-24 at 11:25:39 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -66,6 +66,8 @@
 (declare-function symtable:add "hact")
 (declare-function action-key "hmouse-drv")
 (declare-function hkey-either "hmouse-drv")
+
+(declare-function find-library-name "find-func")
 
 ;;;###autoload
 (defcustom hsys-org-enable-smart-keys 'unset
@@ -211,6 +213,7 @@ Return t if Org is reloaded, else nil."
 	     t)))))
 
 (defun hsys-org-get-libraries-to-reload ()
+  "Return all org libraries that needs to be reloaded to avoid mixed versions."
   (interactive)
   (let* ((builtin-org-dir (expand-file-name "../lisp/org/" data-directory))
 	 (default-directory builtin-org-dir)
@@ -556,7 +559,7 @@ TARGET must be a string."
 ;;; ************************************************************************
 
 (defun hsys-org--set-fold-style ()
-  "Set `org-fold-core-style' to 'overlays for `reveal-mode' compatibility.
+  "Set `org-fold-core-style' to \\='overlays for `reveal-mode' compatibility.
 This must be called before Org mode is loaded."
   (when (and (ignore-errors (find-library-name "org-fold-core"))
 	     (not (boundp 'org-fold-core-style)))

--- a/hversion.el
+++ b/hversion.el
@@ -4,7 +4,7 @@
 ;; Maintainer:   Bob Weiner, Mats Lidell
 ;;
 ;; Orig-Date:     1-Jan-94
-;; Last-Mod:     19-Jan-24 at 23:13:33 by Mats Lidell
+;; Last-Mod:     18-Feb-24 at 12:32:25 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -99,7 +99,8 @@ of stack frames (from innermost to outermost)."
 
 (defun hyperb:window-sys-term (&optional frame)
   "Return first part of the term-type if running under a window system, else nil.
-Where a part in the term-type is delimited by a `-' or  an `_'."
+Where a part in the term-type is delimited by a `-' or  an `_'.
+FRAME defaults to the selected frame."
   (unless frame (setq frame (selected-frame)))
   (let* ((display-type window-system)
 	 (term (cond ((or (memq display-type '(x gtk mswindows win32 w32 ns dps pm))

--- a/hvm.el
+++ b/hvm.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    10-Oct-91 at 01:51:12
-;; Last-Mod:     14-May-23 at 01:50:19 by Bob Weiner
+;; Last-Mod:     18-Feb-24 at 12:33:39 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -392,7 +392,7 @@ Has side-effect of widening buffer."
 	  (point-max))
 	 (vm-show-current-message)
 	 (setq vm-system-state 'reading))
-	(t (error "vm search code is missing, can't continue")))))
+	(t (error "Vm search code is missing, can't continue")))))
 
 ;; Hide any Hyperbole button data when reply to or forward a message.
 ;; See "vm-reply.el".

--- a/hycontrol.el
+++ b/hycontrol.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Jun-16 at 15:35:36
-;; Last-Mod:     20-Jan-24 at 15:41:39 by Mats Lidell
+;; Last-Mod:     18-Feb-24 at 12:42:03 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -502,7 +502,7 @@ Format it with 2 arguments: `prefix-arg' and a plural string indicating if
 (defvar hycontrol--exit-status nil
   "Internal HyControl status indicator of how it was exited.
 After exit, it should be one of the following symbols triggered by the
-associated key: quit {q}, abort {C-g}, or toggle {t}.")
+associated key: quit {q}, abort {\\`C-g'}, or toggle {t}.")
 
 
 (defvar hycontrol--fconfig nil
@@ -813,7 +813,7 @@ by `hycontrol-frame-offset' (x . y) pixels."
       ('right (set-frame-position nil (+ x pixels) y)))))
 
 (defun hycontrol-numeric-keypad (e _arg)
-  "Move frame to screen location based on the last pressed numeric keypad key."
+  "Move frame to screen location based on the last pressed numeric keypad key E."
   (let ((num (if (integerp e)
 		 e
 	       ;; kp-<num> symbol
@@ -899,11 +899,10 @@ Used after selected buffer list is exhausted.")
   "Given a WINDOW, choose the next appropriate buffer to display.
 Uses `hycontrol--buffer-list'.
 
-When `hycontrol--invert-display-buffer-predicates' is non-nil and
-not \\='ignore, the list of buffers used is further filtered using
-the functions and sexpressions in
-`hycontrol-display-buffer-predicate-list', which by default
-filters a frame's buffer-list to just those buffers with attached
+When `hycontrol--invert-display-buffer-predicates' is non-nil and not
+\\='ignore, the list of buffers used is further filtered using the
+functions and sexpressions in `hycontrol-display-buffer-predicate-list',
+which by default filters a frame's buffers to just those with attached
 files.
 
 Filtering is disabled if a specific list of buffers is sent to the
@@ -959,7 +958,7 @@ to distribute among the windows."
 
 
 (defun hycontrol-message (max-msgs &rest msg-args)
-  "Log MAX-MSGS, adding MSG to the *Messages* buffer log."
+  "Log MAX-MSGS, adding MSG-ARGS to the *Messages* buffer log."
   (let ((message-log-max max-msgs))
     (apply #'message msg-args)))
 
@@ -1010,7 +1009,7 @@ is set to 1.  If it is > `hycontrol-maximum-units', it is set to
   (hycontrol-windows-mode -1))
 
 (defun hycontrol-abort ()
-  "Abort HyControl, typically on a press of {C-g}."
+  "Abort HyControl, typically on a press of {\\`C-g'}."
   (interactive)
   (hycontrol-disable-modes)
   (keyboard-quit))
@@ -1281,7 +1280,7 @@ Over 100 is set to 100.  Under 0 is set to 0.  Floats between 0 and 1
 are taken as percentages and used.  Other floats are rounded.
 non-integer arguments are ignored and the default value is used."
   (cond ((numberp arg)
-	 (cond 
+	 (cond
 	  ((= arg 0) 1)
 	  ((= arg 1) 0.5)
 	  ((and (> arg 1) (<= arg 100)) (/ arg 100.0))
@@ -1392,7 +1391,7 @@ The smallest noumber is an approximation."
   "Resize the selected frame to be approximately PERCENT of the screen.
 PERCENT may be given as a decimal percentage or a number between 0 and 100.
 Optional DIMENSION if given must be either of the symbols, height or
-width to affect only that dimension." 
+width to affect only that dimension."
   (interactive "nResize frame to be this percent of the screen (1-100): ")
   (if (and (numberp percent)
 	   (progn
@@ -1439,7 +1438,7 @@ width to affect only that dimension."
 	  (hycontrol-frame-to-bottom))
 	;; Return the scaled percentage for setting as numeric argument.
 	(floor (* percent 100)))
-    (error "(hycontrol-frame-fraction-of-screen): `%s', must be a percent value above 0 and less than or equal to 100." percent)))
+    (error "(hycontrol-frame-fraction-of-screen): `%s', must be a percent value above 0 and less than or equal to 100" percent)))
 
 (defun hycontrol-frame-height-percentage-of-screen (percent)
   "Resize the selected frame's height to be approximately PERCENT of the screen."
@@ -1616,7 +1615,7 @@ IBuffer mode or the existing frame's buffer list."
 (defun hycontrol-windows-grid (arg)
   "Display a grid of windows in the selected frame, sized to prefix ARG.
 Left digit of ARG is the number of grid rows and the right digit
-is the number of grid columns.  Use {C-h h h} to restore the
+is the number of grid columns.  Use {\\`C-h' h h} to restore the
 prior frame configuration after a grid is displayed.
 
 If ARG is 0, prompt for a major mode whose buffers should be
@@ -1647,7 +1646,7 @@ argument.
 
 If the key that invokes this command in `hyperbole-minor-mode' is also
 bound in the current major mode map, then interactively invoke that
-command instead.  Typically prevents clashes over {C-c @}."
+command instead.  Typically prevents clashes over {\\`C-c' @}."
   (interactive "P")
   (let ((numeric-arg (prefix-numeric-value current-prefix-arg)))
     (if (or (<= numeric-arg 0) (> numeric-arg 11))

--- a/hypb.el
+++ b/hypb.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     6-Oct-91 at 03:42:38
-;; Last-Mod:     18-Feb-24 at 23:46:53 by Mats Lidell
+;; Last-Mod:     18-Feb-24 at 23:50:41 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -382,7 +382,7 @@ Use optional OUT-BUF if present, else the current buffer."
 ;; Copied from eww.el, eww-decode-url-file-name, so as to not require
 ;; that package.
 (defun hypb:decode-url (url-file-name)
-  "Decode an URL-FILE-NAME."
+  "Decode a URL-FILE-NAME."
   (let* ((binary (url-unhex-string url-file-name))
          (decoded
           (decode-coding-string

--- a/hypb.el
+++ b/hypb.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     6-Oct-91 at 03:42:38
-;; Last-Mod:     18-Feb-24 at 18:01:59 by Bob Weiner
+;; Last-Mod:     18-Feb-24 at 23:46:53 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -131,7 +131,7 @@ that can be added.
 If `buffer-invisibility-spec' isn't a list before calling this
 function, `buffer-invisibility-spec' will afterwards be a list
 with the value `(t ELEMENT)'.  This means that if text exists
-that invisibility values that aren't either `t' or ELEMENT, that
+that invisibility values that aren't either t or ELEMENT, that
 text will become visible."
   (if (eq buffer-invisibility-spec t)
       (setq buffer-invisibility-spec (list t)))
@@ -379,9 +379,11 @@ Use optional OUT-BUF if present, else the current buffer."
       (load "hbut.el"))
   (setq debug-on-error t))
 
-;; Copied from eww.el so as to not require that package.
-(defun hypb:decode-url (string)
-  (let* ((binary (url-unhex-string string))
+;; Copied from eww.el, eww-decode-url-file-name, so as to not require
+;; that package.
+(defun hypb:decode-url (url-file-name)
+  "Decode an URL-FILE-NAME."
+  (let* ((binary (url-unhex-string url-file-name))
          (decoded
           (decode-coding-string
            binary
@@ -402,7 +404,7 @@ Use optional OUT-BUF if present, else the current buffer."
       ;; If we can't encode the decoded file name (due to language
       ;; environment settings), then we return the original, hexified
       ;; string.
-      string)))
+      url-file-name)))
 
 ;; Similar keyboard macro to next function, but less flexible: {C-x 1 M-o F M-o a C-x b *scratch* RET M-< M-o s C-@ C-M-h M-o t a C-u C-@ C-u C-@ M-o a C-M-p}
 
@@ -819,6 +821,7 @@ PACKAGE-NAME may be a symbol or a string."
 ;; Adapted from cl--do-remf in "cl-extra.el" but uses 'equal' for comparisons.
 ;;;###autoload
 (defun hypb:do-remove-from-plist (plist name)
+  "Remove from property list PLIST a NAME string."
   (let ((p (cdr plist)))
     ;; Can't use `plist-member' here because it goes to the cons-cell
     ;; of NAME and we need the one before.

--- a/set.el
+++ b/set.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    26-Sep-91 at 19:24:19
-;; Last-Mod:      6-Feb-23 at 20:05:30 by Mats Lidell
+;; Last-Mod:     18-Feb-24 at 12:51:49 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -77,7 +77,7 @@ Use (setq set (set:remove elt set)) to assure set is always properly modified."
 (defun set:remove-key-value (key set)
   "Remove element whose car matches KEY in SET.
 Return the set.  Use (setq set (set:remove-key-value key set)) to assure set is
-always properly modified. 
+always properly modified.
 
 Use `set:equal-op' to match against KEY.  Assume each element in the set has a
 car and a cdr."
@@ -88,7 +88,7 @@ car and a cdr."
 This includes the empty set and the SET itself.  Assume SET is a
 valid set.  With optional ARITY, return only subsets with ARITY
 members."
-  (cond ((null arity) 
+  (cond ((null arity)
 	 (setq arity 0)
 	 (cons nil (apply #'nconc (mapcar (lambda (_elt) (setq arity (1+ arity)) (set:combinations set arity))
 					 set))))
@@ -183,7 +183,7 @@ Uses `set:equal-op' for comparison.  See also `set:create'."
 (defun set:replace (old-elt new-elt set)
   "Replace OLD-ELT with NEW-ELT in SET.  Add NEW-ELT if OLD-ELT is not in SET.
 Return the set.  Use (setq set (set:replace elt set)) to assure set is
-always properly modified. 
+always properly modified.
 
 Use `set:equal-op' for element comparisons."
   (set:add new-elt (set:remove old-elt set)))
@@ -191,7 +191,7 @@ Use `set:equal-op' for element comparisons."
 (defun set:replace-key-value (key value set)
   "Replace or add element whose car matches KEY with a cdr of VALUE in SET.
 Return the set.  Use (setq set (set:replace elt set)) to assure set is
-always properly modified. 
+always properly modified.
 
 Use `set:equal-op' to match against KEY.  Assume each element in the set has a
 car and a cdr."


### PR DESCRIPTION
# What

Remove ad hoc flycheck warnings.

# Why

Just started the day with doing some cleanup of various flycheck warnings ranging from adding or fixing comments, removing white spaces...