### PR TITLE
Add Emacs 30 closure support and tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2024-05-16  Mats Lidell  <matsl@gnu.org>
+
+* test/hact-tests.el (hact-tests--action-params-with-lambdas)
+   (hact-tests--actype-act-with-lambdas): Verify closures.
+
+* hact.el (actype:act): Add Emacs 30 closure support.
+
 2024-04-20  Bob Weiner  <rsw@gnu.org>
 
 * hui-select.el (hui-c++-defun-prompt-regexp): Add to eliminate an Emacs

--- a/hact.el
+++ b/hact.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:     14-Apr-24 at 01:33:24 by Bob Weiner
+;; Last-Mod:     16-May-24 at 23:00:41 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -411,7 +411,9 @@ performing ACTION."
 	   (setq args (hpath:absolute-arguments actype args)))
       (let ((hist-elt (hhist:element)))
 	(run-hooks 'action-act-hook)
-	(prog1 (or (if (or (symbolp action) (listp action)
+	(prog1 (or (when (and (fboundp #'closurep) (closurep action))
+			 (apply action args))
+		   (if (or (symbolp action) (listp action)
 			   (byte-code-function-p action)
 			   (subrp action)
 			   (and (stringp action) (not (integerp action))

--- a/test/MANIFEST
+++ b/test/MANIFEST
@@ -1,5 +1,6 @@
 --- HYPERBOLE TEST CASES ---
 demo-tests.el           - unit tests from examples in the DEMO
+hact-tests.el           - hact unit tests
 hactypes-tests.el       - Ert tests for hactypes
 hargs-tests.el          - hargs unit tests
 hbut-tests.el           - hbut unit tests

--- a/test/hact-tests.el
+++ b/test/hact-tests.el
@@ -1,0 +1,38 @@
+;;; hact-tests.el --- unit tests for hact                -*- lexical-binding: t; -*-
+;;
+;; Author:       Mats Lidell
+;;
+;; Orig-Date:    16-May-24 at 00:29:22
+;; Last-Mod:     16-May-24 at 23:51:18 by Mats Lidell
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
+;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
+;; See the "HY-COPY" file for license information.
+;;
+;; This file is part of GNU Hyperbole.
+
+;;; Commentary:
+;;
+
+;;; Code:
+
+(require 'ert)
+(require 'hact)
+
+(ert-deftest hact-tests--action-params-with-lambdas ()
+  "Lambda used with `action:params' should return the lambda parameters."
+  (should (equal nil (action:params (lambda () nil))))
+  (should (equal '(x) (action:params (lambda (x) nil))))
+  (should (equal '(x y) (action:params (lambda (x y) nil)))))
+
+(ert-deftest hact-tests--actype-act-with-lambdas ()
+  "Lambda with `actype:act' should work over versions of Emacs.
+Covers backwards incompatible change in Emacs 30."
+  (should (= 2 (actype:act (lambda () 2))))
+  (should (= 2 (actype:act (lambda (x) x) 2)))
+  (should (= 2 (actype:act (lambda (x) (1+ x)) 1)))
+  (should (= 2 (actype:act (lambda (x y) (+ x y)) 1 1))))
+
+(provide 'hact-tests)
+;;; hact-tests.el ends here


### PR DESCRIPTION
# What

Add Emacs 30 closure support and tests.

# Why

Master branch is broken due to a breaking incompatible change in
Emacs 30. This adopts for the change and adds two test cases for
verification that behavior is consistent over the Emacs versions.

This is supplied as minimal change to make the master branch possible
to build again so we do not need to wait for everything on the rsw
branch to be ready for merge.

# Note

Oddly action:params works unmodified since help-function-arglist picks
up the closure!?


