### PR TITLE
Fix link regression

### DIFF
--- a/FAST-DEMO
+++ b/FAST-DEMO
@@ -73,7 +73,7 @@
   |-----------------------------------------------------+------------------------------|
   | <[HyControl, fast Emacs frame and window manager]>  | https://youtu.be/M3-aMh1ccJk |
   |-----------------------------------------------------+------------------------------|
-  | <[Writing test cases for GNU Hyperbole]>            | https:/youtu.be/maNQSKxXIzI  |
+  | <[Writing test cases for GNU Hyperbole]>            | https://youtu.be/maNQSKxXIzI |
   |-----------------------------------------------------+------------------------------|
   | <[Find/Web Search]>                                 | https://youtu.be/8lMlJed0-OM |
   |-----------------------------------------------------+------------------------------|


### PR DESCRIPTION
# What

The link works but it stands out from the rest of the links by not
using the same pattern.

# Note

This was fixed in #485 but found its way in again some how.
