### PR TITLE
Verify hyrolo match count

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2024-03-31  Mats Lidell  <matsl@gnu.org>
+
+* test/hyrolo-tests.el (hyrolo-test--grep-count): Verify hyrolo match count.
+
 2024-03-31  Bob Weiner  <rsw@gnu.org>
 
 * hyrolo.el (hyrolo-grep-file): Remove this line that was skipping past the

--- a/test/hyrolo-tests.el
+++ b/test/hyrolo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    19-Jun-21 at 22:42:00
-;; Last-Mod:     30-Mar-24 at 23:35:15 by Mats Lidell
+;; Last-Mod:     31-Mar-24 at 11:36:33 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1635,7 +1635,7 @@ body
       (hy-delete-files-and-buffers hyrolo-file-list))))
 
 (ert-deftest hyrolo-test--grep-count ()
-  "Verify number of matches are correct."
+  "Verify number of matched entries are correct."
   :expected-result :failed
   (unwind-protect
       (with-temp-buffer
@@ -1643,12 +1643,22 @@ body
         (insert "\
 * match
 match
+* match
+other
 * other
 match
 ")
+        ;; Count number of entries that have a match
         (should (= (hyrolo-grep "match" nil (current-buffer) t nil) 3))
-        (should (= (hyrolo-grep "match" nil (current-buffer) t t) 1)))
-    (kill-buffer hyrolo-display-buffer)))
+        ;; Count number of entries that only match on the first line
+        (should (= (hyrolo-grep "match" nil (current-buffer) t t) 2))
+        ;; Count number of entries that match but not on the first line
+        (should (= (hyrolo-grep "match" t (current-buffer) t nil) 2))
+        ;; Nothing if there is no match
+        (should (= (hyrolo-grep "nothing" nil (current-buffer) t nil) 0)))
+    (and (get-buffer hyrolo-display-buffer)
+         (kill-buffer hyrolo-display-buffer)
+         (ert-fail "Buffer %s should not have been created" hyrolo-display-buffer))))
 
 (provide 'hyrolo-tests)
 

--- a/test/hyrolo-tests.el
+++ b/test/hyrolo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    19-Jun-21 at 22:42:00
-;; Last-Mod:     22-Mar-24 at 08:37:53 by Bob Weiner
+;; Last-Mod:     30-Mar-24 at 23:35:15 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1633,6 +1633,22 @@ body
 "                           )))
       (kill-buffer hyrolo-display-buffer)
       (hy-delete-files-and-buffers hyrolo-file-list))))
+
+(ert-deftest hyrolo-test--grep-count ()
+  "Verify number of matches are correct."
+  :expected-result :failed
+  (unwind-protect
+      (with-temp-buffer
+        (org-mode)
+        (insert "\
+* match
+match
+* other
+match
+")
+        (should (= (hyrolo-grep "match" nil (current-buffer) t nil) 3))
+        (should (= (hyrolo-grep "match" nil (current-buffer) t t) 1)))
+    (kill-buffer hyrolo-display-buffer)))
 
 (provide 'hyrolo-tests)
 


### PR DESCRIPTION
# What

Verify hyrolo match count.

# Why

Hyrolo match regexps under different options. This is a start
verifying the count result using either match all or just match
headlines. _Both types of matches looks like they fail._ 

The first search for all matches returns 2 but in *HyRolo* all
three lines containing "match" are highlighted. The second
search for just searching in headlines does not find any match.

Sharing for information. I tried to debug this today but with no
success.

Marked as expected to fail for not breaking the CI.

# Note

Can I have I misunderstood what headline means in this 
context? I'm assuming that in org mode it is the first line 
/following a star. 
