### PR TITLE
hyrolo.py - For Org files, include '#+PROPERTY:' lines in file hdr

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2024-04-16  Bob Weiner  <rsw@gnu.org>
+
+* hib-social.el (github-reference): Allow for a - character following
+    commit, issue or pull keywords; already supported / and = characters.
+                (gitlab-reference): Allow for a - character following
+    any ref-type keyword.
+
 * hui-select.el (hui-select-initialize): Disable C++ defun selection regexp until
     regexp is rewritten to prevent Emacs hangs.  See Emacs bug#61436 from 2023
     and; gh#rswgnu/hyperbole/issue-518 from 2024.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+* hui-select.el (hui-select-initialize): Disable C++ defun selection regexp until
+    regexp is rewritten to prevent Emacs hangs.  See Emacs bug#61436 from 2023
+    and; gh#rswgnu/hyperbole/issue-518 from 2024.
+
 2024-04-14  Mats Lidell  <matsl@gnu.org>
 
 * test/hbut-tests.el (hypb--gbut-act-with-web-link): Test for gbut:act

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2024-04-16  Bob Weiner  <rsw@gnu.org>
 
+* hyrolo.py: For Org files, create hyrolo match file header from all
+    initial buffer-level '#+PROPERTY:' lines.
+
 * hib-social.el (github-reference): Allow for a - character following
     commit, issue or pull keywords; already supported / and = characters.
                 (gitlab-reference): Allow for a - character following

--- a/hib-social.el
+++ b/hib-social.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    20-Jul-16 at 22:41:34
-;; Last-Mod:     13-Apr-24 at 11:17:42 by Bob Weiner
+;; Last-Mod:     16-Apr-24 at 22:10:55 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -166,7 +166,7 @@
 ;;     gl#projects                               List all available projects
 ;;
 ;;     gl#milestone=38                           Show a specific project milestone
-;;     gl#snippet/1689487                        Show a specific project snippet
+;;     gl#snippet=1689487                        Show a specific project snippet
 
 ;;; Code:
 ;;; ************************************************************************
@@ -367,7 +367,7 @@ or  /<project>.
   are listed;
 
   one of the words: branch, commit, issue, pull or tag followed
-  by a '/' or '=' and an item-id; the item is shown;
+  by by '/', '-', or '=', and an item-id; the item is shown;
 
   an issue reference given by a positive integer, e.g. 92 or
   prefaced with GH-, e.g. GH-92; the issue is displayed;
@@ -390,7 +390,7 @@ PROJECT value is provided, it defaults to the value of
 		 (url-to-format (assoc-default "github" hibtypes-social-hashtag-alist #'string-match))
 		 (ref-type))
 	     (when url-to-format
-	       (cond ((string-match "\\`\\(branch\\|commit\\|issue\\|pull\\|tag\\)[/=]" reference)
+	       (cond ((string-match "\\`\\(branch\\|commit\\|issue\\|pull\\|tag\\)[-/=]" reference)
 		      ;; [branch | commit | issue | pull | tag]/ref-item
 		      nil)
 		     ((string-match "\\`/?\\(\\([^/#@]+\\)/\\)\\([^/#@]+\\)\\'" reference)
@@ -426,20 +426,21 @@ PROJECT value is provided, it defaults to the value of
 			(setq ref-type reference
 			      reference ""))
 		       ((and (< (length reference) 8) (string-match "\\`\\([gG][hH]-\\)?[0-9]+\\'" reference))
-			;; Issue ref-id reference
+			;; Issue 'number' or 'GH-number' ref-id reference
 			(setq ref-type "issues/"
 			      reference (substring reference (match-end 1) (match-end 0))))
-		       ((string-match "\\`\\(commit\\|issue\\|pull\\)[/=]" reference)
+		       ((string-match "\\`\\(commit\\|issue\\|pull\\)[-/=]" reference)
 			;; Specific reference preceded by keyword branch, commit,
-			;; issue, or pull
+			;; issue, or pull and followed by -, /, = or #.
 			(setq ref-type (substring reference 0 (match-end 1))
 			      reference (substring reference (match-end 0))
-			      ref-type (concat ref-type (if (string-equal ref-type "issue") "s/" "/"))))		       ((string-match "\\`[0-9a-f]+\\'" reference)
+			      ref-type (concat ref-type (if (string-equal ref-type "issue") "s/" "/"))))
+		       ((string-match "\\`[0-9a-f]+\\'" reference)
 			;; Commit reference
 			(setq ref-type "commit/"))
 		       (t
 			;; Specific branch or commit tag reference
-			(if (string-match "\\`\\(branch\\|tag\\)/" reference)
+			(if (string-match "\\`\\(branch\\|tag\\)[-/=]" reference)
 			    ;; Reference is a specific branch or tag.
 			    ;; If preceded by optional keyword, remove that from the reference.
 			    (setq ref-type "blob/"
@@ -482,8 +483,8 @@ or  /<project-or-group> (where a group is a collection of projects).
   listed;
 
   one of the words: branch, commit(s), issue(s), milestone(s),
-  pull(s), snippet(s) or tag(s) followed by a '/' or '=' and an
-  item-id; the item is shown;
+  pull(s), snippet(s) or tag(s) followed by a '/', '-' or '='
+  and an item-id; the item is shown;
 
   an issue reference given by a positive integer, e.g. 92 or
   prefaced with GL-, e.g. GL-92; the issue is displayed;
@@ -592,15 +593,15 @@ PROJECT value is provided, it defaults to the value of
 			;; Labeled category of issues
 			(setq ref-type "issues?label_name%5B%5D="
 			      reference (substring reference (match-end 0))))
-		       ((string-match "\\`\\(commit\\|issues\\|milestones\\|pull\\|snippets\\|tags\\)[/=]" reference)
+		       ((string-match "\\`\\(commit\\|issues\\|milestones\\|pull\\|snippets\\|tags\\)[-/=]" reference)
 			;; Ref-id preceded by a keyword
 			(setq ref-type (concat (substring reference 0 (match-end 1)) "/")
 			      reference (substring reference (match-end 0))))
-		       ((string-match "\\`\\(issue\\|milestone\\|snippet\\|tag\\)[/=]" reference)
+		       ((string-match "\\`\\(issue\\|milestone\\|snippet\\|tag\\)[-/=]" reference)
 			;; Ref-id preceded by a singular keyword that must be converted to plural
 			(setq ref-type (concat (substring reference 0 (match-end 1)) "s/")
 			      reference (substring reference (match-end 0))))
-		       ((string-match "\\`\\(commit\\|pull\\)s[/=]" reference)
+		       ((string-match "\\`\\(commit\\|pull\\)s[-/=]" reference)
 			;; Ref-id preceded by a plural keyword that must be converted to singular
 			(setq ref-type (concat (substring reference 0 (match-end 1)) "/")
 			      reference (substring reference (1+ (match-end 0)))))
@@ -610,7 +611,7 @@ PROJECT value is provided, it defaults to the value of
 		       (t
 			;; Specific branch or commit tag reference
 			(setq ref-type "tree/")
-			(when (string-match "\\`\\(branch\\|tag\\)[/=]" reference)
+			(when (string-match "\\`\\(branch\\|tag\\)[-/=]" reference)
 			  ;; If preceded by optional keyword, remove that from the reference.
 			  (setq reference (substring reference (match-end 0)))))))
 	       (if (and (stringp user) (stringp project))

--- a/hui-select.el
+++ b/hui-select.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Oct-96 at 02:25:27
-;; Last-Mod:     19-Jan-24 at 18:17:28 by Mats Lidell
+;; Last-Mod:     16-Apr-24 at 22:21:45 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -401,9 +401,13 @@ Also, add language-specific syntax setups to aid in thing selection."
   ;; programmers don't put their function braces in the first column.
   (var:add-and-run-hook 'java-mode-hook (lambda ()
 					  (setq defun-prompt-regexp hui-java-defun-prompt-regexp)))
-  (var:add-and-run-hook 'c++-mode-hook (lambda ()
-					 (setq defun-prompt-regexp
-					       "^[ \t]*\\(template\\s-*<[^>;.{}]+>\\s-*\\)?\\(\\(\\(auto\\|const\\|explicit\\|extern\\s-+\"[^\"]+\"\\|extern\\|friend\\|inline\\|mutable\\|overload\\|register\\|static\\|typedef\\|virtual\\)\\s-+\\)*\\(\\([[<a-zA-Z][]_a-zA-Z0-9]*\\(::[]_a-zA-Z0-9]+\\)?\\s-*<[_<>a-zA-Z0-9 ,]+>\\s-*[*&]*\\|[[<a-zA-Z][]_<>a-zA-Z0-9]*\\(::[[<a-zA-Z][]_<>a-zA-Z0-9]+\\)?\\s-*[*&]*\\)[*& \t\n\r]+\\)\\)?\\(\\(::\\|[[<a-zA-Z][]_a-zA-Z0-9]*\\s-*<[^>;{}]+>\\s-*[*&]*::\\|[[<a-zA-Z][]_~<>a-zA-Z0-9]*\\s-*[*&]*::\\)\\s-*\\)?\\(operator\\s-*[^ \t\n\r:;.,?~{}]+\\(\\s-*\\[\\]\\)?\\|[_~<a-zA-Z][^][ \t:;.,~{}()]*\\|[*&]?\\([_~<a-zA-Z][_a-zA-Z0-9]*\\s-*<[^>;{}]+[ \t\n\r>]*>\\|[_~<a-zA-Z][_~<>a-zA-Z0-9]*\\)\\)\\s-*\\(([^{;]*)\\(\\(\\s-+const\\|\\s-+mutable\\)?\\(\\s-*[=:][^;{]+\\)?\\)?\\)\\s-*")))
+
+  ;; !! TODO: defun selection regexp is disabled in C++ until regexp is
+  ;; rewritten as it can hang Emacs; reported in Emacs bug#61436 in
+  ;; 2023 and gh#rswgnu/hyperbole/issue-518 in 2024.
+  ;; (var:add-and-run-hook 'c++-mode-hook (lambda ()
+  ;;					 (setq defun-prompt-regexp
+  ;;					       "^[ \t]*\\(template\\s-*<[^>;.{}]+>\\s-*\\)?\\(\\(\\(auto\\|const\\|explicit\\|extern\\s-+\"[^\"]+\"\\|extern\\|friend\\|inline\\|mutable\\|overload\\|register\\|static\\|typedef\\|virtual\\)\\s-+\\)*\\(\\([[<a-zA-Z][]_a-zA-Z0-9]*\\(::[]_a-zA-Z0-9]+\\)?\\s-*<[_<>a-zA-Z0-9 ,]+>\\s-*[*&]*\\|[[<a-zA-Z][]_<>a-zA-Z0-9]*\\(::[[<a-zA-Z][]_<>a-zA-Z0-9]+\\)?\\s-*[*&]*\\)[*& \t\n\r]+\\)\\)?\\(\\(::\\|[[<a-zA-Z][]_a-zA-Z0-9]*\\s-*<[^>;{}]+>\\s-*[*&]*::\\|[[<a-zA-Z][]_~<>a-zA-Z0-9]*\\s-*[*&]*::\\)\\s-*\\)?\\(operator\\s-*[^ \t\n\r:;.,?~{}]+\\(\\s-*\\[\\]\\)?\\|[_~<a-zA-Z][^][ \t:;.,~{}()]*\\|[*&]?\\([_~<a-zA-Z][_a-zA-Z0-9]*\\s-*<[^>;{}]+[ \t\n\r>]*>\\|[_~<a-zA-Z][_~<>a-zA-Z0-9]*\\)\\)\\s-*\\(([^{;]*)\\(\\(\\s-+const\\|\\s-+mutable\\)?\\(\\s-*[=:][^;{]+\\)?\\)?\\)\\s-*")))
   ;;
   ;; Match to Lisp symbols with : in their names, often included in help buffers.
   (var:add-and-run-hook 'help-mode-hook (lambda () (modify-syntax-entry ?:  "_"  help-mode-syntax-table)))

--- a/man/hyperbole.texi
+++ b/man/hyperbole.texi
@@ -7,7 +7,7 @@
 @c Author:       Bob Weiner
 @c
 @c Orig-Date:     6-Nov-91 at 11:18:03
-@c Last-Mod:     13-Apr-24 at 11:21:43 by Bob Weiner
+@c Last-Mod:     16-Apr-24 at 22:13:33 by Bob Weiner
 
 @c %**start of header (This is for running Texinfo on a region.)
 @setfilename hyperbole.info
@@ -159,7 +159,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.</P>
 
 <PRE>
 Edition 9.0.2pre
-Printed April 7, 2024.
+Printed April 16, 2024.
 
   Published by the Free Software Foundation, Inc.
   Author:    Bob Weiner
@@ -201,7 +201,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
 @example
 Edition 9.0.2pre
-April 7, 2024
+April 16, 2024
 
   Published by the Free Software Foundation, Inc.
   Author:    Bob Weiner
@@ -3203,7 +3203,7 @@ REFERENCE is a string of one of the following forms:
 @table @asis
 @item @bullet{} one of the words: branches, commits, issues, pulls, or tags
 the associated items are listed
-@item @bullet{} one of the words: branch, commit, issue, pull or tag followed by a '/' and item id
+@item @bullet{} one of the words: branch, commit, issue, pull or tag followed by a '/', '-', or '=', and item id
 the item is shown
 @item @bullet{} an issue reference given by a positive integer, e.g. @emph{92} or prefaced with @emph{GH-}, like GH-92
 the issue is displayed
@@ -3242,7 +3242,7 @@ or
 @table @asis
 @item @bullet{} one of the words: activity, analytics, boards or kanban, branches, commits, contributors, groups, issues or list, jobs, labels, merge_requests, milestones, pages, pipelines, pipeline_charts, members or people or staff, projects, pulls, schedules, snippets, status or tags
 the associated items are listed
-@item @bullet{} one of the words: branch, commit(s), issue(s), milestone(s), pull(s), snippet(s) or tag(s) followed by a '/' or '=' and an item-id
+@item @bullet{} one of the words: branch, commit(s), issue(s), milestone(s), pull(s), snippet(s) or tag(s) followed by a '/', '-', or '=', and an item-id
 the item is shown
 @item @bullet{} an issue reference given by a positive integer, e.g. @emph{92} or prefaced with @emph{GL-}, like GL-92
 the issue is displayed


### PR DESCRIPTION
Additionally:

hui-select-initialize - Disable C++ defun-prompt-regexp definition
github/gitlab-reference - Allow a - character following any ref-type
