### PR TITLE
fix pathnames in ls R listings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2024-04-23  Mats Lidell  <matsl@gnu.org>
 
+* hpath.el (hpath:delimited-possible-path): Allow space between file names
+    in "ls -R"-listings.
+
 * test/hpath-tests.el (hpath--hpath:delimited-possible-path): Add test
     case for delimited paths in "ls -R"-listings.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2024-04-23  Mats Lidell  <matsl@gnu.org>
+
+* test/hpath-tests.el (hpath--hpath:delimited-possible-path): Add test
+    case for delimited paths in "ls -R"-listings.
+
 2024-04-20  Bob Weiner  <rsw@gnu.org>
 
 * hui-select.el (hui-c++-defun-prompt-regexp): Add to eliminate an Emacs

--- a/hpath.el
+++ b/hpath.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Nov-91 at 00:44:23
-;; Last-Mod:     31-Mar-24 at 00:23:02 by Bob Weiner
+;; Last-Mod:     23-Apr-24 at 23:11:20 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1140,12 +1140,9 @@ end-pos) or nil."
 	  ;; if `non-exist' is nil, look for any existing whitespace
 	  ;; delimited filename at point.  If match consists of punctuation
 	  ;; only, like . or .., don't treat it as a pathname.
-	  ;; In shell modes, it must be tab delimited.
 	  (unless non-exist
-	    (let* ((space-delimiter (if (derived-mode-p #'shell-mode)
-					"\t"
-				      "[ \t]"))
-		   (triplet (hargs:delimited (format "^\\|\\(%s\\|[\]\[()<>\;&,@]\\)+"
+	    (let* ((space-delimiter "[ \t]")
+	           (triplet (hargs:delimited (format "^\\|\\(%s\\|[\]\[()<>\;&,@]\\)+"
 						     space-delimiter)
 					     "\\([\]\[()<>\;&,@]\\|:*\\s-\\)+\\|$"
 					     t t t))

--- a/test/hpath-tests.el
+++ b/test/hpath-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    28-Feb-21 at 23:26:00
-;; Last-Mod:     23-Apr-24 at 22:15:36 by Mats Lidell
+;; Last-Mod:     23-Apr-24 at 23:52:50 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -405,7 +405,8 @@ file1.ext file2.ext file3.ext
       (let ((filename (concat "file" (number-to-string v))))
         (search-forward filename)
         (should (looking-at-p "\\.ext"))
-        (should (string= (hpath:delimited-possible-path) (concat filename ".ext")))))))
+        (mocklet (((file-exists-p "dir/subdir") => t))
+          (should (string= (hpath:delimited-possible-path) (expand-file-name (concat filename ".ext") "dir/subdir"))))))))
 
 (provide 'hpath-tests)
 ;;; hpath-tests.el ends here

--- a/test/hpath-tests.el
+++ b/test/hpath-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    28-Feb-21 at 23:26:00
-;; Last-Mod:      8-Apr-24 at 16:45:22 by Mats Lidell
+;; Last-Mod:     23-Apr-24 at 22:15:36 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -390,6 +390,22 @@ See `hpath:line-and-column-regexp'."
   (should (string-match hpath:line-and-column-regexp "/foo/bar.org:L1"))
   (should-not (string-match hpath:line-and-column-regexp "/foo/bar.org:LL1"))
   (should-not (string-match hpath:line-and-column-regexp "/foo/bar.org:C1")))
+
+(ert-deftest hpath--hpath:delimited-possible-path ()
+  "Verify delimited path is found in an `ls -R' listings in `shell-mode'."
+  (with-temp-buffer
+    (insert "\
+$ ls -R dir
+dir/subdir:
+file1.ext file2.ext file3.ext
+")
+    (goto-char (point-min))
+    (shell-mode)
+    (dolist (v '(1 2 3))
+      (let ((filename (concat "file" (number-to-string v))))
+        (search-forward filename)
+        (should (looking-at-p "\\.ext"))
+        (should (string= (hpath:delimited-possible-path) (concat filename ".ext")))))))
 
 (provide 'hpath-tests)
 ;;; hpath-tests.el ends here


### PR DESCRIPTION
# What

- Add test case for delimited paths in "ls -R"-listings
- Allow for space between file names in ls -R listings

# Why

Plain file names in ls -R have stopped to work. I suspect it is
because the file names are not found due to that tab separation is
assumed. I don't know what has changed but in my shell-mode ls -R only
use space between the files.

Removing the special treatment for shell-mode resolves the issue
partially and it is what this PR does. For folders that does not
contain files with names having whitespace this fix works.

# Note 

As pointed out above there are other issues with ls -R listings. If
there are files with space in their name the quotes produces by ls
causes problems since hpath:delimited-possible-path can't handle
that. 

The quotes does further harm in that when clicking on other files the
quote are found by the regexps and we get a list of files instead of
just one file. 

The last problematic case is that the ls listing gets indented one
space because of quotes in file names and the current regexp does not
handle that gracefully. (That might be possible to solve locally but
to much for me today. Might give it a try but since it is part of the
quote problem just fixing that might not make sense.)

## Reflection

Can it be that this and the related functions have to much
responsibilities? Looking for patterns only seen in info, tex, html
while being in shell-mode seems to be redundant. Can we not make the
task easier by earlier realizing that we are in shell-mode and maybe
use adjusted pathname functions that knows about that!?

Anyway, something to discuss. 

I'm submitting this as documentation and as a potential fix for the
case with folders that only contains filenames with no whitespaces. So
a step in the right direction.
