### PR TITLE
Do not reference README, it is removed

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2024-02-21  Mats Lidell  <matsl@gnu.org>
+
+* Makefile (HYPERBOLE_FILES): Do not require README. It has been removed.
+
 2024-02-19  Bob Weiner  <rsw@gnu.org>
 
 * hyrolo.el (hyrolo-show-post-command): Add.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,8 @@
 2024-02-21  Mats Lidell  <matsl@gnu.org>
 
 * Makefile (HYPERBOLE_FILES): Do not require README. It has been removed.
+    (website, release, git-tag-release, ftp): Add confirmation of
+    successful operation.
 
 2024-02-19  Bob Weiner  <rsw@gnu.org>
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:     21-Feb-24 at 15:26:01 by Mats Lidell
+# Last-Mod:     21-Feb-24 at 15:54:48 by Mats Lidell
 #
 # Copyright (C) 1994-2023  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -388,6 +388,7 @@ website-local: README.md.html
 # Push to public Hyperbole website
 website: website-local
 	cd $(HYPB_WEB_REPO_LOCATION) && $(CVS) commit -m "Hyperbole release $(HYPB_VERSION)"
+	@ echo "Website for Hyperbole $(HYPB_VERSION) is updated."
 
 # Generate a Hyperbole package suitable for distribution via the Emacs package manager.
 pkg: package
@@ -396,7 +397,7 @@ package: tags doc $(pkg_parent)/hyperbole-$(HYPB_VERSION).tar.sig
 # Generate and distribute a Hyperbole release to ftp.gnu.org.
 # One step in this is to generate an autoloads file for the Koutliner, kotl/kotl-autoloads.el.
 release: git-pull git-verify-no-update package $(pkg_parent)/hyperbole-$(HYPB_VERSION).tar.gz ftp website git-tag-release
-	@ echo; echo "Hyperbole $(HYPB_VERSION) released to ftp.gnu.org successfully."
+	@ echo "Hyperbole $(HYPB_VERSION) is released."
 
 # Ensure local hyperbole directory is synchronized with master before building a release.
 git-pull:
@@ -411,11 +412,13 @@ git-verify-no-update:
 git-tag-release:
 	git tag -a hyperbole-$(HYPB_VERSION) -m "Hyperbole release $(HYPB_VERSION)"
 	git push origin hyperbole-$(HYPB_VERSION)
+	@ echo "Hyperbole $(HYPB_VERSION) is tagged as hyperbole-$(HYPB_VERSION)."
 
 # Send compressed tarball for uploading to GNU ftp site; this must be done from the directory
 # containing the tarball to upload.
 ftp: package $(pkg_parent)/hyperbole-$(HYPB_VERSION).tar.gz
 	cd $(pkg_parent) && $(GNUFTP) hyperbole-$(HYPB_VERSION).tar.gz
+	@ echo "Hyperbole $(HYPB_VERSION) uploaded to ftp.gnu.org."
 
 # Autoloads
 autoloads: kotl/kotl-autoloads.el hyperbole-autoloads.el

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:     19-Feb-24 at 12:30:10 by Bob Weiner
+# Last-Mod:     21-Feb-24 at 15:26:01 by Mats Lidell
 #
 # Copyright (C) 1994-2023  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -205,7 +205,7 @@ HY-TALK  = HY-TALK/.hypb HY-TALK/HYPB HY-TALK/HY-TALK.org HY-TALK/HYPERAMP.org H
 HYPERBOLE_FILES = dir info html $(EL_SRC) $(EL_KOTL) \
 	$(HY-TALK) ChangeLog COPYING Makefile HY-ABOUT HY-ANNOUNCE \
         HY-CONCEPTS.kotl HY-NEWS \
-	HY-WHY.kotl INSTALL DEMO DEMO-ROLO.otl FAST-DEMO MANIFEST README README.md TAGS _hypb \
+	HY-WHY.kotl INSTALL DEMO DEMO-ROLO.otl FAST-DEMO MANIFEST README.md TAGS _hypb \
         .hypb smart-clib-sym topwin.py hyperbole-banner.png $(man_dir)/hkey-help.txt \
 	$(man_dir)/hyperbole.texi $(man_dir)/hyperbole.css $(man_dir)/version.texi
 
@@ -400,12 +400,12 @@ release: git-pull git-verify-no-update package $(pkg_parent)/hyperbole-$(HYPB_VE
 
 # Ensure local hyperbole directory is synchronized with master before building a release.
 git-pull:
-	echo "If this step fails check your work directory for not committed changes"
+	@ echo "If this step fails check your work directory for not committed changes"
 	git checkout master && git pull
 	git diff-index --quiet master
 
 git-verify-no-update:
-	echo "If this step fails check your work directory for updated docs and push these to savannah"
+	@ echo "If this step fails check your work directory for updated docs and push these to savannah"
 	git diff-index --quiet master
 
 git-tag-release:


### PR DESCRIPTION
# What

Do not reference README, it is removed.

# Why

README was still left in the Makefile.

# Note

`make release` should now work if working directory is in sync with master. (There are checks for that.) 

Unfortunately it is hard to test since there are a set of steps that are doing state changing operations on external system:
1. Upload to ftp.gnu.org:hyperbole (requires `gnupload`)
2. Updates the website by committing the updates (requires `cvs`)
3. Tags the release and pushes that to `savannah`. 

I have tested so far I can by commenting out the critical commands.

Added, as a separate commit, a message for each step involving external systems that confirms the step was successful. 