### PR TITLE
Ensure grep for warnings does not fail the build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
           make bin 2>&1 | tee MAKE_BIN_OUTPUT
           echo "Number of warnings: $(grep "Warning:" MAKE_BIN_OUTPUT | wc -l)" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          grep "Warning:" MAKE_BIN_OUTPUT >> $GITHUB_STEP_SUMMARY
+          grep "Warning:" MAKE_BIN_OUTPUT >> $GITHUB_STEP_SUMMARY || true
           echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Test

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2024-03-21  Mats Lidell  <matsl@gnu.org>
+
+* .github/workflows/main.yml (jobs): Ensure grep for warnings does not
+    fail the build if there are none.
+
 2024-03-21  Bob Weiner  <rsw@gnu.org>
 
 * hpath.el (hpath:line-column-instance-regexp): Add and use in addition to


### PR DESCRIPTION
# What

Ensure grep for warnings does not fail the build

# Why

In the unlikely case, it just happend(!), if there are no warnings the
`make bin` step fails.
