### PR TITLE
Respect test specifier for the all-tests target

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2024-07-07  Mats Lidell  <matsl@gnu.org>
+
+* Makefile (HYPB_ERT_INTERACTIVE): New macro for supplying the test
+    specifier as given by the command line test to the all-tests target.
+
 2024-07-06  Bob Weiner  <rsw@gnu.org>
 
 * hibtypes.el (org-id): Fix bug in older versions of Org where where

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:      4-Jul-24 at 11:26:09 by Bob Weiner
+# Last-Mod:      7-Jul-24 at 22:21:42 by Mats Lidell
 #
 # Copyright (C) 1994-2023  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -504,8 +504,10 @@ LOAD_TEST_ERT_FILES=$(patsubst %,(load-file \"%\"),${TEST_ERT_FILES})
 # tests specified by the selector. See "(ert)test selectors"
 ifeq ($(origin test), command line)
 HYPB_ERT_BATCH = (ert-run-tests-batch-and-exit \"${test}\")
+HYPB_ERT_INTERACTIVE = (ert-run-tests-interactively \"${test}\")
 else
 HYPB_ERT_BATCH = (ert-run-tests-batch-and-exit)
+HYPB_ERT_INTERACTIVE = (ert-run-tests-interactively t)
 endif
 
 # For full backtrace run make test FULL_BT=<anything or even empty>
@@ -531,14 +533,14 @@ test-all:
 ifeq ($(TERM), dumb)
 ifneq (,$(findstring .apple.,$(DISPLAY)))
         # Found, on MacOS
-	TERM=xterm-256color $(EMACS) --quick $(PRELOADS) --eval "(load-file \"test/hy-test-dependencies.el\")" --eval "(let ((auto-save-default)) $(LOAD_TEST_ERT_FILES) (ert-run-tests-interactively t))"
+	TERM=xterm-256color $(EMACS) --quick $(PRELOADS) --eval "(load-file \"test/hy-test-dependencies.el\")" --eval "(let ((auto-save-default)) $(LOAD_TEST_ERT_FILES) $(HYPB_ERT_INTERACTIVE))"
 else
         # Not found, set TERM so tests will at least run within parent Emacs session
-	TERM=vt100 $(EMACS) --quick $(PRELOADS) --eval "(load-file \"test/hy-test-dependencies.el\")" --eval "(let ($(LET_VARIABLES)) $(LOAD_TEST_ERT_FILES) (ert-run-tests-interactively t))"
+	TERM=vt100 $(EMACS) --quick $(PRELOADS) --eval "(load-file \"test/hy-test-dependencies.el\")" --eval "(let ($(LET_VARIABLES)) $(LOAD_TEST_ERT_FILES) $(HYPB_ERT_INTERACTIVE))"
 endif
 else
         # Typical case, run emacs normally
-	$(EMACS) --quick $(PRELOADS) --eval "(load-file \"test/hy-test-dependencies.el\")" --eval "(let ($(LET_VARIABLES)) $(LOAD_TEST_ERT_FILES) (ert-run-tests-interactively t))"
+	$(EMACS) --quick $(PRELOADS) --eval "(load-file \"test/hy-test-dependencies.el\")" --eval "(let ($(LET_VARIABLES)) $(LOAD_TEST_ERT_FILES) $(HYPB_ERT_INTERACTIVE))"
 endif
 
 test-all-output:


### PR DESCRIPTION
# What

Add new macro for supplying the test specifier, as given by the
command line test, to the all-tests target.

# Why

To support running make all-tests for a limited number of test or even
just a single one. Can be used from the docker target to support
debugging test cases that fails for a specific Emacs version.

Example:

    make docker version=27.2 targets='clean all-tests test=hyrolo'
    
Will clean the (copied) workspace from any compiled files and then run
all-tests with the specifier set to hyrolo. ie. just run tests
matching that specifier.

Since all-tests does not terminate Emacs the system is in a state
where the tests can be debugged and the backtrace of any failing test
can be examined.
