### PR TITLE
Remove unused optional argument

### DIFF
--- a/hib-social.el
+++ b/hib-social.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    20-Jul-16 at 22:41:34
-;; Last-Mod:     17-Jan-24 at 23:48:46 by Mats Lidell
+;; Last-Mod:      3-Mar-24 at 10:50:02 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -686,10 +686,10 @@ Return the project directory found or nil if none."
       ;; ...and return it.
       project-dir)))
 
-(defun hibtypes-git-build-or-add-to-repos-cache (project &optional _prompt-flag)
-  "Store cache of local git repo directories in `hibtypes-git-repos-cache'.
-With optional PROMPT-FLAG non-nil, prompt user whether to build
-the cache before building.  Return t if built, nil otherwise."
+(defun hibtypes-git-build-or-add-to-repos-cache (project)
+  "Add PROJECT directory to local repo cache in `hibtypes-git-repos-cache'.
+If cache does not exist or is empty, prompt user whether to build the
+cache.  Return t if built, nil otherwise."
   (if (and (file-readable-p hibtypes-git-repos-cache)
 	   ;; Non-zero file size
 	   (not (zerop (nth 7 (file-attributes hibtypes-git-repos-cache)))))
@@ -815,7 +815,7 @@ no PROJECT value is provided, it defaults to the value of
 			    ;; out-of-date and needs to be rebuilt or added
 			    ;; to.  Prompt user and if rebuilt or added to,
 			    ;; continue.
-			    (hibtypes-git-build-or-add-to-repos-cache project t))
+			    (hibtypes-git-build-or-add-to-repos-cache project))
 		       (setq project-dir (and project (hibtypes-git-project-directory project)))
 		     (error "(git-reference): No git directory found for project `%s'" project)))
 		 (when (equal project-dir "") (setq project-dir nil))

--- a/test/hib-social-tests.el
+++ b/test/hib-social-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    20-Feb-21 at 23:24:00
-;; Last-Mod:      3-Mar-24 at 11:05:25 by Mats Lidell
+;; Last-Mod:      3-Mar-24 at 11:28:17 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -75,4 +75,13 @@
       (hy-delete-file-and-buffer hibtypes-git-repos-cache))))
 
 (provide 'hib-social-tests)
+
+;; This file can't be byte-compiled without the `el-mock' package
+;; which is not a dependency of Hyperbole.
+;;
+;; Local Variables:
+;; no-byte-compile: t
+;; End:
+
 ;;; hib-social-tests.el ends here
+

--- a/test/hib-social-tests.el
+++ b/test/hib-social-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    20-Feb-21 at 23:24:00
-;; Last-Mod:     24-Jan-22 at 00:38:39 by Bob Weiner
+;; Last-Mod:      3-Mar-24 at 11:05:25 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -20,6 +20,8 @@
 
 (require 'hib-social)
 (require 'ert)                          ;To define `should' earlier.
+(require 'el-mock)
+(require 'hy-test-helpers)
 
 ;; Hib-social
 (defun hib-social-should-browse-twitter-url (url &optional new-window)
@@ -55,6 +57,22 @@
     (let ((browse-url-browser-function 'hib-social-should-browse-github-url)
           (hibtypes-github-default-user "whatever"))
       (ibtypes::social-reference))))
+
+(ert-deftest hibtypes-repo-cache-does-not-exist-test ()
+  "Verify cache is rebuild if it does not exist."
+  (let ((hibtypes-git-repos-cache "not-existing-file"))
+    (unwind-protect
+        (mocklet (((hibtypes-git-build-repos-cache t) => t))
+          (should (hibtypes-git-build-or-add-to-repos-cache "project")))
+      (hy-delete-file-and-buffer hibtypes-git-repos-cache))))
+
+(ert-deftest hibtypes-repo-cache-exist-test ()
+  "Verify project is added if cache exist."
+  (let ((hibtypes-git-repos-cache (make-temp-file "hypb" nil "cache" "cache contents")))
+    (unwind-protect
+        (mocklet (((hibtypes-git-add-project-to-repos-cache "project") => t))
+          (should (hibtypes-git-build-or-add-to-repos-cache "project")))
+      (hy-delete-file-and-buffer hibtypes-git-repos-cache))))
 
 (provide 'hib-social-tests)
 ;;; hib-social-tests.el ends here


### PR DESCRIPTION
# What

Remove optional prompt-flag arg that is not used. Update docs. Added
tests.

# Why

Remove flycheck warning for not mentioning argument in doc string.
