### PR TITLE
Add target to run make with a dockerized Emacs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2024-03-17  Mats Lidell  <matsl@gnu.org>
+
+* Makefile (dockerized): Add target to run make with a dockerized Emacs.
+
 2024-03-16  Mats Lidell  <matsl@gnu.org>
 
 * test/hbut-tests.el (hbut-tests--ibut-at-p-identifies-a-remote-pathname):

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:     10-Mar-24 at 13:02:13 by Bob Weiner
+# Last-Mod:     17-Mar-24 at 00:49:27 by Mats Lidell
 #
 # Copyright (C) 1994-2023  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -543,3 +543,23 @@ lint:
 	--eval "(hy-test-ensure-package-installed 'package-lint)" \
 	-l package-lint.el -f package-lint-batch-and-exit \
 	$(EL_KOTL) $(EL_SRC)
+
+# Run a build using a dockerized version of Emacs
+#
+# Usage:
+#   make dockerized version=28.1 targets='clean bin test'
+
+# Specify version and targets to run
+ifeq ($(origin targets), command line)
+DOCKER_TARGETS = ${targets}
+else
+DOCKER_TARGETS = clean bin test
+endif
+ifeq ($(origin version), command line)
+DOCKER_VERSION = ${version}-ci
+else
+DOCKER_VERSION = master-ci
+endif
+
+dockerized:
+	docker run -v $$(pwd):/hyperbole -it silex/emacs:${DOCKER_VERSION} bash -c cd hyperbole && make ${DOCKER_TARGETS}


### PR DESCRIPTION
# What

Add target to run make with a dockerized Emacs.

# Why

It is good to easily be a be able to test with alternative versions of
Emacs.
