### PR TITLE
Replace COPYING with DEMO

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2024-04-01  Mats Lidell  <matsl@gnu.org>
+
+* test/hpath-tests.el (hpath:prepend-shell-directory-test):
+* test/demo-tests.el (demo-manifest-test): Replace COPYING with DEMO since
+    it is not exported in all installations, i.e. MELPA.
+
 2024-03-31  Bob Weiner  <rsw@gnu.org>
 
 * test/hbut-tests.el (hbut-tests--ibut-at-p-identifies-a-remote-pathname):

--- a/test/demo-tests.el
+++ b/test/demo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     21-Mar-24 at 10:52:07 by Bob Weiner
+;; Last-Mod:      1-Apr-24 at 17:35:46 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -282,14 +282,14 @@
       (progn
         (find-file (expand-file-name "MANIFEST" hyperb:dir))
         (goto-char (point-min))
-        (forward-line 1)
-        (should (looking-at "COPYING"))
+        (forward-line 2)
+        (should (looking-at "DEMO"))
         (action-key)
-        (should (string= "COPYING" (buffer-name)))
-        (should (looking-at ".*GNU GENERAL PUBLIC LICENSE")))
+        (should (string= "DEMO" (buffer-name)))
+        (should (looking-at "\* GNU Hyperbole Full Demo")))
     (progn
       (hy-test-helpers:kill-buffer "MANIFEST")
-      (hy-test-helpers:kill-buffer "COPYING"))))
+      (hy-test-helpers:kill-buffer "DEMO"))))
 
 ;; Email compose
 (ert-deftest demo-mail-compose-test ()

--- a/test/hpath-tests.el
+++ b/test/hpath-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    28-Feb-21 at 23:26:00
-;; Last-Mod:     24-Mar-24 at 10:10:33 by Mats Lidell
+;; Last-Mod:      1-Apr-24 at 17:45:41 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -207,10 +207,10 @@
                (default-directory hyperb:dir))
 	  (should explicit-shell-file-name)
           (hypb-run-shell-test-command shell-cmd shell-buffer)
-          (dolist (file '("COPYING" "man/hkey-help.txt" "man/version.texi" "man/im/demo.png"))
+          (dolist (file '("DEMO" "man/hkey-help.txt" "man/version.texi" "man/im/demo.png"))
             (goto-char (point-min))
             (should (search-forward (car (last (split-string file "/"))) nil t))
-            (backward-char 5)
+            (backward-char (/ (length file) 2))
             (hy-test-helpers:action-key-should-call-hpath:find (expand-file-name file hyperb:dir))))
       (kill-buffer shell-buffer))))
 


### PR DESCRIPTION
# What

Use DEMO instead of COPYING since COPYING is not exported in all
installations, i.e. MELPA.

# Why

Melpa install test, `install-melpa`, breaks due to two test cases
using COPYING. This uses DEMO instead.
