### PR TITLE
org-link-outside-org-mode - Ignore `hsys-org-enable-smart-keys' value

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 2024-04-07  Bob Weiner  <rsw@gnu.org>
 
+* hibtypes.el (org-link-outside-org-mode): Fix by removing this test:
+    (eq hsys-org-enable-smart-keys t) since should follow Org links outside
+    Org modes independent of this setting, as long as the Hyperbole mode
+    is active.
+
 * Makefile (version, HYPERBOLE_FILES, TEXINFO_SRC):
   test/hpath-tests.el (hpath:prepend-shell-directory-test):
   man/hyperbole.texi: Remove "version.texi" file and include here to simplify

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 2024-04-07  Bob Weiner  <rsw@gnu.org>
 
+* hyrolo.el (hyrolo-consult-grep-paths): Fix handling of zero 'max-matches'
+    arg which triggers headline only searches.
+            (hyrolo-move-to-entry-end): Handled named signals as well as
+    errors.
+
 * hibtypes.el (org-link-outside-org-mode): Fix by removing this test:
     (eq hsys-org-enable-smart-keys t) since should follow Org links outside
     Org modes independent of this setting, as long as the Hyperbole mode

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:     31-Mar-24 at 15:17:46 by Bob Weiner
+;; Last-Mod:      7-Apr-24 at 15:12:46 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -380,8 +380,7 @@ attached file."
   "Follow an Org link in a non-Org mode buffer.
 This should be a very low priority so other Hyperbole types
 handle any links they recognize first."
-  (when (and (eq hsys-org-enable-smart-keys t)
-	     (not (funcall hsys-org-mode-function))
+  (when (and (not (funcall hsys-org-mode-function))
 	     ;; Prevent infinite recursion, e.g. if called via
 	     ;; `org-metareturn-hook' from `org-meta-return' invocation.
 	     (not (hyperb:stack-frame '(ibtypes::debugger-source org-meta-return))))


### PR DESCRIPTION
Otherwise, if that flag is nil, would not activate Org links outside of Org modes.