### PR TITLE
Small fixes after release

### DIFF
--- a/HY-ANNOUNCE
+++ b/HY-ANNOUNCE
@@ -79,7 +79,7 @@ otherwise, skip to the next section.
   |--------------------------------------------------+------------------------------|
   | HyControl, fast Emacs frame and window manager   | https://youtu.be/M3-aMh1ccJk |
   |--------------------------------------------------+------------------------------|
-  | Writing test cases for GNU Hyperbole             | https:/youtu.be/maNQSKxXIzI  |
+  | Writing test cases for GNU Hyperbole             | https://youtu.be/maNQSKxXIzI |
   |--------------------------------------------------+------------------------------|
   | Find/Web Search                                  | https://youtu.be/8lMlJed0-OM |
   |--------------------------------------------------+------------------------------|

--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:      4-Mar-24 at 00:10:14 by Bob Weiner
+;; Last-Mod:     12-Mar-24 at 22:04:28 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -2851,7 +2851,7 @@ within its name or text or if LBL-KEY is a name/name-key of an
 existing implicit button.  It will not find other unnamed implicit
 buttons.
 
-The caller must have populated the attributes of 'hbut:current.
+The caller must have populated the attributes of \='hbut:current.
 
 Return the symbol for the button if found, else nil."
   (unless (stringp lbl-key)

--- a/test/demo-tests.el
+++ b/test/demo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     21-Feb-24 at 23:55:10 by Mats Lidell
+;; Last-Mod:     12-Mar-24 at 22:58:39 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -727,13 +727,6 @@ enough files with matching mode loaded."
 	  (set-process-query-on-exit-flag (get-buffer-process shell-buffer-name) nil)
 	  (hy-test-helpers:kill-buffer shell-buffer-name))))))
 
-;; This file can't be byte-compiled without the `el-mock' package (because of
-;; the use of the `with-mock' macro), which is not a dependency of Hyperbole.
-;;  Local Variables:
-;;  no-byte-compile: t
-;;  End:
-
-
 ;; Fast Demo Grep Messages, Stack Trace, Man Page Apropos
 (ert-deftest fast-demo-grep ()
   "Verify ibuts from grep searches works."
@@ -830,4 +823,12 @@ enough files with matching mode loaded."
     (hy-test-helpers:kill-buffer "EXAMPLE.kotl")))
 
 (provide 'demo-tests)
+
+;; This file can't be byte-compiled without the `el-mock' package
+;; which is not a dependency of Hyperbole.
+;;
+;; Local Variables:
+;; no-byte-compile: t
+;; End:
+
 ;;; demo-tests.el ends here

--- a/test/hsettings-test.el
+++ b/test/hsettings-test.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    20-Jan-24 at 12:28:01
-;; Last-Mod:     20-Jan-24 at 15:12:46 by Bob Weiner
+;; Last-Mod:     12-Mar-24 at 22:59:00 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -36,4 +36,12 @@
   (should (equal (hyperbole-web-search "Jump" "arg" t) '(webjump))))
 
 (provide 'hsettings-test)
+
+;; This file can't be byte-compiled without the `el-mock' package
+;; which is not a dependency of Hyperbole.
+;;
+;; Local Variables:
+;; no-byte-compile: t
+;; End:
+
 ;;; hsettings-test.el ends here

--- a/test/hsys-org-tests.el
+++ b/test/hsys-org-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    23-Apr-21 at 20:55:00
-;; Last-Mod:     27-Aug-23 at 20:40:20 by Bob Weiner
+;; Last-Mod:     12-Mar-24 at 23:04:29 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -129,4 +129,12 @@
     (should (hsys-org-face-at-p 'org-target))))
 
 (provide 'hsys-org-tests)
+
+;; This file can't be byte-compiled without the `el-mock' package
+;; which is not a dependency of Hyperbole.
+;;
+;; Local Variables:
+;; no-byte-compile: t
+;; End:
+
 ;;; hsys-org-tests.el ends here

--- a/test/hypb-ert-tests.el
+++ b/test/hypb-ert-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:     1-Jan-24 at 23:11:54
-;; Last-Mod:      6-Jan-24 at 01:34:38 by Bob Weiner
+;; Last-Mod:     12-Mar-24 at 22:59:20 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -59,4 +59,12 @@
         (hypb-ert-run-test-at-definition t)))))
 
 (provide 'hypb-ert-tests)
+
+;; This file can't be byte-compiled without the `el-mock' package
+;; which is not a dependency of Hyperbole.
+;;
+;; Local Variables:
+;; no-byte-compile: t
+;; End:
+
 ;;; hypb-ert-tests.el ends here

--- a/test/hyrolo-tests.el
+++ b/test/hyrolo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    19-Jun-21 at 22:42:00
-;; Last-Mod:      2-Mar-24 at 22:43:25 by Mats Lidell
+;; Last-Mod:     12-Mar-24 at 23:04:11 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1514,4 +1514,12 @@ body
       (hy-delete-files-and-buffers hyrolo-file-list))))
 
 (provide 'hyrolo-tests)
+
+;; This file can't be byte-compiled without the `el-mock' package
+;; which is not a dependency of Hyperbole.
+;;
+;; Local Variables:
+;; no-byte-compile: t
+;; End:
+
 ;;; hyrolo-tests.el ends here

--- a/test/kotl-mode-tests.el
+++ b/test/kotl-mode-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    18-May-21 at 22:14:10
-;; Last-Mod:     27-Feb-24 at 23:53:09 by Mats Lidell
+;; Last-Mod:     12-Mar-24 at 22:59:42 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1102,4 +1102,12 @@ marked with :ignore t")
                                         (kotl-mode-tests--func-args f)))))
 
 (provide 'kotl-mode-tests)
+
+;; This file can't be byte-compiled without the `el-mock' package
+;; which is not a dependency of Hyperbole.
+;;
+;; Local Variables:
+;; no-byte-compile: t
+;; End:
+
 ;;; kotl-mode-tests.el ends here


### PR DESCRIPTION
# What

Found a few small things after the release

 * One link is broken in the DEMO
 * A single quote causing a warning
 * I also noticed that the package manager byte compiles test files and that causes those with external dependencies to give warnings. This has been reported before but I have taken light on it since it does not show up in the local development environment. I have added no-byte-compile as buffer local setting to the affected files. This change ought to fix this.
