### PR TITLE
fix warnings

### DIFF
--- a/hact.el
+++ b/hact.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:     23-May-24 at 23:18:43 by Bob Weiner
+;; Last-Mod:     22-Jun-24 at 22:50:10 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -31,6 +31,7 @@
 (declare-function hbut:is-p "hbut")
 (declare-function hpath:absolute-arguments "hpath")
 (declare-function hypb:indirect-function "hypb")
+(declare-function hargs:read-match "hargs")
 
 ;;; ************************************************************************
 ;;; Public variables

--- a/hargs.el
+++ b/hargs.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    31-Oct-91 at 23:17:35
-;; Last-Mod:     29-May-24 at 00:57:17 by Bob Weiner
+;; Last-Mod:     22-Jun-24 at 22:53:41 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -253,7 +253,7 @@ button key (no spaces)."
 (defun hargs:delimited-p (start-delim end-delim
 			  &optional start-regexp-flag end-regexp-flag
 			  list-positions-flag exclude-regexp)
-  "Call `hargs:delimited' with its `as-key' arg set to 'none.
+  "Call `hargs:delimited' with its `as-key' arg set to `none'.
 See `hargs:delimited' for full documentation."
   (hargs:delimited start-delim end-delim start-regexp-flag
 		   end-regexp-flag list-positions-flag exclude-regexp 'none))

--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:     25-May-24 at 16:30:50 by Bob Weiner
+;; Last-Mod:     23-Jun-24 at 00:11:37 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1229,7 +1229,7 @@ of point when desired.
 
 Caller must have used (ibut:at-p) to create hbut:current prior to
 calling this function.  When KEY-SRC is given, this set's
-hbut:current's 'loc attribute to KEY-SRC."
+hbut:current's \\='loc attribute to KEY-SRC."
   (if buffer
       (if (bufferp buffer)
 	  (set-buffer buffer)

--- a/hib-kbd.el
+++ b/hib-kbd.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    22-Nov-91 at 01:37:57
-;; Last-Mod:     18-Feb-24 at 11:39:41 by Mats Lidell
+;; Last-Mod:     23-Jun-24 at 00:04:17 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -105,7 +105,7 @@ Return t if the sequence appears to be valid, else nil."
   "Execute a key series (series of key sequences) around point.
 The key series is delimited by curly braces, {}.  Key sequences
 should be in human readable form, e.g. {C-x C-b}, or what
-`key-description' returns.  Forms such as {\C-b}, {\^b}, and {^M}
+`key-description' returns.  Forms such as {\\`C-b'}, {\\`^b'}, and {\\`^M'}
 will not be recognized.
 
 Any key sequence within the series must be a string of one of the following:
@@ -260,8 +260,8 @@ With optional prefix arg FULL, display full documentation for command."
 When STR is a curly-brace {} delimited key series, a
 non-delimited, normalized form is returned, else nil.  Key
 sequences should be in human readable form, e.g. {\\`C-x' \\`C-b'}, or
-what `key-description' returns.  Forms such as {\\`C-b'}, {\^b}, and
-{^M} will not be recognized.
+what `key-description' returns.  Forms such as {\\`C-b'}, {\\`^b'}, and
+{\\`^M'} will not be recognized.
 
 Any key sequence within the series must be a string of one of the following:
   a Hyperbole minibuffer menu item key sequence,

--- a/hmouse-tag.el
+++ b/hmouse-tag.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    24-Aug-91
-;; Last-Mod:     14-Apr-24 at 21:27:25 by Bob Weiner
+;; Last-Mod:     22-Jun-24 at 22:58:03 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1022,7 +1022,7 @@ It assumes that its caller has already checked that the key was pressed in an
 appropriate buffer and has moved the cursor to the selected buffer.
 
 First, it tries to display the IDENTIFIER definition with
-the current 'xref' backend, which may be `eglot' or `etags' in which case
+the current `xref' backend, which may be `eglot' or `etags' in which case
 Hyperbole walks up the current directory tree to find the nearest TAGS
 file.
 
@@ -1501,7 +1501,7 @@ See the \"${hyperb:dir}/smart-clib-sym\" script for more information."
   "Jump to the single definition of TAG or list definition locations.
 If NEXT is non-nil, jump to the next definition.  Optional
 LIST-OF-TAGS-TABLES are the tags tables to use when
-`xref-find-definitions' is called in a context where the 'etags'
+`xref-find-definitions' is called in a context where the `etags'
 backend is used."
   (when next (setq tag nil))
   (let* ((tags-table-list (or list-of-tags-tables

--- a/hpath.el
+++ b/hpath.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Nov-91 at 00:44:23
-;; Last-Mod:     18-May-24 at 19:06:22 by Bob Weiner
+;; Last-Mod:     23-Jun-24 at 00:09:03 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -2168,7 +2168,7 @@ point ends within the narrowed region."
 	(narrow-to-region omin omax)))))
 
 (defun hpath:trim (path)
-  "Return PATH with any [\" \t\n\r] characters trimmed from its start and end."
+  "Return PATH with any [\" \\t\\n\\r] characters trimmed from its start and end."
   ;; Trim only matching starting and ending quoted double quotes (must
   ;; be a single line string).
   (setq path (string-trim path))

--- a/hsys-org.el
+++ b/hsys-org.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Jul-16 at 14:54:14
-;; Last-Mod:      9-Jun-24 at 12:46:05 by Bob Weiner
+;; Last-Mod:     22-Jun-24 at 23:43:08 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -45,6 +45,7 @@
 ;;; ************************************************************************
 
 (declare-function consult-grep "ext:consult")
+(declare-function consult-ripgrep "ext:consult")
 
 (defcustom hsys-org-consult-grep-func
   (cond ((executable-find "rg")
@@ -56,6 +57,7 @@
 
 (defvar hyperbole-mode-map)             ; "hyperbole.el"
 (defvar org--inhibit-version-check)     ; "org-macs.el"
+(defvar hywiki-org-link-type-required)  ; "hywiki.el"
 
 (declare-function org-babel-get-src-block-info "org-babel")
 (declare-function org-fold-show-context "org-fold")
@@ -71,6 +73,7 @@
 (declare-function hkey-either "hmouse-drv")
 
 (declare-function find-library-name "find-func")
+(declare-function hyperb:stack-frame "hversion.el")
 
 ;;;###autoload
 (defcustom hsys-org-enable-smart-keys 'unset

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Jun-89 at 22:08:29
-;; Last-Mod:     29-May-24 at 00:57:28 by Bob Weiner
+;; Last-Mod:     22-Jun-24 at 23:44:04 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -135,6 +135,7 @@
 ;; Forward declarations
 (defvar consult-grep-args)
 (defvar consult-ripgrep-args)
+(defvar consult-async-split-style)
 (defvar google-contacts-expire-time)
 (defvar google-contacts-history)
 (defvar google-contacts-query-string)

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Apr-24 at 22:41:13
-;; Last-Mod:     19-Jun-24 at 15:08:31 by Bob Weiner
+;; Last-Mod:     23-Jun-24 at 00:12:37 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -116,6 +116,7 @@
 ;;; Public declarations
 ;;; ************************************************************************
 
+(defvar org-agenda-buffer-tmp-name)  ;; "org-agenda.el"
 (declare-function org-link-store-props "ol" (&rest plist))
 
 ;;; ************************************************************************
@@ -164,8 +165,8 @@ Use nil for no HyWiki mode indicator."
 
 (defvar-local hywiki-buffer-highlighted-state nil
   "State of HyWikiWords highlighting in the associated buffer.
-'h means the buffer was already highlighted;
-'d means the buffer was dehighlighted;
+\\='h means the buffer was already highlighted;
+\\='d means the buffer was dehighlighted;
 nil means no full buffer highlighting has occurred.")
 
 (defvar hywiki-non-character-commands
@@ -430,7 +431,7 @@ call)
 
 By default, create any non-existent page.  With optional
 PROMPT-FLAG t, prompt to create if non-existent.  If PROMPT-FLAG
-is 'exists, return nil unless the page already exists.  After
+is \\='exists, return nil unless the page already exists.  After
 successfully finding a page and reading it into a buffer, run
 `hywiki-find-page-hook'."
   (interactive (list (completing-read "Find HyWiki page: " (hywiki-get-page-list))))


### PR DESCRIPTION
# What

1. Remove compile warnings.
2. Fix control char warnings in docstrings (in a separate commit.)

# Why

Warnings blurs the picture so we should try to keep them at a
minimum. These have been around for some time and I got some time to
look over them.
