### PR TITLE
Use kotl-mode.el instead of version.texi which is not exported.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -25,6 +25,8 @@
 * test/hpath-tests.el (hpath:prepend-shell-directory-test):
 * test/demo-tests.el (demo-manifest-test): Replace COPYING with DEMO since
     it is not exported in all installations, i.e. MELPA.
+    (hpath:prepend-shell-directory-test): Use kotl-mode.el instead of
+    version.texi which is not exported.
 
 2024-04-01  Bob Weiner  <rsw@gnu.org>
 

--- a/test/hpath-tests.el
+++ b/test/hpath-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    28-Feb-21 at 23:26:00
-;; Last-Mod:      7-Apr-24 at 10:40:03 by Bob Weiner
+;; Last-Mod:      8-Apr-24 at 16:45:22 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -207,7 +207,7 @@
                (default-directory hyperb:dir))
 	  (should explicit-shell-file-name)
           (hypb-run-shell-test-command shell-cmd shell-buffer)
-          (dolist (file '("COPYING" "man/hkey-help.txt" "man/im/demo.png"))
+          (dolist (file '("DEMO" "man/hkey-help.txt" "kotl/kotl-mode.el" "man/im/demo.png"))
             (goto-char (point-min))
             (should (search-forward (car (last (split-string file "/"))) nil t))
             (backward-char (/ (length file) 2))


### PR DESCRIPTION
# What

Use kotl-mode.el instead of version.texi which is not exported.

# Why

Not all files are exported to melpa package in the recipe and
version.texi is not. When fixing this same issue for the file COPYING
recently I missed there were more of the same problem.  

All files used in tests should now be picked from files available
through all different install packages.

