### PR TITLE
Various hyrolo and ert enhancements

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 2024-03-03  Bob Weiner  <rsw@gnu.org>
 
+* hyrolo.el (hyrolo-install-markdown-mode): Centralize install of this package.
+
 * HY-NEWS: Updated with Hyperbole changes since 2024-01-07.
 
 * hyrolo.el (hyrolo-any-file-type-problem-p): Use 'nongnu' archive instead
@@ -125,11 +127,11 @@ V9.0.1 changes ^^^^:
 
 * hui-menu.el (hui-menu-explicit-buttons): Use ebut:act-label.
 
-* hbut.el (ibut:act-label, ebut:act-label): Rename ebut:act and ibut:act
+* hbut.el (ibut:act-label, ebut:act-label): Rename 'ebut:act' and 'ibut:act'
     since they take a label as arg.
-    (ebut:act, ibut:act): Add new act functions taking a hbut as
-    arg. Allow only to be called with ebut or ibut respectively. If
-    falling back on hbut:current check that it is of the same type as the
+          (ebut:act, ibut:act): Add new act functions taking an hbut as
+    an arg.  Allow calling only with an ebut or ibut respectively.  If
+    falling back on 'hbut:current', check that it is of the same type as the
     call.
 
 2024-02-08  Mats Lidell  <matsl@gnu.org>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2024-02-24  Bob Weiner  <rsw@gnu.org>
+
+* man/hyperbole.texi (HyRolo Searching): Update this section with doc
+    on auto-expansion and how to hide entries again.
+
+* MANIFEST (HYPERBOLE INTERNALS):
+  Makefile (HYPERBOLE_FILES): Add .mailmap.
+
 2024-02-22  Mats Lidell  <matsl@gnu.org>
 
 * test/MANIFEST: Add hywconfig-test.el.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 2024-03-03  Bob Weiner  <rsw@gnu.org>
 
+* HY-NEWS: Updated with Hyperbole changes since 2024-01-07.
+
 * hyrolo.el (hyrolo-any-file-type-problem-p): Use 'nongnu' archive instead
     of 'melpa' for 'markdown-mode' package.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,8 @@
 2024-03-03  Bob Weiner  <rsw@gnu.org>
 
 * hyrolo.el (hyrolo-install-markdown-mode): Centralize install of this package.
+            (hyrolo-install-markdown-mode): Add 'package-refresh-contents'
+    call so CI/CD tests pass when installing this.
 
 * HY-NEWS: Updated with Hyperbole changes since 2024-01-07.
 

--- a/FAST-DEMO
+++ b/FAST-DEMO
@@ -341,7 +341,7 @@ pspell-config(1)         - prints information about a libpspell installation
        cell clipped to 2.
 
     <ert-deftest hbut-tests-ibut-program-link-to-directory ()
-      "Programmatically create ibut link-to-directory."
+      "Test programmatically creating a link-to-directory implicit button."
       (with-temp-buffer
 	(ibut:program nil 'link-to-directory "/tmp")
 	(should (string= "\"/tmp\"" (buffer-string))))>
@@ -354,6 +354,11 @@ pspell-config(1)         - prints information about a libpspell installation
        the <> delimiters.  Start with the first one which defines an ERT
        test case; the second one runs it, displaying the result which should
        be successful.
+
+    <hyperbole-run-tests hyrolo>
+
+       The above will even run all Hyperbole regression tests for the HyRolo
+       hierarchical full-text record retriever part of Hyperbole.
 
 
 ** Many More Implicit Button Types to Learn Across Time

--- a/HY-NEWS
+++ b/HY-NEWS
@@ -94,8 +94,17 @@
       want a quick read about how Hyperbole concepts all interrelate.
       View it with {C-h h d c}.
 
-  *** Action Types: Added newer types and updated existing doc summaries
+  *** Action Types: Add newer types and updated existing doc summaries
       in the Hyperbole manual.  See "(hyperbole)Action Types".
+
+  *** Doc Viewing: Updated to display many files from the Doc> menu in Org
+      mode, so can cycle through expanding and collapsing entries with TAB
+      when point is at the beginning of the buffer, allowing you to view
+      just the sections of interest.  View minor mode is also enabled so
+      you can scroll forward and backward with SPC and DEL.
+
+      This includes DEMO, FAST-DEMO, HY-ABOUT, HY-NEWS and the Hyperbole
+      Files MANIFEST.
 
   *** Emacs 2023 Talk Videos:
 
@@ -121,10 +130,8 @@
         - Build a Zettelkasten with HyRolo: The video is at
           "https://emacsconf.org/2022/talks/rolodex/".
 
-  *** Doc Viewing: Updated to display many files from the Doc> menu in view
-      minor mode, so can expand and collapse entries to view just the
-      sections of interest.  This includes DEMO, FAST-DEMO, HY-ABOUT,
-      HY-NEWS and the Hyperbole Files MANIFEST.
+  *** FAST-DEMO: Add <hyperbole-run-tests hyrolo> ERT multiple test run
+      example.
 
   *** New Menu Key Doc: Documented these Hyperbole minibuffer menu keys:
 
@@ -143,7 +150,10 @@
 
       Some of the updates include:
 
-  **** Ibut Menu: Documented in the manual, notably the new Ibut/Create menu
+  **** HyRolo Searching: Update this section with doc on auto-expansion and
+       how to hide entries again.
+
+  **** Ibut Menu: Document in the manual, notably the new Ibut/Create menu
        item.  See "(hyperbole)menu, Ibut/Create".  For the Ibut/Link menu
        item, see "(hyperbole)menu, Ibut/Link".
 
@@ -160,6 +170,8 @@
 
   **** Smart Key - Org Mode: Expanded with doc for more extensive behavior.
        See "(hyperbole)Smart Key - Org Mode".
+
+  *** README.md: Unify this as the only readme file and remove "README".
 
 
 ** EXPLICIT BUTTONS  (See "(hyperbole)Explicit Buttons").
@@ -191,9 +203,11 @@
       buttons now works on any display capable of displaying colors.  See
       "(hyperbole)Button Colors".
 
-  *** Create Buttons in Current Buffer: Stopped prompting for a source
-      buffer when creating a Hyperbole button.  Always use the current
-      buffer and point.  See "(hyperbole)Creation".
+  *** Create Buttons in Current Buffer: Stop prompting for a source buffer
+      when creating a Hyperbole button.  Always use the current buffer and
+      point.  See "(hyperbole)Creation".
+
+  *** DuckDuckGo Web Search: {C-h h f w k} runs a DuckDuckGo web search.
 
   *** Hyperbole Keys Defer to Current Modes: Hyperbole bindings of {C-c RET},
       {C-c .}, {C-c @}, and {C-c /} defer to any major mode, like org-mode,
@@ -213,11 +227,11 @@
       of warnings for the current buffer.  See "(hyperbole)Smart Key - Flymake
       Mode" for details.
 
-  *** Interactive Org-Roam DB Consult Grep: {M-x hsys-org-roam-consult-grep
-      RET} Interactively greps org-roam files with live in-buffer display as
-      you move through matching lines.  It uses the automatically installed
-      consult-org-roam package when invoked.  See
-      "(hyperbole)hsys-org-roam-consult-grep".
+  *** Makefile (eln): Use echo target for showing build info as part of the
+      eln build.
+               (echo): Show Emacs location and version in build environment
+      info.
+               (lint): Use "package-lint" to lint Hyperbole source code. 
 
   *** mhtml-mode Markup Selection: Hyperbole's matching markup pair selection,
       copying and movement now works with Emacs' builtin mhtml-mode.  See
@@ -318,7 +332,7 @@
       buffer, rather than jumping to the start of the entry.
 
   *** New HyRolo menu items ConsultFind and HelmFind: These appear when you
-      independently load the @file{consult} or @file{helm-org-rifle} package.
+      independently load the `consult' or `helm-org-rifle' package.
       These menu items then use the related interactive search functions to
       search over the HyRolo file list.
 
@@ -398,7 +412,12 @@
   *** Path Implicit Buttons: Much improved relative path handling, including
       expanding into executable paths when pathname is prefixed by ! or &,
       and handling info paths outside `Info-directory-list', like
-      "man/hyperbole.info".
+      "man/hyperbole.info".  Also, prioritize 'load-path' and 'exec-path' above
+      'Info-directory-list' within 'hpath:variables' when expanding pathnames.
+      Remove outdated 'Info-directory' from 'hpath:variables' as well.
+
+      Automatically invoke `outline-mode' on files with ".outl" suffix;
+      previously, only ".otl" suffixes did this.
 
   *** Read-only Context Errors: Trigger errors when trying to create an
       implicit button with point on read-only text, read-only Org contexts,
@@ -542,6 +561,16 @@
   *** (hyrolo-add-match): Remove first arg, `hyrolo-matches-buffer' and
       use global `hyrolo-display-buffer' instead.
 
+  *** (hyrolo-auto-mode-alist): Add new variable to control major modes used
+       by files read in for HyRolo searches.
+
+      (hypb:major-mode-from-file-name): Rename to
+      `hyrolo-major-mode-from-file-name' and move to "hyrolo.el".  Prefix
+      `auto-mode-alist' values with those in `hyrolo-auto-mode-alist'.
+
+      (hyrolo-logic): Change call from `hyrolo-find-file' to
+      `hyrolo-find-file-noselect' to enable use of `hyrolo-auto-mode-alist'.
+
   *** hsys-org-roam.el: This library supports interactively grepping over
       org-roam files with live in-buffer display.  It uses the automatically
       installed consult package when `hsys-org-roam-consult-grep' is invoked.
@@ -645,6 +674,10 @@
   *** (smart-push-button): Added and referenced in `hkey-help' to trigger
       push-button-specific help output.
 
+  *** (smart-emacs-lisp-mode-p ,smart-lisp-mode-p): Change to use `derived-mode-p'
+      rather than checking for 'major-mode' matches directly.
+      (smart-emacs-lisp-mode-p): Add optional `skip-identifier-flag'.
+
   *** (hpath:to-markup-anchor, hpath:to-line): Updated to find matches
       outside narrowed area.
 
@@ -741,11 +774,40 @@
 
   *** (hywconfig-named-get-entries, hywconfig-named-put, hywconfig-named-get): Add.
 
+  *** (hbut:actype, ibut:type): Add for Hyperbole API use.
+      (ibut:is-type-p): Add to give both an ibut and a type for comparison and API use.
+
+  *** Add "hsys-xref.el".  Rename all Hyperbole defined 'xref-' functions to 'hsys-xref-'
+      and move here.  The xref function, 'xref--item-at-point' is redefined to handle
+      the beginning of buffer.
+
+  *** (ibut:act-label, ebut:act-label): Rename `ebut:act' and `ibut:act' since they take
+      a label as arg.
+      (ebut:act, ibut:act): Add new act functions taking an hbut as an arg.
+      (hbut:act-label): Add to match same func for ebuts and ibuts.
+
 
 ** ORG MODE INTEGRATION (See "(hyperbole)Smart Key - Org Mode").
 
+  *** Automatic Fix of Mixed Org Versions: Loading Hyperbole (via its
+      `hyperb:init' function) automatically detects and resolves the
+      hard-to-fix problem when some older builtin Org libraries are loaded
+      before a newer version of the Org package is loaded.  The fix utilizes
+      libraries exclusively from the newer Org package.  See the doc for
+      `hsys-org-fix-version'.
+
   *** Org Links Outside Org Buffers: The `org-link' actype now opens links
       found inside and outside of Org buffers.
+
+  *** Interactive Org Directory Consult Grep: {M-x hsys-org-consult-grep
+      RET} interactively greps your `org-directory' files with live in-buffer
+      display as you move through matching lines.
+
+  *** Interactive Org-Roam DB Consult Grep: {M-x hsys-org-roam-consult-grep
+      RET} interactively greps org-roam files with live in-buffer display as
+      you move through matching lines.  It uses the automatically installed
+      consult-org-roam package when invoked.  See
+      "(hyperbole)hsys-org-roam-consult-grep".
 
   *** Org and Org Roam IDs: New `org-id' implicit button type and
       `link-to-org-id-marker' action type that jump to the referent of an Org
@@ -763,9 +825,16 @@
       lookup now works in Org code blocks.  Smart Keys on Org internal
       targets now work just as they do on radio button targets.
 
+  *** HyRolo Integration with Org 9.7 and Up: Support "org-fold.el" and other
+      newer features fo Org mode.
+
   *** Todo Cycling: An Action Key press on an Org mode todo state keyword,
       cycles to the next state.  An Assist Key press in the same place cycles
       to the next set of states, if any.
+
+  *** Bobp Hyperbole Doc File Cycling: Allow for org global cycling at the start
+      of a buffer on a non-heading line within Hyperbole Doc/ files when displayed
+      from Hyperbole menu items.
 
   *** {C-c /}: The Hyperbole {C-c /} web search binding defers to the org-mode
       binding, `org-show-todo-tree', when in Org mode, but uses the improved
@@ -793,16 +862,19 @@
       etags command-line option:
          etags --regex={lisp}'/(ert-deftest[ \t]+\([^ \t\n\r\f()]+\)/' <src-files>
 
+      For the Hyperbole source code itself, you can do this via 'make tags' from
+      within the Hyperbole source directory, `hyperb:dir'.
+
   *** Run Hyperbole Tests via Make: Use the 'test' target and provide a pattern
       of test names to match like so:
 
-        make test SELECTOR=hyrolo
+        make test test=hyrolo
 
       to run just the HyRolo associated tests.
 
       To enable, full backtraces and not truncated ones, add  'FULL_BT=' at the end:
 
-        make test SELECTOR=hyrolo FULL_BT=
+        make test test=hyrolo FULL_BT=
 
   *** QA: Many quality improvements across Hyperbole and integration with
       Emacs updates with backward compatibility from Emacs 27 through Emacs

--- a/HY-NEWS
+++ b/HY-NEWS
@@ -22,11 +22,70 @@
       See "(hyperbole)Create Link Button".
 
 
+** ACTION AND ASSIST (SMART) KEYS  (See "(hyperbole)Smart Keys").
+
+  *** Angle Bracket and Braces Thing Selection:  In text and fundamental modes,
+      an Action Key press on an angle bracket or a curly brace selects the
+      region between a matching pair.  See "(hyperbole)Smart Key Thing
+      Selection".
+
+  *** Drag Button Referents to Specific Windows: Just as you previously could
+      drag Dired or Buffer Menu items to display in a specific window, you
+      can now do the same with Hyperbole Buttons.  Action or Assist Key drag
+      from a Hyperbole button and release in another window where you want
+      the button's referent (or the result of its action) displayed.  If you
+      release the Smart Key outside of an Emacs window, the referent is
+      displayed in a new frame.  See "(hyperbole)Displaying Items".
+
+      Visual pulsing of the source line and the destination buffer highlights
+      the transfer taking place (hmouse-pulse-flag controls this).
+
+      Dragging a button to a modeline splits the window of the modeline and
+      displays the referent in the leftmost or uppermost of the split windows.
+
+  *** Drag to Create Implicit Link Buttons: An Assist Mouse Key drag across
+      windows (when not starting from a draggable item) creates an implicit
+      link button with an action type determined by the referent at the point
+      of button release.  This parallels the same Action Mouse Key drag which
+      creates explicit link buttons.  See "(hyperbole)creating implicit
+      links".
+
+      Previously this drag would swap buffers in windows.  Now you must drag
+      from open space in a modeline of the depress window to the buffer text
+      in the release window to swap buffers in windows.
+
+      Alternatively, with two windows in a frame, you can create an implicit
+      link button from point to the point of the other buffer with {C-h h i l}.
+
+  *** Hyperbole Symbol Tags: Hyperbole now includes a pre-built TAGS file so
+      that an Action Key press on any Hyperbole symbol jumps to its
+      definition without the need for any additional support.  This also
+      works on Hyperbole type names (which have a hidden prefix) in a help
+      buffer where an Action Key press displays the type definition.
+
+  *** Lisp Load, Autoload and Require Expressions: Action Key press on any
+      named target in such expressions displays the associated library.
+
+  *** Lisp Action Button Help: Action Buttons that utilize regular Lisp
+      functions (rather than Hyperbole Action Types) can now have :help
+      functions run with a press of the Assist Key on such buttons.  See
+      "(hyperbole)Action Buttons".
+
+  *** Smart Dired: Action Key subdirectory selection at point now works on
+      any dired header line, not just the first one.  Use {i} to insert
+      multiple subdirectories in Dired mode.  Smart Key end-of-line behavior
+      is no longer specified in Dired mode but handled globally for
+      consistency across modes.  See "(hyperbole)Smart Key - Dired Mode".
+
+
 ** ACTION TYPES  (See "(hyperbole)Action Types").
 
   *** display-boolean, display-value, display-variable: Made all of these
       interactive, so can be used as button actypes.  See "(hyperbole)
       actypes display-boolean".
+
+  *** Long Action Buttons: The length limit on action buttons has been removed
+      to allow for long, multi-line sexpressions.
 
 
 ** DOCUMENTATION
@@ -38,10 +97,22 @@
   *** Action Types: Added newer types and updated existing doc summaries
       in the Hyperbole manual.  See "(hyperbole)Action Types".
 
+  *** Emacs 2023 Talk Videos:
+
+        - Hyperbole Amps Up Emacs: Org slide file is included in
+          "HY-TALK/HYPERAMP.org" with the video at
+          "https://emacsconf.org/2023/talks/hyperamp/".
+
+        - Koutline for Stream of Thought Journaling: The video is at
+          "https://emacsconf.org/2023/talks/koutline/".
+
+        - What I learned by writing test cases for GNU Hyperbole: The video
+          is at "https://emacsconf.org/2023/talks/test/".
+
   *** Emacs 2022 Talk Videos:
 
         - Hyperbole and Org Mode: Org slide file is included in
-          "HY-TALK/Hyperbole-and-Org-Mode.org" with the video at
+          "HY-TALK/HYPERORG.org" with the video at
           "https://emacsconf.org/2022/talks/hyperorg/".
 
         - Linking Personal Info with Implicit Buttons: The video is at
@@ -63,7 +134,7 @@
           mode; {C-h h} re-enables it.  See "(hyperbole)menu,
           entry/exit commands".
 
-  *** Extensive 150-page Reference Manual: Includes multiple indexes for easy
+  *** Updated 150-page Reference Manual: Includes multiple indexes for easy
       cross-referencing, Info viewer version and PDF for printing. View it:
 
         - with the Emacs Info reader: {C-h h d i}.
@@ -75,6 +146,9 @@
   **** Ibut Menu: Documented in the manual, notably the new Ibut/Create menu
        item.  See "(hyperbole)menu, Ibut/Create".  For the Ibut/Link menu
        item, see "(hyperbole)menu, Ibut/Link".
+
+  **** Implicit Button Types: Add doc for 'hib-python-traceback'
+       and 'hyrolo-stuck-msg'.  See "(hyperbole)Implicit Button Types".
 
   **** Link Menu Items: With two windows on screen, link from source window
        point to referent window point.  Do a similar thing when more windows
@@ -90,8 +164,8 @@
 
 ** EXPLICIT BUTTONS  (See "(hyperbole)Explicit Buttons").
 
-  *** Ebut/Link Menu Item: Inserts a named ebutton that links to point in
-      another window.  See "(hyperbole)menu item, Ebut/Link".
+  *** Ebut/Link Menu Item {C-h h e l}: Inserts a named ebutton that links to
+      point in another window.  See "(hyperbole)menu item, Ebut/Link".
 
 
 ** GLOBAL BUTTONS  (See "(hyperbole)Global Buttons").
@@ -134,6 +208,11 @@
       buttons, displaying their attributes and associated action.  See
       "(hyperbole)Smart Key help".
 
+  *** Flymake Lint Warning Display: The new "hsys-flymake" library provides
+      commands to display the flymake warning at point as well as the full list
+      of warnings for the current buffer.  See "(hyperbole)Smart Key - Flymake
+      Mode" for details.
+
   *** Interactive Org-Roam DB Consult Grep: {M-x hsys-org-roam-consult-grep
       RET} Interactively greps org-roam files with live in-buffer display as
       you move through matching lines.  It uses the automatically installed
@@ -152,7 +231,7 @@
   *** Natively Compiled Functions as Action Types: Now may be used as
       Hyperbole button action types.  See "(hyperbole)Action Types".
 
-  *** Reduced Warnings: Almost all byte-compiler and native compiler warnings
+  *** Warnings Removed: Almost all byte-compiler and native compiler warnings
       have been eliminated when building the Hyperbole package.  None of the
       remaining warnings should affect use of Hyperbole.  Most open Hyperbole
       issues have also been resolved.
@@ -165,10 +244,14 @@
 
   *** Koutline and Markdown File Support: The `hyrolo-file-list' can now
       contain Koutline or Markdown files and will search their outline entries
-      just like it does for Org and Emacs outline files.  See
-      "(hyperbole)HyRolo Concepts".
+      just like it does for Org and Emacs outline files.  The `markdown-mode'  
+      package will be auto-installed if a Markdown file is searched by HyRolo.
+      See "(hyperbole)HyRolo Concepts".
 
   *** hyrolo-file-list Support for File Wildcards, Variables and Dirs:
+
+      The `hyrolo-file-list' variable that HyRolo uses to determine the files
+      to search for pattern matches may not contain file patterns itself.
 
       If you include file wildcards in pathnames and `find-file-wildcards' is
       non-nil (the default), they will be expanded into matching files
@@ -183,8 +266,15 @@
       hyrolo list, hyrolo will search recursively across all of its files
       that match `hyrolo-file-suffix-regexp'.  See `hpath.el#hpath:expand-list'.
 
-  *** HyRolo Match Buffer Key Bindings: Improved movement keys:
+      HyRolo will display a detailed error list if any invalid file type is
+      included in the `hyrolo-file-list' after expansion.  See
+      `hyrolo-any-file-type-problem-p'.
 
+  *** *HyRolo* Match Buffer Key Bindings:
+
+        Improved movement keys:
+
+        - {TAB} Move to next search match; works across all supported file types
         - {b} Move backward at the same outline level
         - {f} Move forward at the same outline level
         - {n} Move to the next visible outline heading
@@ -192,6 +282,12 @@
   	- {u} Move up a heading level
         - {,} Move to the beginning of the current entry
         - {.} Move to the end of the current entry
+	- {[} Move to previous @loc> line of previous file header
+	- {]} Move to next     @loc> line of next file header
+
+        Improved hide/show commands now work when in file headers:
+	- {h} Hide the rest of the file header and matches after this line
+        - {s} Show all of the file header and matches
 
       See "(hyperbole)HyRolo Keys".
 
@@ -199,7 +295,7 @@
       and individual cells extracted properly with any HyRolo query.  Then the
       interactive commands:
 
-        {t} show the top-level matches
+        {t} show the top-level (highest matching level) matches
         {o} show an outline of matches
         {s} show/expand current match
         {h} hide current match
@@ -211,6 +307,16 @@
   *** Match Buffer Name Change: Changed match buffer name from "*Hyperbole
       Rolo*" to "*HyRolo*".
 
+  *** Auto-Expand Hidden Text: Whenever point moves into a hidden/invisible part
+      of the *HyRolo* buffer, the entire tree of entries below that point is
+      auto-expanded/shown.  Presently, there is no auto-hide functionality.
+      You must press {h} to hide entries or an entire file of matches when in
+      the file header.
+
+  *** Editing Entries Jumps to Current Position: The {e} command in the *HyRolo*
+      match buffer now lets you edit the current point within the entry's source
+      buffer, rather than jumping to the start of the entry.
+
   *** New HyRolo menu items ConsultFind and HelmFind: These appear when you
       independently load the @file{consult} or @file{helm-org-rifle} package.
       These menu items then use the related interactive search functions to
@@ -219,6 +325,16 @@
       ConsultFind utilizes `consult-ripgrep' or `consult-grep'.  HelmFind uses
       the helm-org-rifle package and searches over .org and .otl files
       exclusively.  See "(hyperbole)ConsultFind".
+
+  *** .otl and .outl Suffixed Files: Setup to auto-invoke `outline-mode'.
+
+  *** hyrolo-date-format Empty String: Setting this variable to an empty string
+      will disable adding and updating modification dates in HyRolo entries.
+
+  *** hyrolo-hdr-and-entry-regexp: Rename to 'hyrolo-hdr-and-entry-regexp' and
+    in 'hyrolo-mode' extend its value to include all multiple trailing whitespace
+    chars after the entry delimiter.
+      Make variable `hyrolo-entry-regexp' which does not match to file headers.
 
 
 ** IMPLICIT BUTTONS  (See "(hyperbole)Implicit Buttons").
@@ -242,19 +358,22 @@
 
   *** Emacs Regression Test Runs: New 'hyperbole-run-test-definition' implicit
       button type defined in "hypb-ert.el".  An Action Key press on the first
-      line of an ert test def and not on a grouping symbol (like a parenthesis)
-      nor at the end of a line, evaluates the definition and runs the test;
-      this ensures that the latest version is always run.  An Assist Key press
-      does likewise but runs the test with edebug, stepping through it.
+      line of an ert test definition (ert-deftest) within the test name,
+      evaluates the definition and runs the test; this ensures that the latest
+      version is always run.  An Assist Key press does likewise but runs the
+      test with edebug, stepping through it.  This also works for tests defined
+      with `ert-deftest-async' from the "ert-async" package.  See also "#Action
+      Link Types to Run Tests".
+
+      With the optional package, "ert-results", the Smart Keys can be used
+      within the ERT results buffer to filter the display and to show the
+      documentation for each test.  See "(hyperbole)Smart Key - ERT Results
+      Mode".
 
   *** Highlighting of Ibut Names: New `property:ibut-face' used to highlight
       any <[name]> prefixing an implicit button.  All hproperty functions now
       support this face as well as the `hproperty:but-face' used for explicit
       buttons.
-
-  *** Jump to Lisp Identifier Definition in More Buffers: Lisp identifiers are
-      now recognized as programming etags in the *Warnings* byte-compilation
-      buffer and in Flymake log and diagnostics buffers.
 
   *** Info Nodes: Better handling of embedded double quotes and added support
       for HTML &quot; quoting.
@@ -264,13 +383,17 @@
       Allow for unquoted filenames with spaces in them in ls listings in shell
       buffers (assume files are tab-delimited).
 
-  *** Ibut/Create Menu Item: Creates a named/labeled implicit button of any
-      type.  Separates the name and the implicit button with " - ".  See
-      "(hyperbole)menu item, Ibut/Create".
+  *** Ibut/Create Menu Item {C-h h i c}: Creates a named/labeled implicit
+      button of any type.  Separates the name and the implicit button with
+      " -  ".  See "(hyperbole)menu item, Ibut/Create".
 
-  *** Ibut/Link Menu Item - Inserts an ibutton that links to point in another
-      window.  With a C-u prefix argument, prompts for a name as well.  See
-      "(hyperbole)menu item, Ibut/Link".
+  *** Ibut/Link Menu Item {C-h h i l} - Inserts an ibutton that links to point
+      in another window.  With a C-u prefix argument, prompts for a name as
+      well.  See "(hyperbole)menu item, Ibut/Link".
+
+  *** Jump to Lisp Identifier Definition in More Buffers: Lisp identifiers are
+      now recognized as programming etags in the *Warnings* byte-compilation
+      buffer and in Flymake log and diagnostics buffers.
 
   *** Path Implicit Buttons: Much improved relative path handling, including
       expanding into executable paths when pathname is prefixed by ! or &,
@@ -401,6 +524,24 @@
       (hyrolo-helm-org-rifle-directory): Behaves similarly but searches
       over `org-directory'.
 
+  *** (hyrolo-outline-*): Add hyrolo-specific versions of all
+      `outline-minor-mode' commands to support HyRolo searches across multiple
+      file types.
+
+  *** (hyrolo-funcall-match, hyrolo-map-matches): Add these functions to
+      wrap function calls in the HyRolo display matches buffer that require the
+      original major mode of the location, e.g. outline commands.
+
+  *** (hyrolo-map-logic): Add doc for last arg, whole-buffer-flag.
+
+  *** (hyrolo-outline-minor-mode): Define and enable in `hyrolo-mode'.
+
+  *** (hyrolo-grep-file): Remove `backward-search-limit' as may miss prior
+      entry starting positions.
+  
+  *** (hyrolo-add-match): Remove first arg, `hyrolo-matches-buffer' and
+      use global `hyrolo-display-buffer' instead.
+
   *** hsys-org-roam.el: This library supports interactively grepping over
       org-roam files with live in-buffer display.  It uses the automatically
       installed consult package when `hsys-org-roam-consult-grep' is invoked.
@@ -468,9 +609,6 @@
        hyrolo-previous-match, hyrolo-isearch-for-regexp): Added support for
        use in main HyRolo file, not just the match buffer.
 
-  *** (ibut:at-p): Fixed to return nil if name and lbl-key are both nil.  Also
-      added support for <> and {} ibut delimiters.
-
   *** (hyrolo-find-file-noselect-function): Added so can customize low-level
       function used to read in each file searched by HyRolo.
 
@@ -493,6 +631,16 @@
 
   *** (hyrolo-next-regexp-match, hyrolo-next-match-function): Added to allow
       for different hyrolo entry matching functions.
+
+  *** (hyrolo-next-visible-heading): Rename to `hyrolo-outline-next-visible-heading'.
+
+  *** (ibtype:test-p, ibtype:act): Add these to mirror actype functions.
+      (ibtype:elisp-symbol): Add alias similar to existing actype one.  So
+      that (ibtype:act <ibtype-sym-or-name>) executes the ibtype action if the
+      current buffer context supports it.
+
+  *** (ibut:at-p): Fixed to return nil if name and lbl-key are both nil.  Also
+      added support for <> and {} ibut delimiters.
 
   *** (smart-push-button): Added and referenced in `hkey-help' to trigger
       push-button-specific help output.
@@ -579,11 +727,25 @@
   *** (hpath:expand-list): Add to recursively expand matching files within a list of
       directories.
 
+  *** (hypb:major-mode-from-file-name): Add for initial use in "hyrolo.el".
+
   *** (hui--ibut-link-directly-to-dired): Handle alternative dired formats with text
       after the last colon on the first
 
+  *** (hywconfig-add-by-name, hywconfig-delete-by-name, hywconfig-restore-by-name): 
+      Change all these to return a  boolean value based on whether the operation
+      succeeds or not.
+
+  *** (hywconfig-set-names): Replace with `hywconfig-named-set-entries'.
+      (hywconfig-get-names): Replace with 'hywconfig-named-get-names'.
+
+  *** (hywconfig-named-get-entries, hywconfig-named-put, hywconfig-named-get): Add.
+
 
 ** ORG MODE INTEGRATION (See "(hyperbole)Smart Key - Org Mode").
+
+  *** Org Links Outside Org Buffers: The `org-link' actype now opens links
+      found inside and outside of Org buffers.
 
   *** Org and Org Roam IDs: New `org-id' implicit button type and
       `link-to-org-id-marker' action type that jump to the referent of an Org
@@ -611,57 +773,9 @@
       to specific todo states.
 
 
-** SMART (ACTION AND ASSIST) KEYS  (See "(hyperbole)Smart Keys").
-
-  *** Drag Button Referents to Specific Windows: Just as you previously could
-      drag Dired or Buffer Menu items to display in a specific window, you
-      can now do the same with Hyperbole Buttons.  Action or Assist Key drag
-      from a Hyperbole button and release in another window where you want
-      the button's referent (or the result of its action) displayed.  If you
-      release the Smart Key outside of an Emacs window, the referent is
-      displayed in a new frame.  See "(hyperbole)Displaying Items".
-
-      Visual pulsing of the source line and the destination buffer highlights
-      the transfer taking place (hmouse-pulse-flag controls this).
-
-      Dragging a button to a modeline splits the window of the modeline and
-      displays the referent in the leftmost or uppermost of the split windows.
-
-  *** Create Implicit Link Buttons: An Assist Mouse Key drag across windows
-      (when not starting from a draggable item) creates an implicit link
-      button with an action type determined by the referent at the point of
-      button release.  This parallels the same Action Mouse Key drag which
-      creates explicit link buttons.  See "(hyperbole)creating implicit
-      links".
-
-      Previously this drag would swap buffers in windows.  Now you must drag
-      from open space in a modeline of the depress window to the buffer text
-      in the release window to swap buffers in windows.
-
-  *** Hyperbole Symbol Tags: Hyperbole now includes a pre-built TAGS file so
-      that an Action Key press on any Hyperbole symbol jumps to its
-      definition without the need for any additional support.  This also
-      works on Hyperbole type names (which have a hidden prefix) in a help
-      buffer where an Action Key press displays the type definition.
-
-  *** Lisp Load, Autoload and Require Expressions: Action Key press on any
-      named target in such expressions displays the associated library.
-
-  *** Lisp Action Button Help: Action Buttons that utilize regular Lisp
-      functions (rather than Hyperbole Action Types) can now have :help
-      functions run with a press of the Assist Key on such buttons.  See
-      "(hyperbole)Action Buttons".
-
-  *** Smart Dired: Action Key subdirectory selection at point now works on
-      any dired header line, not just the first one.  Use {i} to insert
-      multiple subdirectories in Dired mode.  Smart Key end-of-line behavior
-      is no longer specified in Dired mode but handled globally for
-      consistency across modes.  See "(hyperbole)Smart Key - Dired Mode".
-
-
 ** TEST CASES  (See "${hyperb:dir}/test").
 
-  *** Hyperbole Automated Testing: Over 330 automated test cases.  Simply run
+  *** Hyperbole Automated Testing: Over 400 automated test cases.  Simply run
       'make test-all' or 'make test' from the command-line when in the
       Hyperbole source directory and you should see all tests pass.  If any
       fail, you can press the Action Key to see the source of the failure.
@@ -678,6 +792,17 @@
       a TAGS table be built in the project root directory with the following
       etags command-line option:
          etags --regex={lisp}'/(ert-deftest[ \t]+\([^ \t\n\r\f()]+\)/' <src-files>
+
+  *** Run Hyperbole Tests via Make: Use the 'test' target and provide a pattern
+      of test names to match like so:
+
+        make test SELECTOR=hyrolo
+
+      to run just the HyRolo associated tests.
+
+      To enable, full backtraces and not truncated ones, add  'FULL_BT=' at the end:
+
+        make test SELECTOR=hyrolo FULL_BT=
 
   *** QA: Many quality improvements across Hyperbole and integration with
       Emacs updates with backward compatibility from Emacs 27 through Emacs
@@ -787,7 +912,7 @@
       source of the failure.  Full testing is supported under POSIX systems
       only.  See "Makefile" and "test/MANIFEST".
  
-  *** Implicit Button Types to Run Tests: The file "hypb-ert.el" contains two
+  *** Action Link Types to Run Tests: The file "hypb-ert.el" contains two
       action link types:
         hyperbole-run-test  - run a single Hyperbole test by name
         hyperbole-run-tests - run one more tests matching a pattern

--- a/MANIFEST
+++ b/MANIFEST
@@ -81,6 +81,7 @@ kotl/EXAMPLE.kotl    - Sample Koutline document explaining Koutliner features
 hgnus.el             - GNU Hyperbole buttons in news reader/poster: GNUS
 
 * --- HYPERBOLE INTERNALS ---
+.mailmap             - Normalize author name and email addresses
 hactypes.el          - Default action types for GNU Hyperbole
 hbdata.el            - GNU Hyperbole button attribute accessor functions
 hibtypes.el          - GNU Hyperbole default implicit button types

--- a/MANIFEST
+++ b/MANIFEST
@@ -8,7 +8,6 @@ HY-ANNOUNCE          - GNU Hyperbole release announcement
 HY-CONCEPTS.kotl     - Techncial introduction to Hyperbole concept interrelations
 HY-COPY              - GNU Hyperbole Copyright
 HY-NEWS              - What's new in each release of GNU Hyperbole
-HY-TALK.org          - Source slides and video link from the author's 2020 talk on Hyperbole
 HY-WHY.kotl          - Quick list of great reasons to use Hyperbole
 INSTALL              - GNU Hyperbole installation and invocation instructions
 Makefile             - Build GNU Hyperbole directories and distributions
@@ -26,9 +25,9 @@ man/hyperbole.info   - The GNU Hyperbole Manual  (GNU Info version)
 man/hyperbole.pdf    - The GNU Hyperbole Manual  (printable version)
 man/hyperbole.texi   - The GNU Hyperbole Manual  (GNU Texinfo source form)
 man/hkey-help.txt    - Summarizes Smart Key behaviors in different contexts
-HY-TALK/HY-TALK.org  - EmacsNYC Talk: Make Your Text Come Alive
-HY-TALK/HYPERAMP.org - EmacsConf 2023 Talk: Top 10 Ways Hyperbole Amps Up Emacs
-HY-TALK/HYPERORG.org - EmacsConf 2022 Talk: Powerful Productivity with Hyperbole and Org Mode
+HY-TALK/HY-TALK.org  - EmacsNYC 2020 Talk: Make Your Text Come Alive slides
+HY-TALK/HYPERAMP.org - EmacsConf 2023 Talk: Top 10 Ways Hyperbole Amps Up Emacs slides
+HY-TALK/HYPERORG.org - EmacsConf 2022 Talk: Powerful Productivity with Hyperbole and Org Mode slides
 
 * --- USER INTERFACE ---
 hmouse-info.el       - Walks through Info networks using one key

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:     24-Feb-24 at 10:28:47 by Bob Weiner
+# Last-Mod:     25-Feb-24 at 10:45:34 by Bob Weiner
 #
 # Copyright (C) 1994-2023  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -39,7 +39,7 @@
 #		Note: Releasing to ELPA is automatic in that the
 #		master branch on savannah is automatically synced
 #		daily by ELPA. The pkg and release targets are for
-#		making and uploading tar ball to ftp.gnu.org.
+#		making and uploading a tar ball to ftp.gnu.org.
 #
 #               To assemble a Hyperbole Emacs package for testing:
 #		     make pkg
@@ -49,6 +49,9 @@
 #
 #		Generate the website sources and upload them:
 #		    make website - generate web site in folder $(HYPB_WEB_REPO_LOCATION)"
+#
+#               Lint all Hyperbole code files:
+#                   make lint
 #
 #               To setup Hyperbole to run directly from the latest test source
 #               code, use:
@@ -530,7 +533,7 @@ install-local:
 	(cd ./install-test/ && \
 	./local-install-test.sh $(subst install-,,$@) $(shell pwd) $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null))
 
-package-lint:
+lint:
 	$(EMACS_BATCH) \
 	--eval "(setq package-lint-main-file \"hyperbole.el\")" \
 	--eval "(load-file \"test/hy-test-dependencies.el\")" \

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:     21-Feb-24 at 15:54:48 by Mats Lidell
+# Last-Mod:     24-Feb-24 at 10:28:47 by Bob Weiner
 #
 # Copyright (C) 1994-2023  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -203,7 +203,7 @@ ELC_KOTL = $(EL_KOTL:.el=.elc)
 HY-TALK  = HY-TALK/.hypb HY-TALK/HYPB HY-TALK/HY-TALK.org HY-TALK/HYPERAMP.org HY-TALK/HYPERORG.org
 
 HYPERBOLE_FILES = dir info html $(EL_SRC) $(EL_KOTL) \
-	$(HY-TALK) ChangeLog COPYING Makefile HY-ABOUT HY-ANNOUNCE \
+	$(HY-TALK) .mailmap ChangeLog COPYING Makefile HY-ABOUT HY-ANNOUNCE \
         HY-CONCEPTS.kotl HY-NEWS \
 	HY-WHY.kotl INSTALL DEMO DEMO-ROLO.otl FAST-DEMO MANIFEST README.md TAGS _hypb \
         .hypb smart-clib-sym topwin.py hyperbole-banner.png $(man_dir)/hkey-help.txt \

--- a/README.md
+++ b/README.md
@@ -499,6 +499,13 @@ default context-sensitive Hyperbole key bindings (Smart Keys).
 ## User Quotes
 
 
+  Hyperbole is a wonderful package, I love the feeling of the deep,
+  well-thought out, poised engineering.  It may be from the 90s, but it
+  feels like a breath of fresh air to me.
+
+                        -- de_sonnaz on reddit  
+
+
   \*\*\* MAN I love Hyperbole!!!  Wow! \*\*\*
 
                         -- Ken Olstad  

--- a/hui.el
+++ b/hui.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 21:42:03
-;; Last-Mod:     20-Jan-24 at 20:20:21 by Mats Lidell
+;; Last-Mod:     25-Feb-24 at 11:56:14 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1134,7 +1134,7 @@ Signal an error when no such button is found in the current buffer."
 	(hui:ibut-message t)))))
 
 (defun hui:ebut-link-directly (&optional depress-window release-window)
-  "Create a link ebutton at Action Key depress point, linked to release point.
+  "Create a link ebutton at Assist Key depress point, linked to release point.
 If an explicit button already exists at point, replace it with the new
 link button and return t; otherwise, return nil.
 
@@ -1172,10 +1172,10 @@ runs this command."
       ;; It is rarely possible that a *Warnings* buffer popup might have
       ;; displaced the button src buffer in the depress window, so switch
       ;; to it to be safe.
-      (when (and action-key-depress-buffer
-		 (not (eq (current-buffer) action-key-depress-buffer))
-		 (buffer-live-p action-key-depress-buffer))
-	(switch-to-buffer action-key-depress-buffer))
+      (when (and assist-key-depress-buffer
+		 (not (eq (current-buffer) assist-key-depress-buffer))
+		 (buffer-live-p assist-key-depress-buffer))
+	(switch-to-buffer assist-key-depress-buffer))
       (hui:buf-writable-err (current-buffer) "ebut-link-directly")
       (if (ebut:at-p)
 	  (setq edit-flag t
@@ -1232,7 +1232,7 @@ runs this command."
       edit-flag)))
 
 (defun hui:ibut-link-directly (&optional depress-window release-window name-arg-flag)
-  "Create a link ibutton at Assist Key depress point, linked to release point.
+  "Create a link ibutton at Action Key depress point, linked to release point.
 If an ibutton already exists at point, replace it with the new
 link button and return t; otherwise, return nil.
 
@@ -1277,10 +1277,10 @@ runs this command."
       ;; It is rarely possible that a *Warnings* buffer popup might have
       ;; displaced the button src buffer in the depress window, so switch
       ;; to it to be safe.
-      (when (and assist-key-depress-buffer
-		 (not (eq (current-buffer) assist-key-depress-buffer))
-		 (buffer-live-p assist-key-depress-buffer))
-	(switch-to-buffer assist-key-depress-buffer))
+      (when (and action-key-depress-buffer
+		 (not (eq (current-buffer) action-key-depress-buffer))
+		 (buffer-live-p action-key-depress-buffer))
+	(switch-to-buffer action-key-depress-buffer))
       (hui:buf-writable-err (current-buffer) "ibut-link-directly")
       (if (ibut:at-p)
 	  (setq edit-flag t

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Jun-89 at 22:08:29
-;; Last-Mod:      3-Mar-24 at 13:17:49 by Bob Weiner
+;; Last-Mod:      3-Mar-24 at 18:25:10 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -2906,6 +2906,7 @@ a default of MM/DD/YYYY."
       (setq package-archives (cl-copy-list package-archives))
       (add-to-list 'package-archives '("nongnu" . "https://elpa.nongnu.org/nongnu/")
 		   t))
+    (package-refresh-contents)
     (package-install 'markdown-mode)))
 
 (defun hyrolo-isearch-for-regexp (regexp fold-search-flag)

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Jun-89 at 22:08:29
-;; Last-Mod:     19-Feb-24 at 12:09:48 by Bob Weiner
+;; Last-Mod:      3-Mar-24 at 10:31:34 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -91,9 +91,6 @@
 (declare-function hpath:find "hpath")
 (declare-function hpath:expand-list "hpath")
 (declare-function hbut:get-key-src "hbut")
-;; This next function is replaced by `hyrolo-outline-function'
-;; within `hyrolo-cache-set-major-mode'.
-(declare-function markdown-outline-level "ext:markdown-mode")
 (declare-function org-outline-level "org")
 
 (defvar org-directory)                  ; "org.el"
@@ -125,6 +122,9 @@
 (declare-function markdown-live-preview-if-markdown "ext:markdown-mode")
 (declare-function markdown-live-preview-remove-on-kill "ext:markdown-mode")
 (declare-function markdown-make-gfm-checkboxes-buttons "ext:markdown-mode")
+;; This next function is replaced by `hyrolo-outline-function'
+;; within `hyrolo-cache-set-major-mode'.
+(declare-function markdown-outline-level "ext:markdown-mode")
 (declare-function markdown-pipe-at-bol-p "ext:markdown-mode")
 (declare-function markdown-remove-gfm-checkbox-overlays "ext:markdown-mode")
 
@@ -608,8 +608,8 @@ a parent entry which begins with the parent string."
       (when (derived-mode-p 'kotl-mode)
 	(kotl-mode:to-valid-position))
       (unless (get-text-property 0 'hyrolo-line-entry name)
-	;; Run hooks like adding a date only when not handling a
-	;; non-delimited entry.
+	;; Run hooks like adding a date only when handling a
+	;; delimited (rather than single-line) entry.
 	(run-hooks 'hyrolo-edit-hook)))))
 
 (defun hyrolo-edit-entry ()
@@ -1408,13 +1408,7 @@ matched entries."
 						(and (car (hyrolo-get-file-list))
 						     (file-name-nondirectory (car (hyrolo-get-file-list)))))
 					  (mapcar #'file-name-nondirectory
-						  (hpath:expand-list hsys-org-cycle-bob-file-list))
-					  ;; (when (boundp 'hynote-display-buffer)
-					  ;;   hynote-display-buffer)
-					  ;; (when (boundp 'hynote-file-list)
-					  ;;   (and (car hynote-file-list)
-					  ;; 	(file-name-nondirectory (car hynote-file-list))))
-					  )))
+						  (hpath:expand-list hsys-org-cycle-bob-file-list)))))
     (error "(HyRolo): Use this command in HyRolo match buffers or primary file buffers")))
 
 (defun hyrolo-widen ()
@@ -2783,19 +2777,20 @@ package is not installed."
 	files-invalid-suffix-list
 	package-archives)
 
-    ;;  2. If any `hyrolo-file-list' file has a markdown file suffix,
-    (when (delq nil (mapcar (lambda (suffix)
-			      (string-match-p (concat "\\(?:" hyrolo-markdown-suffix-regexp "\\)$")
-					      suffix))
-			    file-suffixes))
+    ;;  2. Skip this if the markdown-mode package is installed
+    (unless (package-installed-p 'markdown-mode)
+    ;;  3. If any `hyrolo-file-list' file has a markdown file suffix,
+      (when (delq nil (mapcar (lambda (suffix)
+				(string-match-p (concat "\\(?:" hyrolo-markdown-suffix-regexp "\\)$")
+						suffix))
+			      file-suffixes))
 
-      ;;  3. ensure the markdown-mode package is installed from melpa.
-      (unless (package-installed-p 'markdown-mode)
-	;;  4. if not, ensure melpa is temporarily added to package
+	;;  4. if not, ensure nongnu is temporarily added to package
 	;;     source list and then install markdown-mode.
-	(unless (assoc "melpa" package-archives)
+	(unless (assoc "nongnu" package-archives)
 	  (setq package-archives (cl-copy-list package-archives))
-	  (add-to-list 'package-archives '("melpa" . "https://melpa.org/packages/") t))
+	  (add-to-list 'package-archives '("nongnu" . "https://elpa.nongnu.org/nongnu/")
+		       t))
 	(package-install 'markdown-mode)))
 
     ;;  5. Check that each file has an entry in `hyrolo-auto-mode-alist' or `auto-mode-alist',
@@ -2916,10 +2911,12 @@ When FOLD-SEARCH-FLAG is non-nil search ignores case.  Then add
 characters to further narrow the search."
   (hyrolo-verify)
   (if (stringp regexp)
-      (progn (setq unread-command-events
-		   (append unread-command-events (string-to-list regexp)))
-	     (let ((case-fold-search fold-search-flag))
-	       (isearch-forward-regexp)))
+      (let ((case-fold-search fold-search-flag)
+	    (insert-func (lambda () (insert regexp))))
+	(unwind-protect
+	    (progn (add-hook 'minibuffer-setup-hook insert-func 100)
+		   (isearch-forward-regexp))
+	  (remove-hook 'minibuffer-setup-hook insert-func)))
     (error "(hyrolo-isearch-for-regexp): 'regexp' must be a string, not: %s" regexp)))
 
 (defun hyrolo-kill-buffer (&optional hyrolo-buf)

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Jun-89 at 22:08:29
-;; Last-Mod:      3-Mar-24 at 10:31:34 by Bob Weiner
+;; Last-Mod:      3-Mar-24 at 13:17:49 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -38,8 +38,7 @@
 (require 'hsys-org) ;; For `hsys-org-cycle-bob-file-list'
 (require 'hypb)     ;; For `hypb:mail-address-regexp' and `hypb:add-to-invisibility-spec'
 (eval-when-compile
-  `(unless (fboundp 'markdown-mode)
-     (package-install 'markdown-mode)))
+  `(hyrolo-install-markdown-mode))
 (require 'outline)
 (require 'package)
 (require 'reveal)
@@ -976,8 +975,7 @@ or NAME is invalid, return nil."
 ;;;###autoload
 (define-derived-mode hyrolo-markdown-mode text-mode "Markdown"
   "Major mode for editing Markdown files."
-  (unless (fboundp 'markdown-mode)
-    (package-install 'markdown-mode))
+  (hyrolo-install-markdown-mode)
   (require 'markdown-mode)
 
   ;; Don't actually derive from `markdown-mode' to avoid its costly setup
@@ -2787,11 +2785,7 @@ package is not installed."
 
 	;;  4. if not, ensure nongnu is temporarily added to package
 	;;     source list and then install markdown-mode.
-	(unless (assoc "nongnu" package-archives)
-	  (setq package-archives (cl-copy-list package-archives))
-	  (add-to-list 'package-archives '("nongnu" . "https://elpa.nongnu.org/nongnu/")
-		       t))
-	(package-install 'markdown-mode)))
+	(hyrolo-install-markdown-mode)))
 
     ;;  5. Check that each file has an entry in `hyrolo-auto-mode-alist' or `auto-mode-alist',
     (setq file-and-major-mode-list
@@ -2904,6 +2898,15 @@ a default of MM/DD/YYYY."
 	  (hproperty:but-add (match-beginning 0) (match-end 0)
 			     (or hyrolo-highlight-face
 				 hproperty:highlight-face)))))))
+
+(defun hyrolo-install-markdown-mode ()
+  "Install `markdown-mode' package unless already installed."
+  (unless (package-installed-p 'markdown-mode)
+    (unless (assoc "nongnu" package-archives)
+      (setq package-archives (cl-copy-list package-archives))
+      (add-to-list 'package-archives '("nongnu" . "https://elpa.nongnu.org/nongnu/")
+		   t))
+    (package-install 'markdown-mode)))
 
 (defun hyrolo-isearch-for-regexp (regexp fold-search-flag)
   "Interactively search forward for the next occurrence of REGEXP.

--- a/man/hyperbole.texi
+++ b/man/hyperbole.texi
@@ -7,7 +7,7 @@
 @c Author:       Bob Weiner
 @c
 @c Orig-Date:     6-Nov-91 at 11:18:03
-@c Last-Mod:     24-Feb-24 at 11:31:23 by Bob Weiner
+@c Last-Mod:     26-Feb-24 at 00:46:32 by Bob Weiner
 
 @c %**start of header (This is for running Texinfo on a region.)
 @setfilename hyperbole.info
@@ -156,7 +156,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.</P>
 
 <PRE>
 Edition 8.0.2pre
-Printed February 19, 2024.
+Printed February 26, 2024.
 
   Published by the Free Software Foundation, Inc.
   Author:    Bob Weiner
@@ -198,7 +198,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
 @example
 Edition 8.0.2pre
-February 19, 2024
+February 26, 2024
 
   Published by the Free Software Foundation, Inc.
   Author:    Bob Weiner
@@ -2195,15 +2195,15 @@ type, not just links.
 
 @cindex mouse drag, implicit link creation
 @cindex drag
-@cindex Assist Key drag
+@cindex Action Key drag
 Alternatively, to create an implicit link button to something
 displayed within an Emacs window (the referent), simply drag with the
-Assist (not the Action) Mouse Key depressed from an editable source
-window to another window with the desired link referent and then
-release.  The drag must start outside of a draggable item,
-@pxref{Displaying Items}.  Hyperbole will either automatically select
-the button type based on the referent context or will prompt you to
-select from one of a few possible link types.
+Action Mouse Key depressed from an editable source window to another
+window with the desired link referent and then release.  The drag must
+start outside of a draggable item, @pxref{Displaying Items}.
+Hyperbole will either automatically select the button type based on
+the referent context or will prompt you to select from one of a few
+possible link types.
 
 @cindex implicit link creation
 @cindex menu item, Ibut/Link
@@ -3539,7 +3539,8 @@ what buttons do.
 If you want to create an explicit link button to somewhere within an
 Emacs window, then simply drag with the Assist Mouse Key from an
 editable buffer (outside of a draggable item) to the target buffer.
-Note, the same Action Mouse Key drag creates an implicit button.
+Note, the same Action Mouse Key drag creates an implicit button
+instead.
 
 Alternatively, the Hyperbole minibuffer menu item, Ebut/Create, will
 create any type of explicit button, but requires a few steps.

--- a/man/hyperbole.texi
+++ b/man/hyperbole.texi
@@ -7,7 +7,7 @@
 @c Author:       Bob Weiner
 @c
 @c Orig-Date:     6-Nov-91 at 11:18:03
-@c Last-Mod:     19-Feb-24 at 12:40:29 by Bob Weiner
+@c Last-Mod:     24-Feb-24 at 11:31:23 by Bob Weiner
 
 @c %**start of header (This is for running Texinfo on a region.)
 @setfilename hyperbole.info
@@ -6279,12 +6279,14 @@ displayed.
 @cindex rolo, finding matches
 @cindex rolo, moving through matches
 If your emacs version supports textual highlighting, each search match
-is highlighted for quick, visual location.  @bkbd{@key{TAB}} moves point
-forward to successive spans of text which match the search expression.
-@bkbd{M-@key{TAB}} or @bkbd{@key{SHIFT}-@key{TAB}} move point backward
-to earlier matches.  These keys allow you to quickly find the matching
-entry of most interest to you if your search expression failed to
-narrow the matches sufficiently.
+is highlighted for quick, visual location.  @bkbd{@key{TAB}} moves
+point forward to successive spans of text which match the search
+expression.  If the matching text is hidden/invisible, it is shown;
+the body of the entry with the match, as well as all of its sub-entries
+are shown.  @bkbd{M-@key{TAB}} or @bkbd{@key{SHIFT}-@key{TAB}} move
+point backward to earlier matches.  These keys allow you to quickly
+find the matching entry of most interest to you if your search
+expression failed to narrow the matches sufficiently.
 
 @kindex rolo, M-s
 @kindex rolo, C-s
@@ -6293,20 +6295,19 @@ narrow the matches sufficiently.
 @cindex rolo, extending a match
 @cindex rolo, interactive searching
 @cindex rolo, locating a name
-If you want to extend the match expression with some more characters
-to find a particular entry, use @bkbd{M-s}.  This performs an
-interactive search forward for the match expression.  You may add to
-or delete characters from this expression to find different
-occurrences or move to the next match with @bkbd{C-s}.
-@bkbd{C-r} reverses the direction of the search.
+To extend the match expression with some more characters to find a
+particular entry, use @bkbd{M-s}.  This performs an interactive search
+forward for the match expression.  You may add to or delete characters
+from this expression to find different occurrences or move to the next
+match with @bkbd{C-s}.  @bkbd{C-r} reverses the direction of the
+search.
 
-If you would like to search for a specific entry name in the match
-buffer, use @bkbd{l} to interactively locate the text immediately
-following the entry start delimiter, typically one or more asterisks.
-This lets you find entries by last name quickly, eliminating other
-matches.  Standard string, @bkbd{C-s}, and regular expression,
-@bkbd{C-M-s}, interactive search commands are also available within
-the rolo match buffer.
+To search for a specific entry name in the match buffer, use @bkbd{l}
+to interactively locate the text immediately following the entry start
+delimiter, typically one or more asterisks.  This lets you find
+entries by last name quickly, eliminating other matches.  Standard
+string, @bkbd{C-s}, and regular expression, @bkbd{C-M-s}, interactive
+search commands are also available within the rolo match buffer.
 
 @kindex rolo, o
 @kindex rolo, t
@@ -6334,13 +6335,11 @@ file from the end of the current line forward, so you can leave parts of
 the header displayed, if desired.  Press @bkbd{a} to expand all entries
 in the buffer across all matched files.
 
-@c If an entry is collapsed/hidden, moving to any hidden part auto-expands
-@c it and then re-collapses it when point is moved to another entry (just
-@c like isearch).
-
-Please note that to facilitate further use of movement by entry commands,
-the @bkbd{h} hide entry subtree command leaves point at the beginning of
-the entry (does not apply in file headers).
+If an entry is collapsed/hidden, moving to any hidden part
+auto-expands it.  Use @bkbd{h}, the hide entry subtree to hide it
+again, if desired; this leaves point at the beginning of the entry
+(does not apply in file headers) to facilitate further use of movement
+by entry commands.
 
 @noindent
 Other keys are defined to help you work with matching entries.


### PR DESCRIPTION
2024-03-03  Bob Weiner  <rsw@gnu.org>

* hyrolo.el (hyrolo-any-file-type-problem-p): Use 'nongnu' archive instead
    of 'melpa' for 'markdown-mode' package.

2024-02-25  Bob Weiner  <rsw@gnu.org>

* FAST-DEMO: Add <hyperbole-run-tests hyrolo> ERT multiple test run example.

* hui.el (hui:ibut-link-directly): Fix doc to say 'Action Key' instead of 'Assist Key'
            and on error to go to Action Key depress buffer, not Assist one.
         (hui:ebut-link-directly): Fix doc to say 'Assist Key' instead of 'Action Key'.
            and on error to go to Assist Key depress buffer, not Action one.

2024-02-24  Bob Weiner  <rsw@gnu.org>

* Makefile (lint): Rename 'package-lint' target to 'lint' and doc in comments.

* hyrolo.el (hyrolo-isearch-for-regexp): Update to use minibuffer hook
    instead of unread-command-events since that was not working.  Including
    a newline in the regexp which 'hyrolo-hdr-and-entry-regexp' does, may
    also cause the 'hyrolo-locate' command bound to {l} to fail.

* man/hyperbole.texi (HyRolo Searching): Update this section with doc
    on auto-expansion and how to hide entries again.

* MANIFEST (HYPERBOLE INTERNALS):
  Makefile (HYPERBOLE_FILES): Add .mailmap.
