### PR TITLE
HyRolo tags searching; HyWikiWord improved highlight/dehighlight; improved ibtype debugging

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,8 @@
 * hsys-org-roam.el (hsys-org-roam-tags-view, hsys-org-roam-consult-grep): Prompt
     whether to install needed package when not yet installed.
 
+* hbut.el (ibut:create): Improve messages and traceback generation on ibtype error.
+
 2024-07-06  Bob Weiner  <rsw@gnu.org>
 
 * hibtypes.el (org-id): Fix bug in older versions of Org where where

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 2024-07-07  Bob Weiner  <rsw@gnu.org>
 
+* hywiki.el (hywiki-word-highlight-flag-changed): Ensure highlighting via
+    'window-buffer-change-functions' is properly reset when toggling this flag.
+    Also ensure highlighting/dehighlighting of HyWikiWords.  Remove separate
+    setting of this functions variable since this function is called on load.
+
 * hpath.el  (hpath:expand-list): Change 3rd arg from 'exists-flag' to 'filter',
     a predicate function that allows filtering the list of returned paths,
     e.g. 'file-readable-p'.  It t is sent, then file 'file-exists-p' is used.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,9 @@
 2024-07-07  Bob Weiner  <rsw@gnu.org>
 
+* hibtypes.el (elisp-compiler-msg): Fix to handle both of these cases:
+  skipped  13/15  hywiki-tests--no-face-property-for-no-wikipage (0.000121 sec)
+  SKIPPED  hywiki-tests--face-property-for-wikiword-with-wikipage
+
 * hywiki.el (hywiki-word-highlight-flag-changed): Ensure highlighting via
     'window-buffer-change-functions' is properly reset when toggling this flag.
     Also ensure highlighting/dehighlighting of HyWikiWords.  Remove separate

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,19 @@
+2024-07-07  Bob Weiner  <rsw@gnu.org>
+
+* hpath.el  (hpath:expand-list): Change 3rd arg from 'exists-flag' to 'filter',
+    a predicate function that allows filtering the list of returned paths,
+    e.g. 'file-readable-p'.  It t is sent, then file 'file-exists-p' is used.
+  hyrolo.el (hyrolo-expand-path-list): Update to return only readable files.
+            (hyrolo-at-tags-p): Add to test if point is within HyRolo Org tags.
+	    (hyrolo-tags-view): Add to display HyRolo Org tags using Agenda search.
+  hsys-org.el (hsys-org-hyrolo-agenda-tags): Add.
+              (hsys-org-agenda-tags-p): Add calls to above new functions.
+  hsys-consult.el (hsys-consult-hyrolo-grep-tags): Add.
+                  (hsys-consult-org-grep-tags-p): Add calls to above new functions.
+
+* hsys-org-roam.el (hsys-org-roam-tags-view, hsys-org-roam-consult-grep): Prompt
+    whether to install needed package when not yet installed.
+
 2024-07-06  Bob Weiner  <rsw@gnu.org>
 
 * hibtypes.el (org-id): Fix bug in older versions of Org where where

--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:      6-Jul-24 at 01:31:19 by Bob Weiner
+;; Last-Mod:      7-Jul-24 at 14:57:30 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1959,13 +1959,9 @@ If a new button is created, store its attributes in the symbol,
 			   (setq itype (car types))
 			   (when (condition-case err
 				     (and itype (setq args (funcall itype)))
-				   ;; Purposely trigger another error
-				   ;; here by sending a symbol
-				   ;; argument to the message call
-				   ;; below so can see the value of
-				   ;; itype whose funcall failed above.
-				   (error (progn (message "%S" err)
-						 (message itype))))
+				   (error (progn (message "%S: %S" itype err)
+						 ;; Show full stack trace
+						 (debug))))
 			     (setq is-type itype)
 			     ;; Any implicit button type check should leave point
 			     ;; unchanged.  Trigger an error if not.

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:      6-Jul-24 at 01:43:04 by Bob Weiner
+;; Last-Mod:      7-Jul-24 at 23:38:46 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1180,13 +1180,13 @@ This works when activated anywhere within file line references."
             (save-excursion
               (and (re-search-backward "^[^ \t\n\r]" nil t)
                    (looking-at "While compiling\\|In \\([^ \n]+\\):$"))))
-    (let (src buffer-p label start-end
-	  lbl-start-end)
+    (let ((case-fold-search t)
+	  src buffer-p label start-end lbl-start-end)
       (or
        ;; Emacs Regression Test (ERT) output lines
        (when (or (save-excursion
 		   (forward-line 0)
-		   (or (looking-at "\\s-+\\(passed\\|failed\\|skipped\\)\\s-+[0-9]+/[0-9]+\\s-+\\(\\S-+\\)\\s-+(")
+		   (or (looking-at "\\s-+\\(passed\\|failed\\|skipped\\)\\s-+\\(?:[0-9]+/[0-9]+\\s-+\\)\\(\\S-+\\)")
 		       (looking-at "\\(Test\\)\\s-+\\(\\S-+\\)\\s-+\\(backtrace\\|condition\\):")))
 		 ;; Handle symbols and pathnames in a backtrace from an ERT test exception
 		 (save-match-data

--- a/hsys-consult.el
+++ b/hsys-consult.el
@@ -2,7 +2,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     4-Jul-24 at 09:57:18
-;; Last-Mod:      6-Jul-24 at 00:24:36 by Bob Weiner
+;; Last-Mod:      7-Jul-24 at 21:58:54 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -117,7 +117,9 @@ call."
 	  ((hsys-org-roam-directory-at-tags-p t)
 	   #'hsys-consult-org-roam-grep-tags)
 	  ((hywiki-at-tags-p t)
-	   #'hsys-consult-hywiki-grep-tags))))
+	   #'hsys-consult-hywiki-grep-tags)
+	  ((hyrolo-at-tags-p t)
+	   #'hsys-consult-hyrolo-grep-tags))))
 
 (defun hsys-consult-grep-tags (org-consult-grep-function)
   "When on an Org tag, call ORG-CONSULT-GREP-FUNCTION to find matches.
@@ -130,6 +132,13 @@ max-count which finds all matches within headlines only."
   (interactive)
   (when (hsys-org-at-tags-p)
     (funcall org-consult-grep-function (hsys-consult--org-grep-tags-string) 0)))
+
+(defun hsys-consult-hyrolo-grep-tags ()
+  "When on a HyRolo tag, use `consult-grep' to list all HyRolo tag matches.
+If on a colon, match to sections with all tags around point;
+otherwise, just match to the single tag around point."
+  (interactive)
+  (hsys-consult-grep-tags #'hyrolo-consult-grep))
 
 (defun hsys-consult-hywiki-grep-tags ()
   "When on a HyWiki tag, use `consult-grep' to list all HyWiki tag matches.

--- a/hsys-org-roam.el
+++ b/hsys-org-roam.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    26-Feb-23 at 11:20:15 by Bob Weiner
-;; Last-Mod:      6-Jul-24 at 00:11:29 by Bob Weiner
+;; Last-Mod:      7-Jul-24 at 17:04:57 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -46,9 +46,7 @@
 Actual grep function used is given by the variable,
 `consult-org-roam-grep-func'."
   (interactive)
-  (unless (package-installed-p 'consult-org-roam)
-    (package-install 'consult-org-roam))
-  (require 'consult-org-roam)
+  (hypb:require-package 'consult-org-roam)
   (let ((grep-func (when (and (boundp 'consult-org-roam-grep-func)
 			      (fboundp consult-org-roam-grep-func))
 		     consult-org-roam-grep-func)))
@@ -73,9 +71,7 @@ todo items only.  With optional VIEW-BUFFER-NAME, use that rather
 than the default, \"*Org Roam Tags*\"."
   (interactive "P")
   (require 'org-agenda)
-  (unless (package-installed-p 'org-roam)
-    (package-install 'org-roam))
-  (require 'org-roam)
+  (hypb:require-package 'org-roam)
   (let* ((org-agenda-files (list org-roam-directory))
 	 (org-agenda-buffer-name (or view-buffer-name "*Org Roam Tags*"))
 	 ;; `org-tags-view' is mis-written to require setting this next

--- a/hsys-org.el
+++ b/hsys-org.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Jul-16 at 14:54:14
-;; Last-Mod:      6-Jul-24 at 00:25:11 by Bob Weiner
+;; Last-Mod:      7-Jul-24 at 21:52:26 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -163,7 +163,9 @@ call."
 	  ((hsys-org-roam-directory-at-tags-p t)
 	   #'hsys-org-roam-agenda-tags)
 	  ((hywiki-at-tags-p t)
-	   #'hsys-org-hywiki-agenda-tags))))
+	   #'hsys-org-hywiki-agenda-tags)
+	  ((hyrolo-at-tags-p t)
+	   #'hsys-org-hyrolo-agenda-tags))))
 
 (defun hsys-org-get-agenda-tags (org-consult-agenda-function)
   "When on an Org tag, call ORG-CONSULT-AGENDA-FUNCTION to find matches.
@@ -176,6 +178,13 @@ max-count which finds all matches within headlines only."
   (interactive)
   (when (hsys-org-at-tags-p)
     (funcall org-consult-agenda-function nil (hsys-org--agenda-tags-string))))
+
+(defun hsys-org-hyrolo-agenda-tags ()
+  "When on a HyRolo tag, use `hyrolo-tags-view' to list all HyRolo tag matches.
+If on a colon, match to sections with all tags around point;
+otherwise, just match to the single tag around point."
+  (interactive)
+  (hsys-org-get-agenda-tags #'hyrolo-tags-view))
 
 (defun hsys-org-hywiki-agenda-tags ()
   "When on a HyWiki tag, use `hywiki-tags-view' to list all HyWiki tag matches.

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Apr-24 at 22:41:13
-;; Last-Mod:      6-Jul-24 at 00:05:17 by Bob Weiner
+;; Last-Mod:      7-Jul-24 at 23:15:29 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -564,7 +564,6 @@ interactively), limit dehighlighting to the region."
 
 (defun hywiki-directory-modified-p ()
   "Return non-nil if `hywiki-directory' has been modified since last read."
-
   (or (zerop hywiki--directory-mod-time)
       (/= hywiki--directory-mod-time (hywiki-directory-get-mod-time))))
 

--- a/hywiki.el
+++ b/hywiki.el
@@ -1005,6 +1005,8 @@ Highlight/dehighlight HyWiki page names across all frames on change."
 	;; enabled
 	(progn (add-hook 'post-self-insert-hook 'hywiki-buttonize-character-commands)
 	       (add-hook 'post-command-hook     'hywiki-buttonize-non-character-commands 95)
+	       (add-hook 'window-buffer-change-functions
+			 'hywiki-maybe-highlight-page-names-in-frame)
 	       (add-to-list 'yank-handled-properties
 			    '(hywiki-word-face . hywiki-highlight-on-yank))
 	       (hywiki-maybe-highlight-page-names-in-frame t))
@@ -1012,6 +1014,9 @@ Highlight/dehighlight HyWiki page names across all frames on change."
       (remove-hook 'post-self-insert-hook 'hywiki-buttonize-character-commands)
       (remove-hook 'post-command-hook     'hywiki-buttonize-non-character-commands)
       (hywiki-mode 0) ;; also dehighlights HyWiki words outside of HyWiki pages
+      (remove-hook 'window-buffer-change-functions
+		   'hywiki-maybe-highlight-page-names-in-frame)
+      (hywiki-maybe-highlight-page-names-in-frame t)
       (setq yank-handled-properties
 	    (delete '(hywiki-word-face . hywiki-highlight-on-yank)
 		    yank-handled-properties)))))
@@ -1042,9 +1047,6 @@ Highlight/dehighlight HyWiki page names across all frames on change."
 ;; Sets HyWiki page auto-HyWikiWord highlighting and `yank-handled-properties'
 (hywiki-word-highlight-flag-changed 'hywiki-word-highlight-flag
 				    hywiki-word-highlight-flag 'set nil)
-
-(add-to-list 'window-buffer-change-functions
-	     #'hywiki-maybe-highlight-page-names-in-frame nil 'eq)
 
 (provide 'hywiki)
 


### PR DESCRIPTION
 [hyrolo - Add support for Org tags Agenda searching or consult-grep](https://github.com/rswgnu/hyperbole/commit/287a2dcaad2e2ea8f354d169da6325e8490f2dce) 

[ibut:create - Improve messages and traceback gen on ibtype error](https://github.com/rswgnu/hyperbole/commit/ed438e42beb527dfa5cde023e8d35e38be5dfba5)

[hywiki-word-highlight-flag-changed - highlight/dehighlight WikiWords](https://github.com/rswgnu/hyperbole/commit/28bb3a3f045f1f6850e65c835f89057af6526367)

[elisp-compiler-msg - Fix to handle two forms of test result messages](https://github.com/rswgnu/hyperbole/pull/559/commits/c77f4460ccaa990382d6acaeb93282cfeb6bdb57)