### PR TITLE
update docker for batch tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,10 +2,10 @@
 
 * Makefile (internal-docker-all-tests-ert-output): Target for running all
     tests using ert from within docker used by docker-all-tests.
-    (VERSIONS): List of Emacs versions to run batch-tests and all-tests to
+    (VERSIONS_VERSIONS): List of Emacs versions to run batch-tests and all-tests to
     check same versions as the CI/CD run locally.
     (docker-all-tests, docker-batch-tests): Targets for running
-    batch-tests and all-tests for all VERSIONS.
+    batch-tests and all-tests for all DOCKER_VERSIONS.
     Update developer target documentation.
 
 2024-06-30  Bob Weiner  <rsw@gnu.org>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2024-06-30  Mats Lidell  <matsl@gnu.org>
+
+* Makefile (docker-test-all-ert): Target for running all tests using ert
+    from within docker.
+    (VERSIONS): List of Emacs versions to run batch tests for to allow
+    checking same versions as the CI/CD run locally.
+    (docker-batch-test-all, docker-batch-test): Run batch tests for all
+    VERSIONS.
+
 2024-06-30  Bob Weiner  <rsw@gnu.org>
 
 * hbut.el (defib): Remove requirement for call to 'hact' since sometimes

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,11 +1,12 @@
 2024-06-30  Mats Lidell  <matsl@gnu.org>
 
-* Makefile (docker-test-all-ert): Target for running all tests using ert
-    from within docker.
-    (VERSIONS): List of Emacs versions to run batch tests for to allow
-    checking same versions as the CI/CD run locally.
-    (docker-batch-test-all, docker-batch-test): Run batch tests for all
-    VERSIONS.
+* Makefile (internal-docker-all-tests-ert-output): Target for running all
+    tests using ert from within docker used by docker-all-tests.
+    (VERSIONS): List of Emacs versions to run batch-tests and all-tests to
+    check same versions as the CI/CD run locally.
+    (docker-all-tests, docker-batch-tests): Targets for running
+    batch-tests and all-tests for all VERSIONS.
+    Update developer target documentation.
 
 2024-06-30  Bob Weiner  <rsw@gnu.org>
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:     30-Jun-24 at 11:12:17 by Mats Lidell
+# Last-Mod:     30-Jun-24 at 19:08:27 by Mats Lidell
 #
 # Copyright (C) 1994-2023  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -86,7 +86,7 @@
 #
 #                   make docker version=28.2 targets='clean bin' - byte-compile Hyperbole with Emacs 28.2
 #
-#                   For CI/CD Emacs versions see macro VERSIONS below.
+#                   For CI/CD Emacs versions see macro DOCKER_VERSIONS below.
 #
 #		    make docker-batch-tests      - run all non-interactive tests in docker for all CI/CD Emacs versions
 #		    make docker-all-tests        - run all tests in docker for all CI/CD Emacs versions
@@ -175,6 +175,9 @@ ELISP_TO_COMPILE = $(pkg_parent)/elc-${USER}
 # Path to dir where the web repository is located i.e. hypb:web-repo-location
 HYPB_WEB_REPO_LOCATION = "../hyweb/hyperbole/"
 
+# CI/CD Emacs versions for local docker based tests
+DOCKER_VERSIONS=27.2 28.2 29.3 master
+
 ##########################################################################
 #                     NO CHANGES REQUIRED BELOW HERE.                    #
 ##########################################################################
@@ -254,7 +257,7 @@ help:
 	@echo "  To run unit tests:"
 	@echo "     make all-tests          - run all tests with Emacs under a window system"
 	@echo "     make batch-tests        - run non-interactive tests with Emacs in batch mode"
-	@echo "  Using docker and the macro VERSIONS for selected Emacs versions to test against"
+	@echo "  Using docker and the macro DOCKER_VERSIONS for selected Emacs versions to test against"
 	@echo "     make docker-all-tests   - run all tests"
 	@echo "     make docker-batch-tests - run non-interactive tests"
 	@echo "  To selectively run make targets in docker:"
@@ -547,10 +550,9 @@ test-all-output:
 internal-docker-all-tests-ert-output:
 	@$(EMACS) --quick $(PRELOADS) --eval "(load-file \"test/hy-test-dependencies.el\")" --eval "(let ($(LET_VARIABLES) (ert-quiet t)) $(LOAD_TEST_ERT_FILES) (ert t) (with-current-buffer \"*ert*\" (write-region (point-min) (point-max) \"/hypb-tmp/ERT-OUTPUT-ERT\")) (kill-emacs))"
 
-VERSIONS=27.2 28.2 29.3 master
 docker-all-tests:
 	@total_summary=$(shell mktemp); \
-	for i in $(VERSIONS); do printf "=== Emacs $$i ===\n" | tee -a $$total_summary; \
+	for i in $(DOCKER_VERSIONS); do printf "=== Emacs $$i ===\n" | tee -a $$total_summary; \
 		make docker version=$$i targets='clean bin internal-docker-all-tests-ert-output'; \
 		cat /tmp/ERT-OUTPUT-ERT | tee -a $$total_summary; \
 	done; \
@@ -559,7 +561,7 @@ docker-all-tests:
 
 docker-batch-tests:
 	@total_summary=$(shell mktemp); build_summary=$(shell mktemp); \
-	for i in $(VERSIONS); do printf "=== Emacs $$i ===\n" | tee -a $$total_summary; \
+	for i in $(DOCKER_VERSIONS); do printf "=== Emacs $$i ===\n" | tee -a $$total_summary; \
 		make docker version=$$i targets='clean bin test' | tee $$build_summary; \
 		sed -n -E '/^Ran [0123456789]+ tests/,/^make:/p' $$build_summary | head -n-1 | tee -a $$total_summary; \
 	done; \


### PR DESCRIPTION
# What

Run batch tests for multiple Emacs versions using docker. Introduces new targets for running all batch tests and all tests for all CI/CD versions of Emacs.  Update docs in Makefile for the changes.

# Why

We want to be able to run the tests locally covering the same tests as the CI/CD and even cover the interactive tests.

# Note

Updates the docs with the preferred names of the targets as discussed in the PR. But kept, at least for now my preferred names, for the old targets for backwards compatibility. We have some loose targets as well but I suggest we clean up after getting some experience with what targets we really uses.

The docker target for running all tests, `docker-all-tests,` summarizes the execution for each version by showing the `*ert*` buffer. That was the only way I could get a not mangled output using built in functionality. I propose we give that a try for now and if that is found to be less ideal we could develop our own ert-summarize function. I'm thinking that the local CI/CD check is mostly for a go/nogo check and not for debugging.

Further improvements to consider is to provide the test dependencies and other dynamic dependencies (ie markdown-mode) in an off-line way so not all docker runs needs to connect to elpa and melpa and download those packages over an over again. This could also be achieved by preparing a local docker image or maybe reuse an instance. So many options. :smile: Anyway. Lets see what we feel is required after giving this a spin for a while. 

