### PR TITLE
Get list of args from closures

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2024-05-18  Mats Lidell  <matsl@gnu.org>
+
+* hargs.el (hargs:action-get): Add Emacs 30 closure support.
+
 2024-05-17  Mats Lidell  <matsl@gnu.org>
 
 * Makefile (dockerized): Add quotes so make is executed in the container.

--- a/hargs.el
+++ b/hargs.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    31-Oct-91 at 23:17:35
-;; Last-Mod:     20-Jan-24 at 19:43:53 by Mats Lidell
+;; Last-Mod:     18-May-24 at 16:07:11 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -100,7 +100,8 @@ Current button is being edited when EDITING-FLAG is t.
 Return nil if ACTION is not a list or `byte-code' object, has no
 interactive form or takes no arguments."
   (save-excursion
-    (and (or (subrp action) (byte-code-function-p action) (listp action))
+    (and (or (subrp action) (byte-code-function-p action) (listp action)
+             (and (fboundp #'closurep) (closurep action)))
 	 (let ((interactive-form (action:commandp action)))
 	   (when interactive-form
 	     (hpath:relative-arguments


### PR DESCRIPTION
# What

Get list of args from closures.

# Why

Closures needs to be identified in order for unit tests to work on
Emacs with native compilation. This makes "make test" and "make
test-all" work for native compiled code.

# Note

The current CI setup does not trigger this since the docker images
does not have native compilation.

There could be more places to look for this type of changes. It does
only fix the code to run the unit tests.
