### PR TITLE
more minor cleanups

### DIFF
--- a/hsys-org-roam.el
+++ b/hsys-org-roam.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    26-Feb-23 at 11:20:15 by Bob Weiner
-;; Last-Mod:     28-Jul-24 at 12:33:29 by Bob Weiner
+;; Last-Mod:      8-Aug-24 at 23:49:13 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -34,7 +34,12 @@
 
 (defvar consult-org-roam-grep-func)
 (defvar org-roam-directory)
+(defvar hsys-org-at-tags-p)
+(defvar org-agenda-files)
+(defvar org-agenda-buffer-tmp-name)
 (declare-function org-roam-db-autosync-mode "ext:org-roam")
+(declare-function hypb:require-package "hypb")
+(declare-function hsys-org-at-tags-p "hsys-org")
 
 ;;; ************************************************************************
 ;;; Public functions

--- a/hsys-org.el
+++ b/hsys-org.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Jul-16 at 14:54:14
-;; Last-Mod:     28-Jul-24 at 12:33:05 by Bob Weiner
+;; Last-Mod:      8-Aug-24 at 23:51:10 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -48,6 +48,13 @@
 (defvar hyperbole-mode-map)             ; "hyperbole.el"
 (defvar org--inhibit-version-check)     ; "org-macs.el"
 (defvar hywiki-org-link-type-required)  ; "hywiki.el"
+(defvar org-agenda-buffer-tmp-name)     ; "org-agenda.el"
+
+(declare-function hywiki-at-tags-p "hywiki")
+(declare-function hywiki-tags-view "hywiki")
+(declare-function hyrolo-tags-view "hyrolo")
+(declare-function hyrolo-at-tags-p "hyrolo")
+(declare-function hsys-org-roam-tags-view "hsys-org")
 
 (declare-function org-babel-get-src-block-info "org-babel")
 (declare-function org-fold-show-context "org-fold")

--- a/hsys-org.el
+++ b/hsys-org.el
@@ -203,14 +203,14 @@ otherwise, just match to the single tag around point."
   (hsys-org-get-agenda-tags #'hywiki-tags-view))
 
 (defun hsys-org-agenda-tags ()
-  "When on an `org-directory' tag, use `hsys-org-tags-view' to list dir tag matches.
+  "On an `org-directory' tag, use `hsys-org-tags-view' to list dir tag matches.
 If on a colon, match to sections with all tags around point;
 otherwise, just match to the single tag around point."
   (interactive)
   (hsys-org-get-agenda-tags #'hsys-org-tags-view))
 
 (defun hsys-org-roam-agenda-tags ()
-  "When on an `org-roam-directory' tag, use `hsys-org-roam-tags-view' to list tag matches.
+  "On an `org-roam-directory' tag, use `hsys-org-roam-tags-view' to list matches.
 If on a colon, match to sections with all tags around point;
 otherwise, just match to the single tag around point."
   (interactive)

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -3524,6 +3524,8 @@ Reveal mode is a buffer-local minor mode.  When enabled, it
 reveals invisible text around point.
 
 Also see the `reveal-auto-hide' variable."
+  :init-value nil
+  :keymap nil
   nil) ;; Make this a no-op until can debug `reveal-mode' in *HyRolo* buffer
 
 (unless (boundp 'reveal-auto-hide)

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Jun-89 at 22:08:29
-;; Last-Mod:     28-Jul-24 at 12:31:58 by Bob Weiner
+;; Last-Mod:      8-Aug-24 at 23:53:10 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -97,6 +97,7 @@
 (defvar org-mode-syntax-table)          ; "org.el"
 (defvar org-outline-regexp)             ; "org.el"
 (defvar org-outline-regexp-bol)         ; "org.el"
+(defvar org-agenda-buffer-tmp-name)     ; "org-agenda.el"
 (defvar google-contacts-buffer-name)    ; "ext:google-contacts.el"
 (defvar hbut:source-prefix)             ; "hbut.el"
 

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Apr-24 at 22:41:13
-;; Last-Mod:     30-Jul-24 at 23:49:43 by Bob Weiner
+;; Last-Mod:      8-Aug-24 at 23:22:05 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -121,6 +121,7 @@
 
 (defvar org-agenda-buffer-tmp-name)  ;; "org-agenda.el"
 (declare-function org-link-store-props "ol" (&rest plist))
+(declare-function hsys-org-at-tags-p "hsys-org")
 
 ;;; ************************************************************************
 ;;; Public variables


### PR DESCRIPTION
# What

More warning removals

- Add public declarations to remove warnings
- Add keywords to remove warning for define-minor-mode
- Shorten first line in docstrings to avoid 80 char warning

# Note

A few of these changes were introduced in PR #561 but apparently
removed by later updates (since I have had to add them again). Was
that intentional or just an unwanted effect of a merge with other
changes?


