### PR TITLE
Makefile (dockerized-run): Add to run dockerized images

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2024-06-23  Bob Weiner  <rsw@gnu.org>
+
+* Makefile: (dockerized-run): Add to intweractively run dockerized versions
+    of Emacs with Hyperbole.  Update Commentary to summarize dockerized
+    targets that build, byte-compile and run Hyperbole.
+
 2024-06-22  Mats Lidell  <matsl@gnu.org>
 
 * test/hywiki-tests.el

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:     22-Jun-24 at 11:35:21 by Mats Lidell
+# Last-Mod:     23-Jun-24 at 00:16:22 by Bob Weiner
 #
 # Copyright (C) 1994-2023  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -76,6 +76,15 @@
 #                   make test                  - run non-interactive tests in batch mode
 #                   make test-all              - run all tests starting an interactive Emacs
 #                   make test test=<test-name> - run a single test or tests matching the name
+#
+#               To interactively run a dockerized version of Emacs with Hyperbole:
+#                   make dockerized-run                - default to running master
+#                   make dockerized-run version=27.1   - run Emacs V27.1
+#
+#               To build and test a dockerized version of Emacs with Hyperbole:
+#                   make dockerized                    - defaults: version=master targets='clean bin test'
+#
+#                   make dockerized version=28.2 targets='clean bin' - Emacs 28.2 with Hyperbole byte-compiled (possibly natively compiled)
 #
 #               Verify hyperbole installation using different sources:
 #                   make install-<source>
@@ -544,11 +553,7 @@ lint:
 	-l package-lint.el -f package-lint-batch-and-exit \
 	$(EL_KOTL) $(EL_SRC)
 
-# Run a build using a dockerized version of Emacs
-#
-# Usage:
-#   make dockerized version=master targets='clean bin test'
-#   make dockerized version=28.2 targets='clean bin test'
+# Dockerized versions of Emacs for interactive running and test execution
 
 # Specify version and targets to run
 ifeq ($(origin targets), command line)
@@ -564,6 +569,9 @@ endif
 
 dockerized:
 	docker run -v $$(pwd):/hypb -it silex/emacs:${DOCKER_VERSION} bash -c "cp -a /hypb /hyperbole && make -C hyperbole ${DOCKER_TARGETS}"
+
+dockerized-run:
+	docker run -v $$(pwd):/hypb -it silex/emacs:${DOCKER_VERSION}
 
 # Update the docker image for the specified version of Emacs
 dockerized-update:


### PR DESCRIPTION
Also, document all dockerized Makefile targets in the Commentary.