### PR TITLE
hywiki.el - Fix, improve a number of features and defaults.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,22 @@
+2024-06-02  Bob Weiner  <rsw@gnu.org>
+
+* hyperbole.el (hyperbole--disable-mode): Add disabling of 'hywiki-mode'.
+
+* hywiki.el (hywiki-active-in-current-buffer-p): Exclude buffers whose
+    major-modes are 'special, e.g. Dired mode.
+            (hywiki-word-highlight-flag): Clarify behavior.
+	    (hywiki-highlight-all-in-prog-modes): Change to a `defcustom'.
+	    (hywiki-get-page-files): Change to find files that end with
+    'hywiki-file-suffix' only.
+            (defib hywiki): Rename to 'hywiki-word' since activates on a
+    HyWikiWord.
+            (defcustom :group): Change from hyperbole-wiki to hyperbole-hywiki.
+            (hywiki-mode): Enable 'hyperbole-mode' which it uses.
+            (hywiki-mode-lighter): Add so can customize mode-line indicator.
+            (hywiki-excluded-major-modes): Rename to 'hywiki-exclude-major-modes'.
+            (hywiki-add-page): Fix case-sensitive check of page-name validity
+    by calling 'hywiki-is-wikiword'.
+
 2024-06-01  Mats Lidell  <matsl@gnu.org>
 
 * test/hywiki-tests.el (hywiki-tests--hywiki-add-page--adds-file-in-wiki-folder)

--- a/hui-mouse.el
+++ b/hui-mouse.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-89
-;; Last-Mod:     29-May-24 at 00:15:48 by Bob Weiner
+;; Last-Mod:      2-Jun-24 at 11:40:22 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1803,19 +1803,19 @@ Active when `hsys-org-enable-smart-keys' is non-nil,
 
 When the Action Key is pressed:
 
-  1. If on an Org todo keyword, cycle through the keywords in
-     that set or if final done keyword, remove it.
+  1. On an Org todo keyword, cycle through the keywords in that
+     set or if final done keyword, remove it.
 
-  2. If on an Org agenda view item, jump to the item for editing.
+  2. On an Org agenda view item, jump to the item for editing.
 
   3. Within a radio or internal target or a link to it, jump between
      the target and the first link to it, allowing two-way navigation.
 
-  4. Follow other internal links in Org mode files.
+  4. On another internal link in an Org mode file, jump to its referent.
 
-  5. Follow Org mode external links.
+  5. On an Org mode external link, jump to its referent.
 
-  6. When on a Hyperbole button, activate the button.
+  6. On a Hyperbole button, activate the button.
 
   7. With point on the :dir path of a code block definition, display the
      directory given by the path.
@@ -1824,8 +1824,8 @@ When the Action Key is pressed:
      or #+end_example header, execute the code block via the Org mode
      standard binding of {\\`C-c' \\`C-c'}, (org-ctrl-c-ctrl-c).
   
-  9. When point is on an Org mode heading, cycle the view of the subtree
-     at point.
+  9. With point on an Org mode heading, cycle the view of the subtree at
+     point.
 
   10. In any other context besides the end of a line, invoke the Org mode
       standard binding of {M-RET}, (org-meta-return).
@@ -1833,10 +1833,10 @@ When the Action Key is pressed:
 When the Assist Key is pressed, it behaves just like the Action Key except
 in these contexts:
 
-  1. If on an Org todo keyword, move to the first todo keyword in
-     the next set, if any.
+  1. On an Org todo keyword, move to the first todo keyword in the next
+     set, if any.
 
-  2. If on an Org mode link or agenda view item, display Hyperbole
+  2. On an Org mode link or agenda view item, display Hyperbole
      context-sensitive help.
 
   3. On a Hyperbole button, perform the Assist Key function, generally

--- a/hyperbole.el
+++ b/hyperbole.el
@@ -9,7 +9,7 @@
 ;; Maintainer:   Mats Lidell <matsl@gnu.org>
 ;; Maintainers:  Robert Weiner <rsw@gnu.org>, Mats Lidell <matsl@gnu.org>
 ;; Created:      06-Oct-92 at 11:52:51
-;; Last-Mod:     28-May-24 at 23:04:52 by Bob Weiner
+;; Last-Mod:      2-Jun-24 at 13:22:35 by Bob Weiner
 ;; Released:     10-Mar-24
 ;; Version:      9.0.2pre
 ;; Keywords:     comm, convenience, files, frames, hypermedia, languages, mail, matching, mouse, multimedia, outlines, tools, wp
@@ -511,8 +511,8 @@ frame, those functions by default still return the prior frame."
   (message "Initializing Hyperbole...done"))
   
 
-  ;; This call loads the rest of the Hyperbole system.
-  (require 'hinit)
+;; This call loads the rest of the Hyperbole system.
+(require 'hinit)
 
 (defun hyperbole--enable-mode ()
   "Enable Hyperbole global minor mode."
@@ -540,6 +540,8 @@ frame, those functions by default still return the prior frame."
 
 (defun hyperbole--disable-mode ()
   "Disable Hyperbole keys, menus and hooks."
+  ;; Deactivate hywiki-mode
+  (hywiki-mode 0)
   ;; Deactivate hyperbole-mode
   ;; Delete Hyperbole menu from all menubars.
   (hui-menu-remove Hyperbole)

--- a/man/hyperbole.texi
+++ b/man/hyperbole.texi
@@ -25,8 +25,8 @@
 @set txicodequoteundirected
 @set txicodequotebacktick
 
-@set UPDATED April, 2024
-@set UPDATED-MONTH April 2024
+@set UPDATED June, 2024
+@set UPDATED-MONTH June 2024
 @set EDITION 9.0.2pre
 @set VERSION 9.0.2pre
 
@@ -159,7 +159,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.</P>
 
 <PRE>
 Edition 9.0.2pre
-Printed April 16, 2024.
+Printed June 2, 2024.
 
   Published by the Free Software Foundation, Inc.
   Author:    Bob Weiner
@@ -201,7 +201,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
 @example
 Edition 9.0.2pre
-April 16, 2024
+June 2, 2024
 
   Published by the Free Software Foundation, Inc.
   Author:    Bob Weiner
@@ -2326,13 +2326,13 @@ Within a radio or internal target or a link to it, jump between
 the target and the first link to it, allowing two-way navigation.
 
 @item
-Follow other internal links and ID references in Org mode files.
+On another internal link in an Org mode file, jump to its referent.
 
 @item
-Follow Org mode external links.
+On an Org mode external link, jump to its referent.
 
 @item
-When on a Hyperbole button, activate the button.
+On a Hyperbole button, activate the button.
 
 @item
 With point on the :dir path of a code block definition, display the
@@ -2344,8 +2344,8 @@ or #+end_example header, execute the code block via the Org mode
 standard binding of @bkbd{C-c C-c}, @code{org-ctrl-c-ctrl-c}.
 
 @item
-When point is on an Org mode heading, cycle the view of the subtree
-at point.
+With point on an Org mode heading, cycle the view of the subtree at
+point.
 
 @item
 In any other context besides the end of a line, invoke the Org mode
@@ -2358,11 +2358,11 @@ except in these contexts:
 
 @enumerate
 @item
-If on an Org todo keyword, move to the first todo keyword in
-the next set, if any.
+On an Org todo keyword, move to the first todo keyword in the next
+set, if any.
 
 @item
-If on an Org mode link or agenda view item, display Hyperbole
+On an Org mode link or agenda view item, display Hyperbole
 context-sensitive help.
 
 @item

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -7,7 +7,7 @@
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
-;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
+;; Copyright (C) 2024  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.
@@ -41,7 +41,6 @@
 
 (ert-deftest hywiki-tests--hywiki-add-page--adds-no-wiki-word-fails ()
   "Verify add page requires a WikiWord."
-  :expected-result :failed
   ;; Should not leave erroneously created file after test but leaving
   ;; added error cleanup till later if it is even needed!? No file
   ;; should be created so only happens on error!? (If this is


### PR DESCRIPTION
Ensure page creation fails if page name does not match HyWikiWord format.  Enable `hyperbole-mode' whenever `hywiki-mode' is enabled since it uses it.