### PR TITLE
Fix window/minibuffer latency issue

### DIFF
--- a/hywiki.el
+++ b/hywiki.el
@@ -832,9 +832,6 @@ the current page unless they have sections attached."
   (walk-windows
    (lambda (window)
      (with-selected-window window
-       ;; Display buffer before `normal-mode' triggers possibly
-       ;; long-running font-locking
-       (sit-for 0.1)
        (hywiki-maybe-highlight-page-names)))
    nil frame))
 


### PR DESCRIPTION
This (sit-for) causes an annoying bit of latency every time a new window or minibuffer is opened. The extra delay makes Emacs feel very clunky, and almost put me off using Hyperbole more. I'm unsure what the consequences are to removing this, but I would like to see a better solution to any bugs this sleep may be hiding.