### PR TITLE
Cleanup test code based on flycheck warnings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2024-02-22  Mats Lidell  <matsl@gnu.org>
+
+* test/MANIFEST: Add hywconfig-test.el.
+
 2024-02-21  Mats Lidell  <matsl@gnu.org>
 
 * test/hyrolo-tests.el (hyrolo-tests--hyrolo-reveal-mode-kotl-file): Add

--- a/test/MANIFEST
+++ b/test/MANIFEST
@@ -20,6 +20,7 @@ hypb-tests.el           - tests for hypb.el utility functions
 hyperbole-tests.el      - tests for hyperbole.el
 hyrolo-tests.el         - unit tests for hyrolo.el
 kcell-tests.el          - test for kcells in Koutlines
+hywconfig-tests.el      - tests for hyperbole window configuration management
 kexport-tests.el        - test exporting Koutlines to file types
 kimport-tests.el        - test importing file types to Koutlines
 kotl-mode-tests.el      - kotl-mode-el tests

--- a/test/demo-tests.el
+++ b/test/demo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:      3-Feb-24 at 23:32:21 by Mats Lidell
+;; Last-Mod:     21-Feb-24 at 23:55:10 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -110,8 +110,8 @@
         (with-temp-buffer
           (insert "Text")
           (hkey-help)
-          (should (get-buffer help-buffer))
-      (hy-test-helpers:kill-buffer help-buffer)))))
+          (should (get-buffer help-buffer)))
+      (hy-test-helpers:kill-buffer help-buffer))))
 
 (ert-deftest demo-assist-key-help ()
   (let ((help-buffer "*Help: Hyperbole Assist Key*"))
@@ -120,8 +120,8 @@
         (with-temp-buffer
           (insert "Text")
           (hkey-help t)
-          (should (get-buffer help-buffer))
-      (hy-test-helpers:kill-buffer help-buffer)))))
+          (should (get-buffer help-buffer)))
+      (hy-test-helpers:kill-buffer help-buffer))))
 
 ;; HyControl
 (ert-deftest demo-window-grid-22-test ()
@@ -281,7 +281,7 @@
   (unwind-protect
       (progn
         (find-file (expand-file-name "MANIFEST" hyperb:dir))
-        (beginning-of-buffer)
+        (goto-char (point-min))
         (forward-line 1)
         (should (looking-at "COPYING"))
         (action-key)
@@ -463,8 +463,8 @@
           (goto-char 3)
           (action-key)
           (setq bufname (buffer-name (current-buffer)))
-          (should (string-prefix-p "subr.el" bufname))))
-    (hy-test-helpers:kill-buffer bufname)))
+          (should (string-prefix-p "subr.el" bufname)))
+      (hy-test-helpers:kill-buffer bufname))))
 
 (ert-deftest fast-demo-info-manual-references ()
   "Verify info manual references works."

--- a/test/hibtypes-tests.el
+++ b/test/hibtypes-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    20-Feb-21 at 23:45:00
-;; Last-Mod:     25-Dec-23 at 23:30:20 by Mats Lidell
+;; Last-Mod:     21-Feb-24 at 23:55:45 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -166,7 +166,7 @@
          (should (string-match "No action defined" (cadr err))))))))
 
 (ert-deftest ibtypes::pathname-dot-slash-in-same-folder-test ()
-  "Pathname that starts with ./ resolves properly when found in default-directory."
+  "Pathname that starts with ./ resolves properly when found in `default-directory'."
   (with-temp-buffer
     (insert "\"./hypb.el\"")
     (goto-char 2)

--- a/test/hmouse-drv-tests.el
+++ b/test/hmouse-drv-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    28-Feb-21 at 22:52:00
-;; Last-Mod:     26-Dec-23 at 22:44:10 by Mats Lidell
+;; Last-Mod:     21-Feb-24 at 23:55:58 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -400,7 +400,7 @@
     (hy-test-helpers:should-last-message "hy-test-dependencies.el")))
 
 (ert-deftest hbut-pathname-directory-test ()
-  "Pathname with directory opens dired."
+  "Pathname with directory opens Dired."
   (unwind-protect
       (with-temp-buffer
         (insert "\"/tmp\"")

--- a/test/hpath-tests.el
+++ b/test/hpath-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    28-Feb-21 at 23:26:00
-;; Last-Mod:     28-Dec-23 at 22:41:51 by Bob Weiner
+;; Last-Mod:     21-Feb-24 at 23:57:35 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -83,7 +83,7 @@
 
 (defun hpath--should-not-exist-p (path)
   (let ((default-directory hyperb:dir)
-	(expanded (condition-case err
+	(expanded (condition-case _err
 		      (hpath:expand path)
 		    (error path))))
     (if (not (file-exists-p expanded))
@@ -107,7 +107,7 @@
 
 (ert-deftest hpath:find-report-lisp-variable-path-name-when-not-exists ()
   "Test that `hpath:find' errors when it is non-existent."
-  (condition-case err
+  (condition-case _err
       (hpath:find "${hyperb:dir}/UNKNOWNFILE")
     (error (should t))))
 

--- a/test/hui-register-tests.el
+++ b/test/hui-register-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    10-Sep-22 at 20:43:17
-;; Last-Mod:     28-Aug-23 at 00:59:44 by Bob Weiner
+;; Last-Mod:     22-Feb-24 at 00:00:12 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -20,6 +20,7 @@
 (require 'ert)
 (require 'hmouse-drv)
 (require 'hui-register)
+(require 'hy-test-helpers "test/hy-test-helpers")
 
 (ert-deftest hui-register-test--create-register-content ()
   "Verify the struct contains its parts."

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     20-Jan-24 at 15:44:10 by Mats Lidell
+;; Last-Mod:     21-Feb-24 at 23:53:09 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -789,7 +789,7 @@ With point on label suggest that ibut for rename."
       (hy-delete-file-and-buffer fileb))))
 
 (ert-deftest hui--ibut-link-directly-to-dired ()
-  "Create a direct link to a directory in dired."
+  "Create a direct link to a directory in Dired."
   (let* ((file (make-temp-file "hypb" nil ".txt"))
          (dir hyperb:dir)
          dir-buf)

--- a/test/hy-test-helpers.el
+++ b/test/hy-test-helpers.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     20-Jan-24 at 15:44:21 by Mats Lidell
+;; Last-Mod:     21-Feb-24 at 23:47:33 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -32,7 +32,7 @@
   (let* ((possible-types (hui:link-possible-types))
 	 (first-type (caar possible-types)))
     (should (= (length possible-types) 1))
-    (should (equal (caar (hui:link-possible-types)) type))))
+    (should (equal first-type type))))
 
 (defun hy-test-helpers:should-last-message (msg)
   "Verify last message is MSG."
@@ -71,7 +71,7 @@
 
 (cl-defun hy-test-helpers-verify-hattr-at-p (&key actype args loc lbl-key name)
   "Verify the attribute of hbut at point.
-Checks ACTYPE, ARGS, LOC and LBL-KEY."
+Checks ACTYPE, ARGS, LOC, LBL-KEY and NAME."
   (let ((hbut-at-p (hbut:at-p)))
     (should (eq (hattr:get hbut-at-p 'actype) actype))
     (should (equal (hattr:get hbut-at-p 'args) args))

--- a/test/kimport-tests.el
+++ b/test/kimport-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:     9-Apr-23 at 23:31:48
-;; Last-Mod:     13-May-23 at 10:08:37 by Bob Weiner
+;; Last-Mod:     22-Feb-24 at 00:02:33 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -19,6 +19,7 @@
 
 (require 'kimport)
 (require 'ert)
+(require 'hy-test-helpers "test/hy-test-helpers")
 
 (ert-deftest kimport--aug-post-outline ()
   "Import .otl star outline as one cell per entry beginning with one or more stars."

--- a/test/kotl-mode-tests.el
+++ b/test/kotl-mode-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    18-May-21 at 22:14:10
-;; Last-Mod:      9-Oct-23 at 00:51:28 by Mats Lidell
+;; Last-Mod:     22-Feb-24 at 00:03:07 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -546,8 +546,8 @@
           (kotl-mode:transpose-cells 1)
 
           (should (string= (kcell-view:idstamp) "01"))
-          (should (looking-at-p "first"))))
-      (hy-delete-file-and-buffer kotl-file)))
+          (should (looking-at-p "first")))
+      (hy-delete-file-and-buffer kotl-file))))
 
 (ert-deftest kotl-mode-transpose-cell-with-mark ()
   "Transpose cell with cell with mark and change point to mark."


### PR DESCRIPTION
# What 

Cleanup test code based on flycheck warnings.

# Why

Did a walk through of the test code and found some issues using flycheck. Mostly minor things but there were some unwind-protect that was not written properly. The unwind forms where in some cases missing due to wrong number of parenthesis. 