### PR TITLE
Tests for org-links outside of org-mode

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2024-04-08  Mats Lidell  <matsl@gnu.org>
+
+* test/hsys-org-tests.el (hsys-org--org-outside-org-mode-tmp-buffer)
+    (hsys-org--org-outside-org-mode-tmp-file): Tests for org-links outside
+    of org-mode.
+
 2024-04-07  Bob Weiner  <rsw@gnu.org>
 
 * hyrolo.el (hyrolo-consult-grep-paths): Fix handling of zero 'max-matches'

--- a/test/hsys-org-tests.el
+++ b/test/hsys-org-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    23-Apr-21 at 20:55:00
-;; Last-Mod:     12-Mar-24 at 23:04:29 by Mats Lidell
+;; Last-Mod:      8-Apr-24 at 16:41:14 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -127,6 +127,31 @@
     (goto-char 6)
     (font-lock-ensure)
     (should (hsys-org-face-at-p 'org-target))))
+
+(ert-deftest hsys-org--org-outside-org-mode-tmp-buffer ()
+  "Org links in a temp buffer should work.
+This is independent of the setting of `hsys-org-enable-smart-keys'."
+  (let ((hsys-org-enable-smart-keys nil)
+        (browse-url-browser-function nil)) ;; Don't open browser on failure
+    (with-temp-buffer
+      (insert "[[file:/tmp/abc][file]]\n")
+      (goto-char 6)
+      (mocklet (((org-open-at-point-global) => t))
+        (action-key)))))
+
+(ert-deftest hsys-org--org-outside-org-mode-tmp-file ()
+  "Org links in a non `org-mode' file should work.
+This is independent of the setting of `hsys-org-enable-smart-keys'."
+  (let ((file (make-temp-file "hypb" nil ".txt" "[[file:/tmp/abc][file]]\n"))
+        (hsys-org-enable-smart-keys nil)
+        (browse-url-browser-function nil)) ;; Don't open browser on failure
+    (unwind-protect
+        (progn
+          (find-file file)
+          (goto-char 6)
+          (mocklet (((org-open-at-point-global) => t))
+            (action-key)))
+      (hy-delete-file-and-buffer file))))
 
 (provide 'hsys-org-tests)
 

--- a/test/hsys-org-tests.el
+++ b/test/hsys-org-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    23-Apr-21 at 20:55:00
-;; Last-Mod:      8-Apr-24 at 16:41:14 by Mats Lidell
+;; Last-Mod:      9-Apr-24 at 09:32:53 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -131,26 +131,30 @@
 (ert-deftest hsys-org--org-outside-org-mode-tmp-buffer ()
   "Org links in a temp buffer should work.
 This is independent of the setting of `hsys-org-enable-smart-keys'."
-  (let ((hsys-org-enable-smart-keys nil)
-        (browse-url-browser-function nil)) ;; Don't open browser on failure
-    (with-temp-buffer
-      (insert "[[file:/tmp/abc][file]]\n")
-      (goto-char 6)
-      (mocklet (((org-open-at-point-global) => t))
-        (action-key)))))
+  (let ((browse-url-browser-function nil)) ;; Don't open browser on failure
+      (dolist (v '('unset 'button t nil))
+        (let ((hsys-org-enable-smart-keys v))
+          (with-temp-buffer
+            (insert "[[file:/tmp/abc][file]]\n")
+            (goto-char 6)
+            (mocklet (((org-open-at-point-global) => t))
+              (should (equal hsys-org-enable-smart-keys v)) ; Traceability
+              (should (action-key))))))))
 
 (ert-deftest hsys-org--org-outside-org-mode-tmp-file ()
   "Org links in a non `org-mode' file should work.
 This is independent of the setting of `hsys-org-enable-smart-keys'."
   (let ((file (make-temp-file "hypb" nil ".txt" "[[file:/tmp/abc][file]]\n"))
-        (hsys-org-enable-smart-keys nil)
         (browse-url-browser-function nil)) ;; Don't open browser on failure
     (unwind-protect
         (progn
           (find-file file)
           (goto-char 6)
-          (mocklet (((org-open-at-point-global) => t))
-            (action-key)))
+          (dolist (v '('unset 'button t nil))
+            (let ((hsys-org-enable-smart-keys v))
+              (mocklet (((org-open-at-point-global) => t))
+                (should (equal hsys-org-enable-smart-keys v)) ; Traceability
+                (should (action-key))))))
       (hy-delete-file-and-buffer file))))
 
 (provide 'hsys-org-tests)


### PR DESCRIPTION
# What

Tests for org-links outside of org-mode.

# Why

There was a bug here where `hsys-org-enable-smart-keys`  would
interfere with the org-links which is should not. It is only
applicable within `org-mode`. A fix for that has already been pushed.
