### PR TITLE
Remove annotated bibliography from table of contents, not included

### DIFF
--- a/DEMO
+++ b/DEMO
@@ -457,7 +457,6 @@ command to return to this DEMO later.
     ** Gitlab (Remote) References
     ** Git (Local) References
     ** Grep, Occurrence, Debugger and Compiler Error Buttons, and Cscope Analyzer Lines
-    ** Annotated Bibliography Buttons
     ** Completion Selection
     ** Hyperbole Source Buttons
     ** UNIX Man Apropos Buttons


### PR DESCRIPTION
# What

Remove Annotated Bibliography Buttons from table of contents. 

# Why 

The section has been removed from DEMO.

