### PR TITLE
First attempt to support test coverage using the testcover package

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,14 @@
 
 2024-03-31  Mats Lidell  <matsl@gnu.org>
 
+* Makefile (coverage): Make target to use the coverage function from the
+    command line.
+
+* test/hy-test-coverage.el: New test file for producing test coverage
+    data. Uses the testcover package.
+    (hy-test--count-coverage): Count the test splotches.
+    (hy-test-coverage-file): Run tests and produce coverage date.
+
 * .github/workflows/main.yml (jobs): Add Emacs 29.3 to versions used for
     the CI builds.
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:     29-Mar-24 at 23:29:53 by Mats Lidell
+# Last-Mod:     31-Mar-24 at 23:04:48 by Mats Lidell
 #
 # Copyright (C) 1994-2023  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -562,3 +562,23 @@ endif
 
 dockerized:
 	docker run -v $$(pwd):/hyperbole -it silex/emacs:${DOCKER_VERSION} bash -c cd hyperbole && make ${DOCKER_TARGETS}
+
+# Run with coverage. Run tests given by testspec and monitor the
+# coverage for the specified file.
+#
+# Usage:
+#    make coverage file=<file> testspec=<testspec>
+
+# Specify file to inspect for coverage while running tests given by testspec
+COVERAGE_FILE = ${file}
+ifeq ($(origin testspec), command line)
+COVERAGE_TESTSPEC = ${testspec}
+else
+COVERAGE_TESTSPEC = t
+endif
+coverage:
+	$(EMACS) --quick $(PRELOADS) \
+	--eval "(load-file \"test/hy-test-dependencies.el\")" \
+	--eval "(load-file \"test/hy-test-coverage.el\")" \
+	--eval "(hy-test-coverage-file \"${file}\" \"${COVERAGE_TESTSPEC}\")"
+

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:     31-Mar-24 at 23:04:48 by Mats Lidell
+# Last-Mod:     31-Mar-24 at 23:05:09 by Mats Lidell
 #
 # Copyright (C) 1994-2023  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -581,4 +581,3 @@ coverage:
 	--eval "(load-file \"test/hy-test-dependencies.el\")" \
 	--eval "(load-file \"test/hy-test-coverage.el\")" \
 	--eval "(hy-test-coverage-file \"${file}\" \"${COVERAGE_TESTSPEC}\")"
-

--- a/test/MANIFEST
+++ b/test/MANIFEST
@@ -14,6 +14,7 @@ hsys-org-tests.el       - hsys-org tests
 hui-register-tests.el   - test for hui-register
 hui-select-tests.el     - hui-select tests
 hui-tests.el            - tests for hui.el Hyperbole UI
+hy-test-coverage.el     - provide test coverage information
 hy-test-dependencies.el - Hyperbole test dependencies
 hy-test-helpers.el      - unit test helpers
 hypb-tests.el           - tests for hypb.el utility functions

--- a/test/hy-test-coverage.el
+++ b/test/hy-test-coverage.el
@@ -3,11 +3,11 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    21-Mar-24 at 13:22:27
-;; Last-Mod:     23-Mar-24 at 00:46:17 by Mats Lidell
+;; Last-Mod:     31-Mar-24 at 23:00:30 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
-;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
+;; Copyright (C) 2024  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.

--- a/test/hy-test-coverage.el
+++ b/test/hy-test-coverage.el
@@ -1,0 +1,57 @@
+;;; hy-test-coverage.el --- support for test coverage     -*- lexical-binding: t; -*-
+;;
+;; Author:       Mats Lidell
+;;
+;; Orig-Date:    21-Mar-24 at 13:22:27
+;; Last-Mod:     23-Mar-24 at 00:46:17 by Mats Lidell
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
+;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
+;; See the "HY-COPY" file for license information.
+;;
+;; This file is part of GNU Hyperbole.
+
+;;; Commentary:
+;;
+;; Uses the testcover functionality and runs the a specified test
+;; suite for a file that is monitored for coverage.  See
+;; "testcover.el" for how to interpret the "splotches", the color code
+;; characters in the monitored filed.
+;;
+;; See also "../Makefile#coverage", a make target for running from the
+;; command line.
+
+;;; Code:
+
+(require 'hypb-ert)
+(require 'testcover)
+
+(defun hy-test--count-coverage ()
+  "Count coverage splotches."
+  (cl-count-if
+   (lambda (x)
+     (string-prefix-p "testcover-" (symbol-name (overlay-get x 'face))))
+   (car (overlay-lists))))
+
+(defun hy-test-coverage-file (filename &optional testspec)
+  "Run TESTSPEC and produce coverage data for FILENAME.
+With no TESTSPEC all tests are used."
+  (interactive "fFilename: \nsTestspec: ")
+  (unless (file-exists-p filename)
+    (error "(hy-test-coverage-file) - File %s does not exist" filename))
+  (unless testspec
+    (setq testspec t))
+  (let ((buff (find-file filename)))
+    (testcover-unmark-all buff)
+    (hypb-ert-require-libraries)
+    (testcover-start filename)
+    (bury-buffer)
+    (ert testspec)
+    (testcover-mark-all buff)
+    (message "Number of splotches %d." (hy-test--count-coverage))
+    (switch-to-buffer buff)
+    (point-min)))
+
+(provide 'hy-test-coverage)
+;;; hy-test-coverage.el ends here


### PR DESCRIPTION
# What

Add new test file for producing test coverage data. Uses the testcover
package.

# Why

It is good to get some feedback how the tests are exercising the code
under test. This PR provides some convenience functions for running
code coverage interactively using the test suite or running it from
the make file.

# Note 

There seems to be some issues with stability of the tests for the
monitored file. Maybe because of the instrumentation. More experience
needs to be gathered here but it is a first attempt.
