### PR TITLE
Add file exist check in ripgrep-msg and a test case

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2024-08-23  Mats Lidell  <matsl@gnu.org>
+
+* hibtypes.el (ripgrep-msg): Add check of file exist.
+
+* test/hibtypes-tests.el (ibtypes::ripgrep-msg-test): Test ripgrep-msg.
+
 2024-08-18  Bob Weiner  <rsw@gnu.org>
 
 * hywiki.el (hywiki-maybe-at-wikiword-beginning): Fix to handle word

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:     23-Aug-24 at 21:28:35 by Mats Lidell
+;; Last-Mod:     23-Aug-24 at 21:32:09 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -996,9 +996,9 @@ than a helm completion buffer)."
           (while (and (= (forward-line -1) 0)
                       (looking-at "[1-9][0-9]*[-:]\\|--$")))
           (unless (or (looking-at "[1-9][0-9]*[-:]\\|--$")
-                      (and (setq file (buffer-substring-no-properties (line-beginning-position) (line-end-position)))
-                           (or (string-empty-p (string-trim file))
-                               (not (file-exists-p (string-trim file))))))
+                      (and (setq file (string-trim (buffer-substring-no-properties (line-beginning-position) (match-beginning 0))))
+                           (or (string-empty-p file)
+		               (not (file-exists-p file)))))
 	    (ibut:label-set (concat file ":" line-num))
 	    (hact 'hib-link-to-file-line file line-num)))))))
 

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:     18-Aug-24 at 09:14:53 by Mats Lidell
+;; Last-Mod:     23-Aug-24 at 21:28:35 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -997,7 +997,8 @@ than a helm completion buffer)."
                       (looking-at "[1-9][0-9]*[-:]\\|--$")))
           (unless (or (looking-at "[1-9][0-9]*[-:]\\|--$")
                       (and (setq file (buffer-substring-no-properties (line-beginning-position) (line-end-position)))
-                           (string-empty-p (string-trim file))))
+                           (or (string-empty-p (string-trim file))
+                               (not (file-exists-p (string-trim file))))))
 	    (ibut:label-set (concat file ":" line-num))
 	    (hact 'hib-link-to-file-line file line-num)))))))
 

--- a/test/hibtypes-tests.el
+++ b/test/hibtypes-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    20-Feb-21 at 23:45:00
-;; Last-Mod:      5-Aug-24 at 17:37:57 by Mats Lidell
+;; Last-Mod:     10-Aug-24 at 23:27:05 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -297,7 +297,33 @@
 ;; ipython-stack-frame
 
 ;; ripgrep-msg
+(ert-deftest ibtypes::ripgrep-msg-test ()
+  "Verify `ripgrep-msg'."
+  ;; Date is picked up as a line number but file existence test before
+  ;; concluding it is a button save it from being identified as
+  ;; a ripgrep-msg.
+  (with-temp-buffer
+    (insert "one two three\n2024-07-30 line\n")
+    (goto-line 2)
+    (should-not (eq (hattr:get (hbut:at-p) 'actype) 'hib-link-to-file-line))
+    (should-not (ibtypes::ripgrep-msg)))
 
+  ;; Regular ripgrep-msg case.
+  (with-temp-buffer
+    (insert "hibtypes.el\n20: line\n")
+    (goto-line 2)
+    (mocklet (((hib-link-to-file-line "hibtypes.el" "20") => t)
+              ((file-exists-p "hibtypes.el") => t))
+      (should (eq (hattr:get (hbut:at-p) 'actype) 'hib-link-to-file-line))
+      (should (ibtypes::ripgrep-msg))))
+
+  ;; Regular match but file does not exist case.
+  (with-temp-buffer
+    (insert "unknown-file\n20: line\n")
+    (goto-line 2)
+    (should-not (eq (hattr:get (hbut:at-p) 'actype) 'hib-link-to-file-line))
+    (should-not (ibtypes::ripgrep-msg))))
+  
 ;; grep-msg
 
 ;; debugger-source


### PR DESCRIPTION
# What

Add a check if file in ripgrep output exists before concluding it is a
valid ripgrep-msg.

# Why

A number on a line can get interpreted as ripgrep line number which it
is not. That will block other buts from having their go at it. By
adding a check that the matching "file" exists makes it some what more
robust although I think there can still be problematic cases.

# Note

The error was found by having a iso date, like 2024-07-30, first on a
line. The string on the line above was interpreted as a file name. The
resulting action was a no-op but the action that should have been
triggered was not given its chance.

A test case triggering the bug for an unmodified ripgrep-msg is
supplied.

What do you think of requiring that the file listed in the ripgrep
output exists for it to be a valid button?
