### PR TITLE
Add Emacs 29.3 to CI builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         version: [27.2, 28.1, 28.2, 29.2, master]
-      exclude:
-        - version: 28.1
+        exclude:
+          - version: 28.1
     container: silex/emacs:${{ matrix.version }}-ci
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [27.2, 28.2, 29.2, master]
+        version: [27.2, 28.2, 29.3, master]
     container: silex/emacs:${{ matrix.version }}-ci
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [27.2, 28.1, 28.2, 29.1, master]
+        version: [27.2, 28.1, 28.2, 29.1, 29.2, master]
     container: silex/emacs:${{ matrix.version }}-ci
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         version: [27.2, 28.1, 28.2, 29.2, master]
-      exclude: 28.1
+      exclude:
+        - version: 28.1
     container: silex/emacs:${{ matrix.version }}-ci
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [27.2, 28.2, 29.2, master]
+        version: [27.2, 28.1, 28.2, 29.2, master]
+      exclude: 28.1
     container: silex/emacs:${{ matrix.version }}-ci
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [27.2, 28.1, 28.2, 29.1, 29.2, master]
+        version: [27.2, 28.2, 29.2, master]
     container: silex/emacs:${{ matrix.version }}-ci
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,9 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [27.2, 28.1, 28.2, 29.2, master]
-        exclude:
-          - version: 28.1
+        version: [27.2, 28.2, 29.2, master]
     container: silex/emacs:${{ matrix.version }}-ci
 
     steps:

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2024-03-31  Mats Lidell  <matsl@gnu.org>
 
+* .github/workflows/main.yml (jobs): Add Emacs 29.3 to versions used for
+    the CI builds.
+
 * test/hyrolo-tests.el (hyrolo-test--grep-count): Verify hyrolo match count.
 
 2024-03-31  Bob Weiner  <rsw@gnu.org>


### PR DESCRIPTION
# What

Add Emacs 29.2 to versions used for the CI builds.

# Why

Noticed when 29.3 was released that we had not included the previous
minor release in the versions we use to CI builds. 

The docker image for 29.3 is not available yet so will add that later.
