### PR TITLE
Add test for hpath:delimited-possible-path

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2024-06-01  Mats Lidell  <matsl@gnu.org>
+
+* test/hpath-tests.el (hpath--hpath:delimited-possible-path): Add test for
+    hpath:delimited-possible-path.
+
 2024-05-31  Mats Lidell  <matsl@gnu.org>
 
 * test/hui-tests.el (hui--gbut-should-execute-in-current-folder): Add test


### PR DESCRIPTION
# What

Add test for hpath:delimited-possible-path.

# Why

ls -R listings can result in many different output formats so we need
to have test cases for the formats we support to avoid regression and
help in adding support for more formats.

# Note

Current test case contains two commented out test cases for file names
that contains quotes. Maybe not that common to have quotes in file
names but it is legal.
