### PR TITLE
Add elisp-compiler-msg-test

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2024-08-08  Mats Lidell  <matsl@gnu.org>
+
+* test/hibtypes-tests.el (elisp-compiler-msg-test): Add test.
+
 2024-08-06  Mats Lidell  <matsl@gnu.org>
 
 * test/hproperty-tests.el: Test file for hproperty.

--- a/test/hibtypes-tests.el
+++ b/test/hibtypes-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    20-Feb-21 at 23:45:00
-;; Last-Mod:      4-Aug-24 at 23:34:43 by Mats Lidell
+;; Last-Mod:      5-Aug-24 at 17:37:57 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -307,31 +307,33 @@
 ;; elisp-compiler-msg
 (ert-deftest elisp-compiler-msg-test ()
   "Verify elisp-compiler-msg."
-  (with-temp-buffer
-    (insert "    passed  1/1  test (0.000100 sec)\n")
-    (goto-line 1)
-    (mocklet (((buffer-name) => "*Compile-Log*")
-              ((smart-tags-display "test" nil) => t))
-      (should (ibtypes::elisp-compiler-msg))))
+  (let ((orig-buffer-name (symbol-function 'buffer-name)))
+    (cl-letf (((symbol-function 'buffer-name)
+               (lambda (&optional buffer)
+                 (if (string-prefix-p " *temp*" (funcall orig-buffer-name))
+                     "*Compile-Log*"
+                   (funcall orig-buffer-name)))))
+      (with-temp-buffer
+        (insert "    passed  1/1  abcde (0.000100 sec)\n")
+        (goto-line 1)
+        (mocklet (((smart-tags-display "abcde" nil) => t))
+          (should (ibtypes::elisp-compiler-msg))))
 
-  (with-temp-buffer
-    (insert "Test test-test backtrace:\n")
-    (goto-line 1)
-    (mocklet (((buffer-name) => "*Compile-Log*")
-              ((smart-tags-display "test-test" nil) => t))
-      (should (ibtypes::elisp-compiler-msg))))
+      (with-temp-buffer
+        (insert "Test abcde backtrace:\n")
+        (goto-line 1)
+        (mocklet (((smart-tags-display "abcde" nil) => t))
+          (should (ibtypes::elisp-compiler-msg))))
 
-  (with-temp-buffer
-    (insert "Compiling /home/user/file.el...
+      (with-temp-buffer
+        (insert "Compiling /home/user/file.el...
 
 In hyperbole-test:
 file.el:10:20: Warning: Message
 ")
-    (goto-line 3)
-    (mocklet (((buffer-name) => "*Compile-Log*")
-              ((actypes::link-to-regexp-match "^(def[a-z \11]+hyperbole-test[ \11\n\15(]" 1 "/home/user/file.el" nil) => t))
-      (should (ibtypes::elisp-compiler-msg))))
-  )
+        (goto-line 3)
+        (mocklet (((actypes::link-to-regexp-match "^(def[a-z \11]+hyperbole-test[ \11\n\15(]" 1 "/home/user/file.el" nil) => t))
+          (should (ibtypes::elisp-compiler-msg)))))))
 
 ;; patch-msg
 

--- a/test/hibtypes-tests.el
+++ b/test/hibtypes-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    20-Feb-21 at 23:45:00
-;; Last-Mod:     28-Jul-24 at 00:33:04 by Mats Lidell
+;; Last-Mod:      4-Aug-24 at 23:34:43 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -305,6 +305,33 @@
 ;; pathname-line-and-column
 
 ;; elisp-compiler-msg
+(ert-deftest elisp-compiler-msg-test ()
+  "Verify elisp-compiler-msg."
+  (with-temp-buffer
+    (insert "    passed  1/1  test (0.000100 sec)\n")
+    (goto-line 1)
+    (mocklet (((buffer-name) => "*Compile-Log*")
+              ((smart-tags-display "test" nil) => t))
+      (should (ibtypes::elisp-compiler-msg))))
+
+  (with-temp-buffer
+    (insert "Test test-test backtrace:\n")
+    (goto-line 1)
+    (mocklet (((buffer-name) => "*Compile-Log*")
+              ((smart-tags-display "test-test" nil) => t))
+      (should (ibtypes::elisp-compiler-msg))))
+
+  (with-temp-buffer
+    (insert "Compiling /home/user/file.el...
+
+In hyperbole-test:
+file.el:10:20: Warning: Message
+")
+    (goto-line 3)
+    (mocklet (((buffer-name) => "*Compile-Log*")
+              ((actypes::link-to-regexp-match "^(def[a-z \11]+hyperbole-test[ \11\n\15(]" 1 "/home/user/file.el" nil) => t))
+      (should (ibtypes::elisp-compiler-msg))))
+  )
 
 ;; patch-msg
 


### PR DESCRIPTION
# What

Add test elisp-compiler-msg-test.

# Discussion

A test is still missing for the byte compiler section of the ibut. I'm not sure the patterns for that in the code is correct. I can't find any byte compile example where these patterns are seen. Neither using batch byte compiler from the make targets nor using the byte compiler functions!? Do you have an example?

Regarding the native byte compiler section it seems that the function reported in the "In function"-section does not have to be part of the file that is byte compiled!? Se example here:

```
Compiling /home/matsl/src/hyperbole/hsys-org.el...
Loading /home/matsl/src/hyperbole/hyperbole-autoloads.el (source)...

In end of data:
hywiki.el:490:25: Warning: the function ‘hsys-org-at-tags-p’ is not known to be defined.

In hyrolo-tags-view:
hyrolo.el:1409:11: Warning: Unused lexical variable ‘org-agenda-buffer-tmp-name’
hyrolo.el:3519:20: Warning: Use keywords rather than deprecated positional arguments to ‘define-minor-mode’
...
```

The file that is compiled is hsys-org.el but the end of data message refers to hywiki.el and `hyrolo-tags-view` is part of hyrolo.el. So it seems this pattern can cause a lot of false positives. In the sunshine case where (verified in the test case) the file referred to in the Compiling line is the file for which the message is for. That works. But in those cases the column and line info on the subsequent lines would be a more direct link to the problem!?

I have tried to look for a spec on how the native compile messages are constructed but so far I have not found anything. Maybe best to ask for that.
