### PR TITLE
hibtypes.el(ipython-stack-frame, ripgrep-msg, grep-msg): Standardize

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,9 +1,17 @@
+2024-06-30  Bob Weiner  <rsw@gnu.org>
+
+* hpath.el (hpath:find-line): Allow line-num and col-num to be strings.
+  hibtypes.el (hib-link-to-file-line): Add to share among multiple grep
+    file ibtypes.
+  hibtypes.el (ipython-stack-frame, ripgrep-msg, grep-msg): Standardize
+    by using above new function.
+
 2024-06-30  Mats Lidell  <matsl@gnu.org>
 
 * Makefile (internal-docker-all-tests-ert-output): Target for running all
     tests using ert from within docker used by docker-all-tests.
-    (VERSIONS_VERSIONS): List of Emacs versions to run batch-tests and all-tests to
-    check same versions as the CI/CD run locally.
+    (VERSIONS_VERSIONS): List of Emacs versions to run batch-tests and
+    all-tests to check same versions as the CI/CD run locally.
     (docker-all-tests, docker-batch-tests): Targets for running
     batch-tests and all-tests for all DOCKER_VERSIONS.
     Update developer target documentation.

--- a/hactypes.el
+++ b/hactypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    23-Sep-91 at 20:34:36
-;; Last-Mod:     10-Mar-24 at 18:35:02 by Bob Weiner
+;; Last-Mod:     30-Jun-24 at 17:12:44 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -429,7 +429,8 @@ the window or as close as possible."
     (hypb:error "(link-to-file): Invalid file name: \"%s\"" path)))
 
 (defact link-to-file-line (path line-num)
-  "Display a file given by PATH scrolled to LINE-NUM."
+  "Display a file given by PATH scrolled to LINE-NUM.
+LINE-NUM may be an integer or string."
   (interactive "fPath to link to: \nnDisplay at line number: ")
   ;; Remove any double quotes and whitespace at the start and end of
   ;; the path that interactive use may have introduced.

--- a/hasht.el
+++ b/hasht.el
@@ -8,7 +8,7 @@
 ;; AUTHOR:       Bob Weiner
 ;;
 ;; ORIG-DATE:    16-Mar-90 at 03:38:48
-;; LAST-MOD:     30-Jul-16 at 08:50:38 by Bob Weiner
+;; LAST-MOD:     30-Jun-24 at 17:39:31 by Bob Weiner
 ;;
 ;; Copyright (C) 1990-1995, 1997, 2016  Free Software Foundation, Inc.
 ;; See the file BR-COPY for license information.
@@ -50,7 +50,7 @@
 ;;; ************************************************************************
 
 (defvar hash-merge-values-function 'hash-merge-values
-  "*Function to call in hash-merge to merge the values from 2 hash tables that contain the same key.
+  "*Hash-merge function to merge values from 2 hash tables with the same key.
 It is sent the two values as arguments.")
 
 ;;; ************************************************************************
@@ -194,7 +194,7 @@ in reverse order of occurrence (they are prepended to the list)."
     (cons 'hasht obarray)))
 
 (defun hash-map (func hash-table)
-  "Return a list of the results of applying FUNC to each (<value> . <key>) element of HASH-TABLE."
+  "Return result of applying FUNC over each (<value> . <key>) in HASH-TABLE."
   (if (not (hashp hash-table))
       (error "(hash-map): Invalid hash-table: `%s'" hash-table))
   (let ((result))

--- a/hpath.el
+++ b/hpath.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Nov-91 at 00:44:23
-;; Last-Mod:     23-Jun-24 at 00:09:03 by Mats Lidell
+;; Last-Mod:     30-Jun-24 at 17:09:25 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1686,6 +1686,7 @@ Return nil if none are found."
 
 (defun hpath:find-line (filename line-num &optional col-num display-where)
   "Edit file FILENAME with point placed at LINE-NUM and optional COL-NUM.
+When given, LINE-NUM and COL-NUM may be strings or integers.
 
 `hpath:display-where-alist' is consulted using the optional
 argument, DISPLAY-WHERE (a symbol) or if that is nil, the value
@@ -1700,10 +1701,14 @@ frame.  Always return t."
   (hpath:find
    (concat
     filename
-    (when (integerp line-num)
-      (concat ":" (int-to-string line-num)))
-    (when (integerp col-num)
-      (concat ":" (int-to-string col-num))))
+    (cond ((integerp line-num)
+	   (concat ":" (int-to-string line-num)))
+	  ((stringp line-num)
+	   (concat ":" line-num)))
+    (cond ((integerp col-num)
+	   (concat ":" (int-to-string col-num)))
+	  ((stringp col-num)
+	   (concat ":" col-num))))
    display-where)
   t)
 


### PR DESCRIPTION
hibtypes.el (hib-link-to-file-line): Add this new function to standardize multiple file and line display ibtypes.