### PR TITLE
Update docs to mention L and C chars suffixes with pathnames

### DIFF
--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:      4-Mar-24 at 00:37:13 by Bob Weiner
+;; Last-Mod:     27-Mar-24 at 20:15:24 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -850,7 +850,7 @@ e.g. <ilink: my series of keys: ${hyperb:dir}/HYPB>."
   "Display path at position given by a pathname:line-num[:column-num] pattern.
 Also works for remote pathnames.
 May also contain hash-style link references with the following format:
-\"<path>[#<link-anchor>]:<line-num>[:<column-num>]}\".
+\"<path>[#<link-anchor>]:[L]<line-num>[:[C]<column-num>]}\".
 
 See `hpath:at-p' function documentation for possible delimiters.
 See `hpath:suffixes' variable documentation for suffixes that are added to or

--- a/hpath.el
+++ b/hpath.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Nov-91 at 00:44:23
-;; Last-Mod:     24-Mar-24 at 01:15:19 by Mats Lidell
+;; Last-Mod:     27-Mar-24 at 20:22:55 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -109,10 +109,11 @@ path variable values.")
 
 (defconst hpath:section-line-and-column-regexp
   "\\([^ \t\n\r\f:][^\t\n\r\f:]+\\(:[^0-9\t\n\r\f]*\\)*\\):L?\\([0-9]+\\)\\(:C?\\([0-9]+\\)\\)?$"
-  "Regexp that matches to a path with optional #section and :line-num:col-num.
-Grouping 1 is path, grouping 3 is line number, grouping 4 is
-column number.  Allow for \\='c:' single letter drive prefixes on
-MSWindows and Elisp vars with colons in them.")
+  "Regexp that matches to a path with optional #section and :line:col.
+Grouping 1 is path, grouping 3 is line number, grouping 4 is column
+number.  Allow for \\='c:' single letter drive prefixes on MSWindows and
+Elisp vars with colons in them.  Line and column can include a leading
+and optional character, L for line and C for column.")
 
 (defconst hpath:variable-regexp "\\$@?\{\\([^\}]+\\)@?\}"
   "Regexp matching variable names that Hyperbole resolves within pathnames.
@@ -1425,6 +1426,9 @@ If PATHNAME does not start with a prefix character:
   preceded by a hash-style link reference, it is relative to the location
   of the link anchor and in the case of Koutlines, relative to the indent
   of the cell;
+
+  Line and column can also include a leading and optional character, L
+  for line and C for column, e.g. \"~/.bashrc:L20:C5\".
 
   if it matches a regular expression in the alist returned by
   (hpath:get-external-display-alist), invoke the associated external

--- a/man/hyperbole.texi
+++ b/man/hyperbole.texi
@@ -7,7 +7,7 @@
 @c Author:       Bob Weiner
 @c
 @c Orig-Date:     6-Nov-91 at 11:18:03
-@c Last-Mod:     10-Mar-24 at 14:21:23 by Bob Weiner
+@c Last-Mod:     27-Mar-24 at 20:28:14 by Mats Lidell
 
 @c %**start of header (This is for running Texinfo on a region.)
 @setfilename hyperbole.info
@@ -2562,6 +2562,8 @@ Make a valid @file{pathname:line-num[:column-num]} pattern display the
 path at @emph{line-num} and optional @emph{column-num}.  Also works
 for remote pathnames.  May also contain hash-style link references
 with the following format: @file{<path>[#<link-anchor>]:<line-num>[:<column-num>]}.
+Line and column can also include a leading and optional character, L
+for line and C for column.
 
 @findex ibtypes ilink
 @cindex implicit button link


### PR DESCRIPTION
# What

Update docs to mention L and C chars.

# Why

The pathname docs focuses on only number line and column in
pathnames. But the line and column suffixes also support the L and C
char receptively. That style is also used in the generated links. So
we need to explain this better.

# Note

Was trickier than expected since line:col is used in many places and
adding optional L and C there would be verbose. So adopting the style
that pure line:col can mean with or without the characters. So just
hinting in the docstring that they are possible. In a few places they
are mention when we talk about what pattern is supported.

