### PR TITLE
Add install-melpa target for checking a melpa install

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2024-03-29  Mats Lidell  <matsl@gnu.org>
+
+* Makefile: Add install-melpa target. Used to validate hyperbole can be
+    installed from melpa.
+* install-test/melpa/.emacs: .emacs used for the melpa install test.
+
 2024-03-24  Mats Lidell  <matsl@gnu.org>
 
 * test/hui-tests.el (hui--ibut-link-directly-to-file)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:     22-Mar-24 at 08:48:26 by Bob Weiner
+# Last-Mod:     29-Mar-24 at 23:29:53 by Mats Lidell
 #
 # Copyright (C) 1994-2023  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -523,9 +523,9 @@ test-all-output:
 # Hyperbole install tests - Verify that hyperbole can be installed
 # using different sources. See folder "install-test"
 .PHONY: install-elpa install-elpa-devel install-tarball install-straight install-all install-local
-install-all: install-elpa install-elpa-devel install-tarball install-straight install-local
+install-all: install-elpa install-elpa-devel install-melpa install-tarball install-straight install-local
 
-install-elpa install-elpa-devel install-tarball install-straight install-elpaca:
+install-elpa install-elpa-devel install-tarball install-melpa install-straight install-elpaca:
 	@echo "Install Hyperbole using $@"
 	(cd ./install-test/ && ./local-install-test.sh $(subst install-,,$@))
 

--- a/install-test/melpa/.emacs
+++ b/install-test/melpa/.emacs
@@ -1,0 +1,13 @@
+;; .emacs
+
+(when (< emacs-major-version 27)
+  (error "Hyperbole requires Emacs 27 or above; you are running version %d" emacs-major-version))
+(require 'package)
+(setq package-native-compile t)
+(add-to-list 'package-archives '("melpa" . "https://melpa.org/packages/"))
+(unless (package-installed-p 'hyperbole)
+  (package-refresh-contents)
+  (package-install 'hyperbole))
+(hyperbole-mode 1)
+
+(message "%s" "Hyperbole successfully installed and activated")


### PR DESCRIPTION
# What

Add install-melpa target for checking a melpa install.

# Why

We want to be able to verify that the version of hyperbole packaged
by melpa can be installed with expected result. i.e. tests works and
Emacs can be started and Hyperbole is initialized properly.

# Note

When run on my machine there are a few test cases that fail when using `install-melpa` but none with `install-elpa` nor `install-elpa-devel`. I have not  checked why yet. Could be that we depend on some file for the tests that we did not include in the melpa recipe or something more serious. I believe this install test config is correct though.
