### PR TITLE
Just set hywiki-directory to clear the page cache

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2024-06-22  Mats Lidell  <matsl@gnu.org>
+
+* test/hywiki-tests.el
+    (hywiki-tests--get-page-list-when-new-wiki-directory): Verify cache is
+    empty for a new hywiki-directory.
+
 2024-06-22  Bob Weiner  <rsw@gnu.org>
 
 * hywiki.el (hywiki-active-in-current-buffer-p): Fix to highlight HyWikiWords


### PR DESCRIPTION
# What

Just set hywiki-directory to clear the page cache.

# Why

That is all that is needed since hywiki picks up if the
hywiki-directory is changed and clears the cache.
