### PR TITLE
minor cleanups

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -196,7 +196,7 @@
             (hynote-file): Add ibtype to display non-HyWikiWord files in
     hywiki-directory'.
 
-* Makefile: (docker-run): Add to intweractively run docker versions
+* Makefile: (docker-run): Add to interactively run docker versions
     of Emacs with Hyperbole.  Update Commentary to summarize docker
     targets that build, byte-compile and run Hyperbole.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2024-07-12  Mats Lidell  <matsl@gnu.org>
+
+* test/hywiki-tests.el (hywiki-tests--maybe-at-wikiword-beginning): Fix
+    set of acceptable chars and use escaped notation.
+
 2024-07-07  Bob Weiner  <rsw@gnu.org>
 
 * hibtypes.el (elisp-compiler-msg): Fix to handle both of these cases:

--- a/hact.el
+++ b/hact.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:     22-Jun-24 at 22:50:10 by Mats Lidell
+;; Last-Mod:     12-Jul-24 at 23:32:57 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -368,7 +368,7 @@ Autoloads action function if need be to get the parameter list."
 	   (action:params-emacs action)))
 	((symbolp action)
 	 (car (cdr (and (fboundp action) (hypb:indirect-function action)))))
-	((and (fboundp #'closurep) (closurep action))
+	((and (fboundp 'closurep) (closurep action))
 	 (aref action 0))))
 
 (defun action:param-list (action)
@@ -414,7 +414,7 @@ performing ACTION."
 	   (setq args (hpath:absolute-arguments actype args)))
       (let ((hist-elt (hhist:element)))
 	(run-hooks 'action-act-hook)
-	(prog1 (or (when (and (fboundp #'closurep) (closurep action))
+	(prog1 (or (when (and (fboundp 'closurep) (closurep action))
 			 (apply action args))
 		   (if (or (symbolp action) (listp action)
 			   (byte-code-function-p action)

--- a/hargs.el
+++ b/hargs.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    31-Oct-91 at 23:17:35
-;; Last-Mod:     22-Jun-24 at 22:53:41 by Mats Lidell
+;; Last-Mod:     12-Jul-24 at 23:33:16 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -102,7 +102,7 @@ Return nil if ACTION is not a list or `byte-code' object, has no
 interactive form or takes no arguments."
   (save-excursion
     (and (or (subrp action) (byte-code-function-p action) (listp action)
-             (and (fboundp #'closurep) (closurep action)))
+             (and (fboundp 'closurep) (closurep action)))
 	 (let ((interactive-form (action:commandp action)))
 	   (when interactive-form
 	     (hpath:relative-arguments

--- a/hasht.el
+++ b/hasht.el
@@ -8,7 +8,7 @@
 ;; AUTHOR:       Bob Weiner
 ;;
 ;; ORIG-DATE:    16-Mar-90 at 03:38:48
-;; LAST-MOD:     30-Jun-24 at 17:39:31 by Bob Weiner
+;; LAST-MOD:     12-Jul-24 at 23:22:26 by Mats Lidell
 ;;
 ;; Copyright (C) 1990-1995, 1997, 2016  Free Software Foundation, Inc.
 ;; See the file BR-COPY for license information.
@@ -54,6 +54,12 @@
 It is sent the two values as arguments.")
 
 ;;; ************************************************************************
+;;; Public declarations
+;;; ************************************************************************
+
+(defvar hash-empty-htable)
+
+;;; ************************************************************************
 ;;; Public functions
 ;;; ************************************************************************
 
@@ -66,7 +72,8 @@ Replaces any VALUE previously referenced by KEY."
 	(if sym (set sym value)))))
 
 (defun hash-copy (hash-table)
-  "Return a copy of HASH-TABLE, list and vector elements are shared across both tables."
+  "Return a copy of HASH-TABLE.
+List and vector elements are shared across both tables."
   (if (not (hashp hash-table))
       (error "(hash-copy): Invalid hash-table: `%s'" hash-table))
   (let ((htable-copy (hash-make (length (hash-obarray hash-table)))))

--- a/hsys-consult.el
+++ b/hsys-consult.el
@@ -2,7 +2,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     4-Jul-24 at 09:57:18
-;; Last-Mod:      7-Jul-24 at 21:58:54 by Bob Weiner
+;; Last-Mod:     12-Jul-24 at 22:05:30 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -27,9 +27,20 @@
 ;; Don't (require 'consult) here since want to create that dependency only
 ;; when a function within this library is called.
 
+(require 'hbut)
+(require 'hargs)
+(require 'hproperty)
+(require 'hsys-org-roam)
+(require 'find-func)
+
 ;;; ************************************************************************
 ;;; Public declarations
 ;;; ************************************************************************
+
+(declare-function hyrolo-at-tags-p "hyrolo")
+(declare-function hywiki-at-tags-p "hywiki")
+(declare-function hsys-org-directory-at-tags-p "hsys-org")
+(declare-function hsys-org-at-tags-p "hsys-org")
 
 (declare-function consult-grep "ext:consult")
 (declare-function consult-ripgrep "ext:consult")
@@ -199,7 +210,7 @@ that start with the '^[*#]+[ \t]*' regexp)."
   "Interactively search PATHS with a consult package grep command.
 Use ripgrep (rg) if found, otherwise, plain grep.  Interactively
 show all matches from PATHS; see the documentation for the `dir'
-argument in `consult-grep' for valid values of PATHS. 
+argument in `consult-grep' for valid values of PATHS.
 
 Initialize search with optional REGEXP and interactively prompt
 for changes.  Limit matches per file to the absolute value of

--- a/hsys-org-roam.el
+++ b/hsys-org-roam.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    26-Feb-23 at 11:20:15 by Bob Weiner
-;; Last-Mod:      7-Jul-24 at 17:04:57 by Bob Weiner
+;; Last-Mod:     12-Jul-24 at 23:17:53 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -34,7 +34,12 @@
 
 (defvar consult-org-roam-grep-func)
 (defvar org-roam-directory)
+(defvar org-agenda-files)
+(defvar org-agenda-buffer-tmp-name)
+
 (declare-function org-roam-db-autosync-mode "ext:org-roam")
+(declare-function hsys-org-at-tags-p "hsys-org")
+(declare-function hypb:require-package "hypb")
 
 ;;; ************************************************************************
 ;;; Public functions

--- a/hsys-org.el
+++ b/hsys-org.el
@@ -48,6 +48,7 @@
 (defvar hyperbole-mode-map)             ; "hyperbole.el"
 (defvar org--inhibit-version-check)     ; "org-macs.el"
 (defvar hywiki-org-link-type-required)  ; "hywiki.el"
+(defvar org-agenda-buffer-tmp-name)     ; "org-agenda"
 
 (declare-function org-babel-get-src-block-info "org-babel")
 (declare-function org-fold-show-context "org-fold")
@@ -63,7 +64,12 @@
 (declare-function hkey-either "hmouse-drv")
 
 (declare-function find-library-name "find-func")
+(declare-function hsys-org-roam-tags-view "hsys-org")
 (declare-function hyperb:stack-frame "hversion.el")
+(declare-function hyrolo-at-tags-p "hyrolo")
+(declare-function hyrolo-tags-view "hyrolo")
+(declare-function hywiki-at-tags-p "hywiki")
+(declare-function hywiki-tags-view "hywiki")
 
 ;;;###autoload
 (defcustom hsys-org-enable-smart-keys 'unset

--- a/hsys-org.el
+++ b/hsys-org.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Jul-16 at 14:54:14
-;; Last-Mod:      7-Jul-24 at 21:52:26 by Bob Weiner
+;; Last-Mod:     12-Jul-24 at 23:11:41 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -200,14 +200,14 @@ otherwise, just match to the single tag around point."
   (hsys-org-get-agenda-tags #'hywiki-tags-view))
 
 (defun hsys-org-agenda-tags ()
-  "When on an `org-directory' tag, use `hsys-org-tags-view' to list dir tag matches.
+  "On an `org-directory' tag, use `hsys-org-tags-view' to list dir tag matches.
 If on a colon, match to sections with all tags around point;
 otherwise, just match to the single tag around point."
   (interactive)
   (hsys-org-get-agenda-tags #'hsys-org-tags-view))
 
 (defun hsys-org-roam-agenda-tags ()
-  "When on an `org-roam-directory' tag, use `hsys-org-roam-tags-view' to list tag matches.
+  "On an `org-roam-directory' tag, use `hsys-org-roam-tags-view' to list matches.
 If on a colon, match to sections with all tags around point;
 otherwise, just match to the single tag around point."
   (interactive)

--- a/hui-mouse.el
+++ b/hui-mouse.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-89
-;; Last-Mod:      6-Jul-24 at 00:38:17 by Bob Weiner
+;; Last-Mod:     12-Jul-24 at 20:48:37 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1814,7 +1814,7 @@ When the Action Key is pressed and `hsys-org-enable-smart-keys' is t:
   3. On an Org agenda view item, jump to the item for editing.
 
 When the Action Key is pressed and `hsys-org-enable-smart-keys' is
-either t or 'buttons:
+either t or \\='buttons:
 
   4. Within a radio or internal target or a link to it, jump between
      the target and the first link to it, allowing two-way navigation.
@@ -1830,13 +1830,13 @@ either t or 'buttons:
 
   9. With point on any #+BEGIN_SRC, #+END_SRC, #+RESULTS, #+begin_example
      or #+end_example header, execute the code block via the Org mode
-     standard binding of {\\`C-c' \\`C-c'}, (org-ctrl-c-ctrl-c).
+     standard binding of {\\`C-c' \\`C-c'}, (`org-ctrl-c-ctrl-c').
   
  10. With point on an Org mode heading, cycle the view of the subtree at
      point.
 
  11. In any other context besides the end of a line, invoke the Org mode
-     standard binding of {M-RET}, (org-meta-return).
+     standard binding of {M-RET}, (`org-meta-return').
 
 When the Assist Key is pressed, it behaves just like the Action Key except
 in these contexts:

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -136,6 +136,7 @@
 (defvar org-fold-core-style)
 (defvar org-link--link-folding-spec)
 (defvar org-roam-directory)
+(defvar org-agenda-buffer-tmp-name)
 (defvar plstore-cache-passphrase-for-symmetric-encryption)
 (defvar reveal-auto-hide)
 

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Jun-89 at 22:08:29
-;; Last-Mod:      7-Jul-24 at 21:47:43 by Bob Weiner
+;; Last-Mod:     12-Jul-24 at 23:13:27 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -3521,6 +3521,8 @@ Reveal mode is a buffer-local minor mode.  When enabled, it
 reveals invisible text around point.
 
 Also see the `reveal-auto-hide' variable."
+  :init-value nil
+  :keymap nil
   nil) ;; Make this a no-op until can debug `reveal-mode' in *HyRolo* buffer
 
 (unless (boundp 'reveal-auto-hide)

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Apr-24 at 22:41:13
-;; Last-Mod:      7-Jul-24 at 23:15:29 by Bob Weiner
+;; Last-Mod:     12-Jul-24 at 23:14:27 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -120,6 +120,7 @@
 
 (defvar org-agenda-buffer-tmp-name)  ;; "org-agenda.el"
 (declare-function org-link-store-props "ol" (&rest plist))
+(declare-function hsys-org-at-tags-p "hsys-org")
 
 ;;; ************************************************************************
 ;;; Public variables

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    18-May-24 at 23:59:48
-;; Last-Mod:     22-Jun-24 at 18:56:31 by Mats Lidell
+;; Last-Mod:      1-Jul-24 at 14:40:05 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -111,7 +111,7 @@
     (should (hywiki-maybe-at-wikiword-beginning))
     (goto-char 2)
     (should-not (hywiki-maybe-at-wikiword-beginning)))
-  (dolist (acceptable-char '("(" "{" "<" "\"" "'" "`" "	" " " "" "" " "))
+  (dolist (acceptable-char '("(" "{" "<" "\"" "'" "`" "\t" "\n" "\r" "\f" " "))
     (with-temp-buffer
       (insert (format "%sWikiWord" acceptable-char))
       (goto-char 2)


### PR DESCRIPTION
# What

- Fix set of acceptable chars and use escaped notation
- Fix spelling
- Use quote, no hash, for fbound check on closurep
- Add require and declarations to silence byte compile warnings
- Forward declare private var and fix long comment
- Fix long doc strings
- Fix quote in doc string plus formatting
- Add keywords to silence deprecation warning

# Why

Some warnings have crept in. This PR tries to silence them.
