### PR TITLE
Add git .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,8 @@
+<matsl@gnu.org> <mats.lidell@cag.se>
+<matsl@gnu.org> <matslidell@spotify.com>
+<matsl@gnu.org> <mats.lidell@lidells.se>
+Bob Weiner <rsw@gnu.org> bw <rsw@gnu.org>
+Bob Weiner <rsw@gnu.org> Robert Weiner <rsw@gnu.org>
+Bob Weiner <rsw@gnu.org> Kathy <rsw@gnu.org>
+Bob Weiner <rsw@gnu.org> Barbara Weiner <rsw@gnu.org>
+<rsw@gnu.org> <Bob.Weiner@DuffandPhelps.com>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2024-02-19  Mats Lidell  <matsl@gnu.org>
+
+* .mailmap: Add git .mailmap for mapping name and emails for commit
+    authors.
+
 2024-02-19  Bob Weiner  <rsw@gnu.org>
 
 * hyrolo.el (hyrolo-show-post-command): Add.


### PR DESCRIPTION
# What

Add git .mailmap

# Why

Git has a mailmap functionality that  maps name and email to what you want typically used to showing one identity of a user overall the his or her contributions. It can even be used to map to a name and email never used in any contributions.  

Note that this is will not change the info stored for each commit. It will change how it is displayed. 

If you want to change the stored info in the commit you would need to change the commit by rebasing and doing an amend commit. This is complicated and error prune and has to be done for all affected commits and maybe even worse. It can also possibly affect users who have pulled the master branch since it is rewriting history.

# Note

With the supplied .mailmap git log produces this result.
```
git shortlog -se | cat
   848	Bob Weiner <rsw@gnu.org>
     2	Hank Greenburg <hank.greenburg@q-ctrl.com>
   405	Mats Lidell <matsl@gnu.org>
    27	Stefan Monnier <monnier@iro.umontreal.ca>
     1	jgart <47760695+jgarte@users.noreply.github.com>
```