### PR TITLE
Add quotes so make is executed in the container

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2024-05-17  Mats Lidell  <matsl@gnu.org>
+
+* Makefile (dockerized): Add quotes so make is executed in the container.
+
 2024-05-16  Mats Lidell  <matsl@gnu.org>
 
 * test/hact-tests.el (hact-tests--action-params-with-lambdas)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:     14-Apr-24 at 23:00:20 by Bob Weiner
+# Last-Mod:      6-May-24 at 00:25:45 by Mats Lidell
 #
 # Copyright (C) 1994-2023  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -561,7 +561,7 @@ DOCKER_VERSION = master-ci
 endif
 
 dockerized:
-	docker run -v $$(pwd):/hyperbole -it silex/emacs:${DOCKER_VERSION} bash -c cd hyperbole && make ${DOCKER_TARGETS}
+	docker run -v $$(pwd):/hyperbole -it silex/emacs:${DOCKER_VERSION} bash -c "make -C hyperbole ${DOCKER_TARGETS}"
 
 # Run with coverage. Run tests given by testspec and monitor the
 # coverage for the specified file.


### PR DESCRIPTION
# What

Add quotes so make is executed in the container.

# Why

The point of the target is to run make using the emacs provide by the
docker image. So make must be run within the target.
