### PR TITLE
Pick next window from selected frame

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,11 @@
-2024-03-06  Mats Lidell  <matsl@gnu.org>
+2024-03-08  Mats Lidell  <matsl@gnu.org>
+
+* test/hmouse-drv-tests.el (hmouse-drv--hmouse-choose-link-and-referent-windows--two-windows-same-frame)
+    (hmouse-drv--hmouse-choose-link-and-referent-windows--two-windows-different-frame):
+    Add tests for choosing the windows non interactively.
 
 * hmouse-drv.el (hmouse-choose-link-and-referent-windows): Only pick next
-    window from the selected frame.
+    window from the selected frame when there are two windows in the frame.
 
 2024-03-04  Bob Weiner  <rsw@gnu.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2024-03-06  Mats Lidell  <matsl@gnu.org>
+
+* hmouse-drv.el (hmouse-choose-link-and-referent-windows): Only pick next
+    window from the selected frame.
+
 2024-03-04  Bob Weiner  <rsw@gnu.org>
 
 * hibtypes.el (elink): Change "elink_" arg to "" so button lbl-key is

--- a/hmouse-drv.el
+++ b/hmouse-drv.el
@@ -806,7 +806,7 @@ buffer to the end window.  The selected window does not change."
       (cond ((or (= (count-windows) 2)
 		 (= (hypb:count-visible-windows) 2))
 	     (setq link-but-window (selected-window)
-		   referent-window (next-window nil nil 'visible)))
+		   referent-window (next-window nil nil (selected-frame))))
 	    ((= (hypb:count-visible-windows) 1)
 	     ;; Fall through to error below
 	     )

--- a/hmouse-drv.el
+++ b/hmouse-drv.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-90
-;; Last-Mod:     20-Jan-24 at 20:15:55 by Mats Lidell
+;; Last-Mod:      8-Mar-24 at 11:06:21 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -803,10 +803,12 @@ buffer to the end window.  The selected window does not change."
 	(referent-window (and (window-live-p assist-key-release-window)
 			      assist-key-release-window)))
     (unless (and link-but-window referent-window)
-      (cond ((or (= (count-windows) 2)
-		 (= (hypb:count-visible-windows) 2))
+      (cond ((= (count-windows) 2)
 	     (setq link-but-window (selected-window)
 		   referent-window (next-window nil nil (selected-frame))))
+	    ((= (hypb:count-visible-windows) 2)
+	     (setq link-but-window (selected-window)
+		   referent-window (next-window nil nil 'visible)))
 	    ((= (hypb:count-visible-windows) 1)
 	     ;; Fall through to error below
 	     )

--- a/test/hmouse-drv-tests.el
+++ b/test/hmouse-drv-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    28-Feb-21 at 22:52:00
-;; Last-Mod:      8-Mar-24 at 12:34:17 by Mats Lidell
+;; Last-Mod:      8-Mar-24 at 16:52:52 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -589,7 +589,7 @@ Regression: Looked up path name '-narrow'."
           (split-window)
           (find-file filea)
           (let ((result (hmouse-choose-link-and-referent-windows)))
-            (should (length= result 2))
+            (should (= (length result) 2))
             (should (equal (list (get-buffer-window (get-file-buffer filea))
                                  (get-buffer-window (get-file-buffer fileb)))
                            result))))
@@ -616,7 +616,7 @@ The frame setup is mocked."
                     ((next-window nil nil 'visible) => fileb-window)
                     (count-windows => 1))
             (let ((result (hmouse-choose-link-and-referent-windows)))
-              (should (length= result 2))
+              (should (= (length result) 2))
               (should (equal (list (get-buffer-window (get-file-buffer filea))
                                    (get-buffer-window (get-file-buffer fileb)))
                              result)))))

--- a/test/hmouse-drv-tests.el
+++ b/test/hmouse-drv-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    28-Feb-21 at 22:52:00
-;; Last-Mod:     21-Feb-24 at 23:55:58 by Mats Lidell
+;; Last-Mod:      8-Mar-24 at 12:34:17 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -575,6 +575,53 @@ Regression: Looked up path name '-narrow'."
             (mock (smart-lisp-find-tag nil nil) => t)
             (action-key)))
       (hy-delete-file-and-buffer el-file))))
+
+(ert-deftest hmouse-drv--hmouse-choose-link-and-referent-windows--two-windows-same-frame ()
+  "Verify two windows in the same frame are chosen."
+  (let ((assist-key-depress-window)
+        (assist-key-release-window)
+        (filea (make-temp-file "hypb" nil ".txt"))
+        (fileb (make-temp-file "hypb" nil ".txt" "1234567890")))
+    (unwind-protect
+        (progn
+          (delete-other-windows)
+          (find-file fileb)
+          (split-window)
+          (find-file filea)
+          (let ((result (hmouse-choose-link-and-referent-windows)))
+            (should (length= result 2))
+            (should (equal (list (get-buffer-window (get-file-buffer filea))
+                                 (get-buffer-window (get-file-buffer fileb)))
+                           result))))
+      (hy-delete-file-and-buffer filea)
+      (hy-delete-file-and-buffer fileb))))
+
+
+(ert-deftest hmouse-drv--hmouse-choose-link-and-referent-windows--two-windows-different-frame ()
+  "Verify two windows in the same frame are chosen.
+The frame setup is mocked."
+  (defvar fileb-window)
+  (let ((assist-key-depress-window)
+        (assist-key-release-window)
+        (filea (make-temp-file "hypb" nil ".txt"))
+        (fileb (make-temp-file "hypb" nil ".txt" "1234567890")))
+    (unwind-protect
+        (progn
+          (delete-other-windows)
+          (find-file fileb)
+          (split-window)
+          (find-file filea)
+          (setq fileb-window (get-buffer-window (get-file-buffer fileb)))
+          (mocklet ((hypb:count-visible-windows => 2)
+                    ((next-window nil nil 'visible) => fileb-window)
+                    (count-windows => 1))
+            (let ((result (hmouse-choose-link-and-referent-windows)))
+              (should (length= result 2))
+              (should (equal (list (get-buffer-window (get-file-buffer filea))
+                                   (get-buffer-window (get-file-buffer fileb)))
+                             result)))))
+      (hy-delete-file-and-buffer filea)
+      (hy-delete-file-and-buffer fileb))))
 
 ;; This file can't be byte-compiled without the `el-mock' and
 ;; `with-simulated-input' package (because of the use of the


### PR DESCRIPTION
# What

Only pick next window from the selected frame.

# Why

I think the intent is to from a spit window situation pick one window
as the link-but-window and the other as the referent-window. In the
call to next-window we need then to limit the choices to the selected
frame.

# Note

A unit test for hmouse-choose-link-and-referent-windows would have
been appropriate but at the moment that became to complicated. The
function mixes interactive events with checking the window setup and
I'm not sure we can mock that in a good way. So for now I have put
that effort aside.

