### PR TITLE
Add test for gbut:act on a web link

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2024-04-14  Mats Lidell  <matsl@gnu.org>
+
+* test/hbut-tests.el (hypb--gbut-act-with-web-link): Test for gbut:act
+    on a web link.
+
 2024-04-14  Bob Weiner  <rsw@gnu.org>
 
 * hbut.el (ibut:create): Set 'name-start' and 'name-end' location attributes

--- a/test/hbut-tests.el
+++ b/test/hbut-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-may-21 at 09:33:00
-;; Last-Mod:     10-Apr-24 at 16:25:30 by Mats Lidell
+;; Last-Mod:     14-Apr-24 at 21:52:52 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -782,13 +782,12 @@ See #10 for the proper way to add an ibutton name.
 
 (ert-deftest hypb--gbut-act-with-web-link ()
   "Verify `gbut:act' with a web link calls browser."
-  :expected-result :failed
   (defvar global-but-file)
   (let ((global-but-file (make-temp-file "gbut" nil ".txt"
                                          "<[Link]> - \"https://savannah.gnu.org/projects/hyperbole/\"\n")))
     (unwind-protect
         (mocklet ((gbut:file => global-but-file)
-                  ((browse-url "https://savannah.gnu.org/projects/hyperbole/" nil) => t)
+                  ((browse-url "https://savannah.gnu.org/projects/hyperbole/") => t)
                   (hpath:find-noselect => (find-file-noselect global-but-file)))
           (gbut:act "Link"))
       (hy-delete-file-and-buffer global-but-file))))

--- a/test/hbut-tests.el
+++ b/test/hbut-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-may-21 at 09:33:00
-;; Last-Mod:     16-Mar-24 at 23:44:27 by Mats Lidell
+;; Last-Mod:     10-Apr-24 at 16:25:30 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -779,6 +779,19 @@ See #10 for the proper way to add an ibutton name.
     (should (equal (hattr:get (ibut:at-p) 'categ) 'ibtypes::pathname))
     (goto-char 8)  ;; ibtypes::mail-address !!
     (should (equal (hattr:get (ibut:at-p) 'categ) 'ibtypes::pathname))))
+
+(ert-deftest hypb--gbut-act-with-web-link ()
+  "Verify `gbut:act' with a web link calls browser."
+  :expected-result :failed
+  (defvar global-but-file)
+  (let ((global-but-file (make-temp-file "gbut" nil ".txt"
+                                         "<[Link]> - \"https://savannah.gnu.org/projects/hyperbole/\"\n")))
+    (unwind-protect
+        (mocklet ((gbut:file => global-but-file)
+                  ((browse-url "https://savannah.gnu.org/projects/hyperbole/" nil) => t)
+                  (hpath:find-noselect => (find-file-noselect global-but-file)))
+          (gbut:act "Link"))
+      (hy-delete-file-and-buffer global-but-file))))
 
 ;; This file can't be byte-compiled without the `el-mock' package (because of
 ;; the use of the `with-mock' macro), which is not a dependency of Hyperbole.


### PR DESCRIPTION
# What

Add a test for `gbut:act` on a web link.

# Why

This was a regression. Last commit where the test case works
using git bisect is 2399a09. 

Invoking the global button using keyseries gives the same
result. Invoking it from within the global button file works.

~Test case set as `expected-result failed`~ 

**It has now been fixed on master.**

# Backtrace

```
Backtrace for test ‘hypb--gbut-act-with-web-link’:
  user-error("No link found")
  org-open-at-point-global()
  eval((org-open-at-point-global))
  actype:act(org-open-at-point-global)
  hbut:act(hbut:current)
  gbut:act("Link")
  (closure (global-but-file t) nil (gbut:act "Link"))()
  [...]
```
