### PR TITLE
Use DEMO in test since COPYING is not exported in melpa

### DIFF
--- a/test/hpath-tests.el
+++ b/test/hpath-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    28-Feb-21 at 23:26:00
-;; Last-Mod:      7-Apr-24 at 10:40:03 by Bob Weiner
+;; Last-Mod:      7-Apr-24 at 23:10:11 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -207,7 +207,7 @@
                (default-directory hyperb:dir))
 	  (should explicit-shell-file-name)
           (hypb-run-shell-test-command shell-cmd shell-buffer)
-          (dolist (file '("COPYING" "man/hkey-help.txt" "man/im/demo.png"))
+          (dolist (file '("DEMO" "man/hkey-help.txt" "man/im/demo.png"))
             (goto-char (point-min))
             (should (search-forward (car (last (split-string file "/"))) nil t))
             (backward-char (/ (length file) 2))


### PR DESCRIPTION
# What

Bring back DEMO in test to replace COPYING.

# Why

COPYING is not exported in the Melpa recipe so should not be used in
tests. Not sure how this was reverted but here is a PR anyway to bring it back to using DEMO
in tests and not COPYING since that is not exported everywhere i.e. Melpa.
