### PR TITLE
Use numbers for line and column in links to org headers, add tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2024-03-23  Mats Lidell  <matsl@gnu.org>
+
+* test/hui-tests.el (hui--ibut-link-directly-to-org-header-first-column)
+    (hui--ibut-link-directly-to-org-header-second-column)
+    (hui--ibut-link-directly-to-org-body): Add tests for ibut links to org
+    mode files.
+
 2024-03-21  Mats Lidell  <matsl@gnu.org>
 
 * .github/workflows/main.yml (jobs): Ensure grep for warnings does not

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,16 @@
+2024-03-24  Mats Lidell  <matsl@gnu.org>
+
+* test/hui-tests.el (hui--ibut-link-directly-to-file)
+    (hui--ibut-link-directly-to-org-body, hui--gbut-link-directly-ibut):
+    Use L and C format for pathnames.
+
+* test/hpath-tests.el (hpath--hpath:line-and-column-regexp): Verify hpath:line-and-column-regexp.
+
+* hpath.el (hpath:section-line-and-column-regexp): Add optional line and
+    column chars, L and C, to regexp.
+    (hpath:file-position-to-line-and-column): Use L and C as standard
+    format for pathnames with line and column.
+
 2024-03-23  Mats Lidell  <matsl@gnu.org>
 
 * test/hui-tests.el (hui--ibut-link-directly-to-org-header-first-column)

--- a/hpath.el
+++ b/hpath.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Nov-91 at 00:44:23
-;; Last-Mod:     21-Mar-24 at 16:06:32 by Bob Weiner
+;; Last-Mod:     24-Mar-24 at 01:15:19 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -108,7 +108,7 @@ Posix has colon-separated and Windows has semicolon-separated
 path variable values.")
 
 (defconst hpath:section-line-and-column-regexp
-  "\\([^ \t\n\r\f:][^\t\n\r\f:]+\\(:[^0-9\t\n\r\f]*\\)*\\):\\([0-9]+\\)\\(:\\([0-9]+\\)\\)?$"
+  "\\([^ \t\n\r\f:][^\t\n\r\f:]+\\(:[^0-9\t\n\r\f]*\\)*\\):L?\\([0-9]+\\)\\(:C?\\([0-9]+\\)\\)?$"
   "Regexp that matches to a path with optional #section and :line-num:col-num.
 Grouping 1 is path, grouping 3 is line number, grouping 4 is
 column number.  Allow for \\='c:' single letter drive prefixes on
@@ -1383,8 +1383,8 @@ The path in the result is abbreviated when possible."
     (save-excursion
       (goto-char position)
       (if (zerop (current-column))
-	  (format "%s:%d" (hpath:shorten path) (line-number-at-pos (point) t))
-	(format "%s:%d:%d"
+	  (format "%s:L%d" (hpath:shorten path) (line-number-at-pos (point) t))
+	(format "%s:L%d:C%d"
 		(hpath:shorten path)
 		(line-number-at-pos (point) t)
 		(current-column))))))

--- a/hui.el
+++ b/hui.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 21:42:03
-;; Last-Mod:     21-Mar-24 at 15:30:24 by Bob Weiner
+;; Last-Mod:     23-Mar-24 at 23:52:49 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;

--- a/hui.el
+++ b/hui.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 21:42:03
-;; Last-Mod:     23-Mar-24 at 23:52:49 by Mats Lidell
+;; Last-Mod:     23-Mar-24 at 23:53:35 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;

--- a/hui.el
+++ b/hui.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 21:42:03
-;; Last-Mod:     23-Mar-24 at 23:52:49 by Mats Lidell
+;; Last-Mod:     21-Mar-24 at 15:30:24 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;

--- a/hui.el
+++ b/hui.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 21:42:03
-;; Last-Mod:     23-Mar-24 at 23:53:35 by Mats Lidell
+;; Last-Mod:     23-Mar-24 at 23:52:49 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;

--- a/test/hpath-tests.el
+++ b/test/hpath-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    28-Feb-21 at 23:26:00
-;; Last-Mod:     21-Feb-24 at 23:57:35 by Mats Lidell
+;; Last-Mod:     24-Mar-24 at 10:10:33 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -378,6 +378,18 @@
       (dolist (f (list org1-file org2-file kotl-file))
         (hy-delete-file-and-buffer f))
       (delete-directory temp-dir))))
+
+(ert-deftest hpath--hpath:line-and-column-regexp ()
+  "Verify that the regexp identifies paths with line and optional column.
+See `hpath:line-and-column-regexp'."
+  (should (string-match hpath:line-and-column-regexp "/foo/bar.org:1:2"))
+  (should (string-match hpath:line-and-column-regexp "/foo/bar.org:L1:2"))
+  (should (string-match hpath:line-and-column-regexp "/foo/bar.org:1:C2"))
+  (should (string-match hpath:line-and-column-regexp "/foo/bar.org:L1:C2"))
+  (should (string-match hpath:line-and-column-regexp "/foo/bar.org:1"))
+  (should (string-match hpath:line-and-column-regexp "/foo/bar.org:L1"))
+  (should-not (string-match hpath:line-and-column-regexp "/foo/bar.org:LL1"))
+  (should-not (string-match hpath:line-and-column-regexp "/foo/bar.org:C1")))
 
 (provide 'hpath-tests)
 ;;; hpath-tests.el ends here

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -784,7 +784,7 @@ With point on label suggest that ibut for rename."
           (find-file filea)
           (hui:ibut-link-directly (get-buffer-window)
            (get-buffer-window (get-file-buffer fileb)))
-          (should (string= (buffer-string) (concat "\"" fileb ":1:10\""))))
+          (should (string= (buffer-string) (concat "\"" fileb ":L1:C10\""))))
       (hy-delete-file-and-buffer filea)
       (hy-delete-file-and-buffer fileb))))
 
@@ -827,7 +827,7 @@ With point on label suggest that ibut for rename."
           (find-file filea)
           (with-simulated-input "label RET"
             (hui:ibut-link-directly (get-buffer-window) (get-buffer-window (get-file-buffer fileb)) 4))
-          (should (string= (buffer-string) (concat "<[label]> - " "\"" fileb ":1:10\""))))
+          (should (string= (buffer-string) (concat "<[label]> - " "\"" fileb ":L1:C10\""))))
       (hy-delete-file-and-buffer filea)
       (hy-delete-file-and-buffer fileb))))
 
@@ -890,7 +890,7 @@ With point on label suggest that ibut for rename."
           (find-file filea)
           (hui:ibut-link-directly (get-buffer-window)
                                   (get-buffer-window (get-file-buffer fileb)))
-          (should (string= (buffer-string) (concat "\"" fileb ":2\"")))
+          (should (string= (buffer-string) (concat "\"" fileb ":L2\"")))
           (goto-char (point-min))
           (search-forward ":")
           (action-key)
@@ -976,7 +976,7 @@ With point on label suggest that ibut for rename."
             (hui:gbut-link-directly t)
             (with-current-buffer (find-buffer-visiting global-but-file)
               (should (string= (buffer-string)
-                               (concat "First\n<[button]> - \"" file ":1\""))))))
+                               (concat "First\n<[button]> - \"" file ":L1\""))))))
       (hy-delete-file-and-buffer global-but-file)
       (hy-delete-file-and-buffer file))))
 

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     21-Feb-24 at 23:53:09 by Mats Lidell
+;; Last-Mod:     19-Mar-24 at 22:41:23 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -828,6 +828,59 @@ With point on label suggest that ibut for rename."
           (with-simulated-input "label RET"
             (hui:ibut-link-directly (get-buffer-window) (get-buffer-window (get-file-buffer fileb)) 4))
           (should (string= (buffer-string) (concat "<[label]> - " "\"" fileb ":1:10\""))))
+      (hy-delete-file-and-buffer filea)
+      (hy-delete-file-and-buffer fileb))))
+
+(ert-deftest hui--ibut-link-directly-to-org-header-first-column ()
+  "Create a direct link to an org file header point in first column."
+  (let ((filea (make-temp-file "hypb" nil ".txt"))
+        (fileb (make-temp-file "hypb" nil ".org" "* header\nbody\n")))
+    (unwind-protect
+        (progn
+          (delete-other-windows)
+          (find-file fileb)
+          (goto-char 1)
+          (split-window)
+          (find-file filea)
+          (hui:ibut-link-directly (get-buffer-window)
+                                  (get-buffer-window (get-file-buffer fileb)))
+          (should (string= (buffer-string) (concat "\"" fileb "#header\""))))
+      (hy-delete-file-and-buffer filea)
+      (hy-delete-file-and-buffer fileb))))
+
+(ert-deftest hui--ibut-link-directly-to-org-header-second-column ()
+  "Create a direct link to an org file header point in second column."
+  (let ((filea (make-temp-file "hypb" nil ".txt"))
+        (fileb (make-temp-file "hypb" nil ".org" "* header\nbody\n")))
+    (unwind-protect
+        (progn
+          (delete-other-windows)
+          (find-file fileb)
+          (goto-char 2)
+          (split-window)
+          (find-file filea)
+          (hui:ibut-link-directly (get-buffer-window)
+                                  (get-buffer-window (get-file-buffer fileb)))
+          (should (string= (buffer-string) (concat "\"" fileb "#header:1:1\""))))
+      (hy-delete-file-and-buffer filea)
+      (hy-delete-file-and-buffer fileb))))
+
+(ert-deftest hui--ibut-link-directly-to-org-body ()
+  "Create a direct link to an org file body."
+  (let ((filea (make-temp-file "hypb" nil ".txt"))
+        (fileb (make-temp-file "hypb" nil ".org" "* header\nbody\n")))
+    (unwind-protect
+        (progn
+          (delete-other-windows)
+          (find-file fileb)
+          (goto-char (point-min))
+          (forward-line 1)
+          (should (looking-at-p "body"))
+          (split-window)
+          (find-file filea)
+          (hui:ibut-link-directly (get-buffer-window)
+                                  (get-buffer-window (get-file-buffer fileb)))
+          (should (string= (buffer-string) (concat "\"" fileb ":2\""))))
       (hy-delete-file-and-buffer filea)
       (hy-delete-file-and-buffer fileb))))
 

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     20-Mar-24 at 21:53:36 by Mats Lidell
+;; Last-Mod:     21-Mar-24 at 17:30:27 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -866,7 +866,7 @@ With point on label suggest that ibut for rename."
           (find-file filea)
           (hui:ibut-link-directly (get-buffer-window)
                                   (get-buffer-window (get-file-buffer fileb)))
-          (should (string= (buffer-string) (concat "\"" fileb "#header:1:1\"")))
+          (should (string= (buffer-string) (concat "\"" fileb "#header:L1:C1\"")))
           (goto-char (point-min))
           (search-forward "#")
           (action-key)

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     19-Mar-24 at 22:41:23 by Mats Lidell
+;; Last-Mod:     20-Mar-24 at 21:53:36 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -844,7 +844,12 @@ With point on label suggest that ibut for rename."
           (find-file filea)
           (hui:ibut-link-directly (get-buffer-window)
                                   (get-buffer-window (get-file-buffer fileb)))
-          (should (string= (buffer-string) (concat "\"" fileb "#header\""))))
+          (should (string= (buffer-string) (concat "\"" fileb "#header\"")))
+          (goto-char (point-min))
+          (search-forward "#")
+          (action-key)
+          (should (string= (buffer-name) (file-name-nondirectory fileb)))
+          (should (= (point) 1)))
       (hy-delete-file-and-buffer filea)
       (hy-delete-file-and-buffer fileb))))
 
@@ -861,7 +866,12 @@ With point on label suggest that ibut for rename."
           (find-file filea)
           (hui:ibut-link-directly (get-buffer-window)
                                   (get-buffer-window (get-file-buffer fileb)))
-          (should (string= (buffer-string) (concat "\"" fileb "#header:1:1\""))))
+          (should (string= (buffer-string) (concat "\"" fileb "#header:1:1\"")))
+          (goto-char (point-min))
+          (search-forward "#")
+          (action-key)
+          (should (string= (buffer-name) (file-name-nondirectory fileb)))
+          (should (= (point) 2)))
       (hy-delete-file-and-buffer filea)
       (hy-delete-file-and-buffer fileb))))
 
@@ -880,7 +890,12 @@ With point on label suggest that ibut for rename."
           (find-file filea)
           (hui:ibut-link-directly (get-buffer-window)
                                   (get-buffer-window (get-file-buffer fileb)))
-          (should (string= (buffer-string) (concat "\"" fileb ":2\""))))
+          (should (string= (buffer-string) (concat "\"" fileb ":2\"")))
+          (goto-char (point-min))
+          (search-forward ":")
+          (action-key)
+          (should (string= (buffer-name) (file-name-nondirectory fileb)))
+          (should (= (line-number-at-pos) 2)))
       (hy-delete-file-and-buffer filea)
       (hy-delete-file-and-buffer fileb))))
 


### PR DESCRIPTION
# What

Use numbers for implicit links to org headers.

# Why

~Links were created with pattern file#header:L{number}:C{number} which is not identified as a link? Is is a bug? I'm surprised it passed our testing in that case but it seems I did not add any tests for this functionality.  But now it is there.~ My bad. It is an optional feature but then we could use the more standard link without the L and C. Any reason not to do that?

I noticed this while looking at #491 to figure out if link to string match would be possible to use easily.

I also added tests to document the changed behavior. A link to a header now looks file:#header:{number}:{number}.

# Note

Is there any direct way now to create a link to string match? Was thinking if we could prefer that link type if the region is active in the file to link to? Or would that be to subtle?
