### PR TITLE
Use compose-mail-other-window for implicit mail address

### DIFF
--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:     25-May-24 at 10:11:05 by Bob Weiner
+;; Last-Mod:     16-Jun-24 at 11:25:46 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -228,7 +228,7 @@ in all buffers."
     (let ((address (mail-address-at-p)))
       (when address
         (ibut:label-set address (match-beginning 1) (match-end 1))
-        (hact 'mail-other-window nil address)))))
+        (hact 'compose-mail-other-window address)))))
 
 ;;; ========================================================================
 ;;; Displays files and directories when a valid pathname is activated.

--- a/test/demo-tests.el
+++ b/test/demo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:      1-Apr-24 at 17:35:46 by Mats Lidell
+;; Last-Mod:     16-Jun-24 at 18:38:13 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -297,7 +297,8 @@
       (with-temp-buffer
         (insert "receiver@mail.org")
         (goto-char 2)
-        (action-key)
+        (let ((mail-user-agent 'sendmail-user-agent))
+          (action-key))
         (should (string= "*mail*" (buffer-name))))
     (hy-test-helpers:kill-buffer "*mail*")))
 

--- a/test/hibtypes-tests.el
+++ b/test/hibtypes-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    20-Feb-21 at 23:45:00
-;; Last-Mod:     21-Feb-24 at 23:55:45 by Mats Lidell
+;; Last-Mod:     16-Jun-24 at 18:45:13 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -47,7 +47,8 @@
       (with-temp-buffer
         (insert "receiver@mail.org")
         (goto-char 2)
-        (ibtypes::mail-address)
+        (let ((mail-user-agent 'sendmail-user-agent))
+          (ibtypes::mail-address))
         (should (string= "*mail*" (buffer-name))))
     (kill-buffer "*mail*")))
 

--- a/test/hmouse-drv-tests.el
+++ b/test/hmouse-drv-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    28-Feb-21 at 22:52:00
-;; Last-Mod:      5-Apr-24 at 23:05:53 by Mats Lidell
+;; Last-Mod:     16-Jun-24 at 18:46:42 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -242,7 +242,8 @@
       (with-temp-buffer
         (insert "receiver@mail.org")
         (goto-char 2)
-        (action-key)
+        (let ((mail-user-agent 'sendmail-user-agent))
+          (action-key))
         (should (string= "*mail*" (buffer-name))))
     (hy-test-helpers:kill-buffer "*mail*")))
 

--- a/test/hyrolo-tests.el
+++ b/test/hyrolo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    19-Jun-21 at 22:42:00
-;; Last-Mod:      1-Jun-24 at 16:49:47 by Mats Lidell
+;; Last-Mod:     16-Jun-24 at 15:46:18 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1488,10 +1488,10 @@ body
     (unwind-protect
         (let ((hypb:mail-address-mode-list '(hyrolo-mode)))
           (hyrolo-grep "receiver\\.org")
-          (mocklet (((mail-other-window nil "first@receiver.org") => t))
+          (mocklet (((compose-mail-other-window "first@receiver.org") => t))
             (hyrolo-mail-to))
           (forward-line)
-          (mocklet (((mail-other-window nil "second@receiver.org") => t))
+          (mocklet (((compose-mail-other-window "second@receiver.org") => t))
             (hyrolo-mail-to)))
       (kill-buffer hyrolo-display-buffer)
       (hy-delete-files-and-buffers hyrolo-file-list))))


### PR DESCRIPTION
# What

Use compose-mail-other-window for mail address ibut.

# Why

Compose-mail allows user to customize the preferred mail composer and
is standard functionality in Emacs.
