### PR TITLE
Fix *link ibtypes to not prepend type name to lbl-key.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,30 @@
+2024-03-04  Bob Weiner  <rsw@gnu.org>
+
+* hibtypes.el (elink): Change "elink_" arg to "" so button lbl-key is
+    set properly.
+              (glink): Change "glink_" arg to "" so button lbl-key is
+    set properly.
+              (ilink): Change "ilink_" arg to "" so button lbl-key is
+    set properly.
+  hactypes.el (link-to-ibut): 'hbut:current may be the prior ilink that
+    invoked this action for the ibut at point; before activating the
+    button, call 'ibut:at-p' to ensure attributes are properly set.  Fixes
+    ilink bug.
+  hbut.el (ibut:to-text): Rewrite to assume 'hbut:current has been set
+    by the caller.
+
 2024-03-03  Bob Weiner  <rsw@gnu.org>
+
+* hbut.el (hbut:act): If arg 'hbut' is given as a symbol, ensure its properties
+    are copied to 'hbut:current so subcalls can reference them.
+
+* hactypes.el (link-to-ibut): Fix to use 'ibut:to-text' instead of 'ibut:to'.
+
+* hbut.el (ibut:label-start, ibut:label-end, ibut:label-regexp,
+           ibut:label-instances-regexp, ibut:next-occurrence,
+	   ibut:previous-occurrence): Fix doc strings to refer to ibut name.
+          (ibut:label-instances-regexp): Rename to 'ibut:name-instances-regexp'.
+	  (ibut:label-regexp): Rename to 'ibut:name-regexp'.
 
 * hyrolo.el (hyrolo-install-markdown-mode): Centralize install of this package.
             (hyrolo-install-markdown-mode): Add 'package-refresh-contents'
@@ -1970,7 +1996,7 @@ V8.0.2pre changes ^^^^:
 * test/hui-register-tests.el (hui-register-test--register-val-insert-ibut): Fix this test.
 
 * hbut.el (ebut:to): Simplify so if 'lbl-key' is nil, look only for ebutton at point.
-          (ibut:to): Simplify so if 'name-key' is nil, look only for ebutton at point.
+          (ibut:to): Simplify so if 'name-key' is nil, look only for ibutton at point.
     Fix so finds any matching name-key without using attributes of hbut:current.
 
 * hsys-www.el (eww-browse-url): Remove unused '(let ((url-allow-non-local-files t))'.

--- a/HY-NEWS
+++ b/HY-NEWS
@@ -591,15 +591,18 @@
 
   *** (ibut:label-sort-instances): Sort label key instance numbers.
 
-  *** ebut:label-start, ebut:label-end: Renamed from `ebut:start' and
+  *** (ibut:label-instances-regexp): Rename to `ibut:name-instances-regexp'.
+      (ibut:label-regexp): Rename to `ibut:name-regexp'.
+
+  *** (ebut:label-start, ebut:label-end): Rename from `ebut:start' and
       `ebut:end'.
 
-  *** (hpath:delimited-possible-path): Added support for HTML &quot;
+  *** (hpath:delimited-possible-path): Add support for HTML &quot;
       quoting and embedded double quotes.
 
-  *** (hargs:read): Added support for 'i' interactive spec (ignored arg).
+  *** (hargs:read): Add support for 'i' interactive spec (ignored arg).
 
-  *** (set:replace-key-value): Renamed from `set:replace'.
+  *** (set:replace-key-value): Rename from `set:replace'.
 
       (set:replace): Now replaces a non-keyed old-value with a new value.
 

--- a/hactypes.el
+++ b/hactypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    23-Sep-91 at 20:34:36
-;; Last-Mod:     20-Jan-24 at 15:36:54 by Mats Lidell
+;; Last-Mod:      4-Mar-24 at 00:24:53 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -532,7 +532,8 @@ on the implicit button to which to link."
 	    hargs:defaults)
 	   (t
 	    (hypb:error "(link-to-ibut): Point must be on an implicit button to create a link-to-ibut")))))
-  (when (null name-key)
+
+  (unless name-key
     (hypb:error "(link-to-ibut): Point must be on an implicit button to create a link-to-ibut"))
   (let (but
 	normalized-file)
@@ -548,8 +549,9 @@ on the implicit button to which to link."
       (hmail:msg-narrow))
     (when (integerp point)
       (goto-char (min point (point-max))))
-    (setq but (ibut:to name-key))
+    (setq but (ibut:to-text name-key))
     (cond (but
+	   (setq but (ibut:at-p))
 	   (hbut:act but))
 	  (name-key
 	   (hypb:error "(link-to-ibut): No implicit button named `%s' found in `%s'"

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:      3-Mar-24 at 00:19:27 by Mats Lidell
+;; Last-Mod:      4-Mar-24 at 00:37:13 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -810,7 +810,7 @@ context of the current buffer.
 Recognizes the format '<elink:' button_label [':' button_file_path] '>',
 where : button_file_path is given only when the link is to another file,
 e.g. <elink: project-list: ~/projs>."
-  (hlink 'link-to-ebut "elink_" elink:start elink:end))
+  (hlink 'link-to-ebut "" elink:start elink:end))
 
 (defconst glink:start "<glink:"
   "String matching the start of a link to a Hyperbole global button.")
@@ -824,7 +824,7 @@ of the current buffer.
 
 Recognizes the format '<glink:' button_label '>',
 e.g. <glink: open todos>."
-  (hlink 'link-to-gbut "glink_" glink:start glink:end))
+  (hlink 'link-to-gbut "" glink:start glink:end))
 
 (defconst ilink:start "<ilink:"
   "String matching the start of a link to a Hyperbole implicit button.")
@@ -839,7 +839,7 @@ current buffer.
 Recognizes the format '<ilink:' button_label [':' button_file_path] '>',
 where button_file_path is given only when the link is to another file,
 e.g. <ilink: my series of keys: ${hyperb:dir}/HYPB>."
-  (hlink 'link-to-ibut "ilink_" ilink:start ilink:end))
+  (hlink 'link-to-ibut "" ilink:start ilink:end))
 
 ;;; ========================================================================
 ;;; Displays files at specific lines and optional column number


### PR DESCRIPTION
(ibut:label-instances-regexp): Rename to 'ibut:name-instances-regexp'.
(ibut:label-regexp): Rename to 'ibut:name-regexp'.