### PR TITLE
Set pipefail so that makes error code is propagated to the shell

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,7 @@ jobs:
         run: make clean
 
       - name: Compile
+        shell: bash
         run: |
           make binn 2>&1 | tee MAKE_BIN_OUTPUT
           test 0 -eq ${PIPESTATUS}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Compile
         shell: bash
         run: |
-          make binn 2>&1 | tee MAKE_BIN_OUTPUT
+          make bin 2>&1 | tee MAKE_BIN_OUTPUT
           test 0 -eq ${PIPESTATUS}
           echo "Number of warnings: $(grep "Warning:" MAKE_BIN_OUTPUT | wc -l)" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Compile
         shell: bash
         run: |
-          make binn 2>&1 | tee MAKE_BIN_OUTPUT
+          make bin 2>&1 | tee MAKE_BIN_OUTPUT
           echo "Number of warnings: $(grep "Warning:" MAKE_BIN_OUTPUT | wc -l)" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
           grep "Warning:" MAKE_BIN_OUTPUT >> $GITHUB_STEP_SUMMARY || true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,8 @@ jobs:
 
       - name: Compile
         run: |
-          make bin 2>&1 | tee MAKE_BIN_OUTPUT
+          make binn 2>&1 | tee MAKE_BIN_OUTPUT
+          test 0 -eq ${PIPESTATUS}
           echo "Number of warnings: $(grep "Warning:" MAKE_BIN_OUTPUT | wc -l)" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
           grep "Warning:" MAKE_BIN_OUTPUT >> $GITHUB_STEP_SUMMARY || true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,8 +26,7 @@ jobs:
       - name: Compile
         shell: bash
         run: |
-          make bin 2>&1 | tee MAKE_BIN_OUTPUT
-          test 0 -eq ${PIPESTATUS}
+          make binn 2>&1 | tee MAKE_BIN_OUTPUT
           echo "Number of warnings: $(grep "Warning:" MAKE_BIN_OUTPUT | wc -l)" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
           grep "Warning:" MAKE_BIN_OUTPUT >> $GITHUB_STEP_SUMMARY || true


### PR DESCRIPTION
# What

Current pipe with tee swallows the error code if any from make.

# Why

The pipe to tee for both showing the output from make and storing it
for processing swallows the error code from make if it fails. Setting shell 
to bash explicitly gets the `pipefail` option set which makes the 
pipe a whole fail if make fails.

# Note

I noticed this incorrectness when looking at why the `rsw` branch with 
the hywiki did not fail since it should. (But it actually did fail. It was not
noticed since the compilation error was swallowed. This PR fixes this.) 

There are some test commits before I got it right but I will squash them 
on merge.