### PR TITLE
Use 29.4 in CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [27.2, 28.2, 29.3, master]
+        version: [27.2, 28.2, 29.4, master]
     container: silex/emacs:${{ matrix.version }}-ci
 
     steps:

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2024-07-07  Mats Lidell  <matsl@gnu.org>
+
+* .github/workflows/main.yml (jobs): Use update 29 to 29.4 in CI workflow.
+
 2024-07-06  Bob Weiner  <rsw@gnu.org>
 
 * hibtypes.el (org-id): Fix bug in older versions of Org where where


### PR DESCRIPTION
# What

Use 29.4 in CI workflow.

# Why

29.4 is the latest official release in the 29 series. See [Emacs releases]( https://www.gnu.org/software/emacs/history.html).

# Note

This requires changing github to drop the requirement for a successful
29.3 build and instead require 29.4 build. 

See `settings/branch_protection_rules` to configure the status checks to allow for this change.
