### PR TITLE
Add tree-sitter "programming modes" supported by Hyperbole

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2024-08-18  Mats Lidell  <matsl@gnu.org>
+
+* kotl/klink.el (klink:ignore-modes, klink:c-style-modes):
+* hui-select.el (hui-select-brace-modes)
+    (hui-select-brace-def-or-declaration):
+* hui-mouse.el (hkey-alist):
+* hmouse-tag.el (smart-java-cross-reference):
+* hibtypes.el (annot-bib): Add corresponding tree-sitter modes for the
+    modes supported by Hyperbole.
+
 2024-08-17  Bob Weiner  <rsw@gnu.org>
 
 * hui-mini.el (hui:menus): Org-M-RET/ Customization menu, add doc to items

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:     31-Jul-24 at 01:31:32 by Bob Weiner
+;; Last-Mod:     16-Aug-24 at 20:51:12 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -376,7 +376,8 @@ attached file."
        buffer-file-name
        (let ((chr (aref (buffer-name) 0)))
          (not (or (eq chr ?\ ) (eq chr ?*))))
-       (not (apply #'derived-mode-p '(prog-mode c-mode objc-mode c++-mode java-mode markdown-mode org-mode)))
+       (not (apply #'derived-mode-p '(prog-mode c-mode objc-mode c++-mode java-mode markdown-mode org-mode
+                                                c-ts-mode c++-ts-mode java-ts-mode)))
        (unless (ibut:label-p t "[[" "]]" t) ;; Org link
 	 (let ((ref (hattr:get 'hbut:current 'lbl-key))
 	       (lbl-start (hattr:get 'hbut:current 'lbl-start))

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:     16-Aug-24 at 20:51:12 by Mats Lidell
+;; Last-Mod:     18-Aug-24 at 09:14:53 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -376,8 +376,9 @@ attached file."
        buffer-file-name
        (let ((chr (aref (buffer-name) 0)))
          (not (or (eq chr ?\ ) (eq chr ?*))))
-       (not (apply #'derived-mode-p '(prog-mode c-mode objc-mode c++-mode java-mode markdown-mode org-mode
-                                                c-ts-mode c++-ts-mode java-ts-mode)))
+       (not (apply #'derived-mode-p
+                   '(c++-mode c++-ts-mode c-mode c-ts-mode java-mode java-ts-mode
+                              markdown-mode objc-mode org-mode prog-mode)))
        (unless (ibut:label-p t "[[" "]]" t) ;; Org link
 	 (let ((ref (hattr:get 'hbut:current 'lbl-key))
 	       (lbl-start (hattr:get 'hbut:current 'lbl-start))

--- a/hmouse-tag.el
+++ b/hmouse-tag.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    24-Aug-91
-;; Last-Mod:     14-Jul-24 at 11:55:33 by Bob Weiner
+;; Last-Mod:     16-Aug-24 at 22:30:09 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1319,7 +1319,7 @@ package for class and feature lookups."
   ;; fairly bad form anyway.
   ;;
   (let ((opoint (point)))
-    (if (and (eq major-mode 'java-mode) buffer-file-name
+    (if (and (memq major-mode '(java-mode java-ts-mode)) buffer-file-name
 	     (fboundp 'br-env-load)
 	     (or (looking-at "@see[ \t]+")
 		 (and (re-search-backward "[@\n\r\f]" nil t)

--- a/hui-mouse.el
+++ b/hui-mouse.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-89
-;; Last-Mod:     12-Jul-24 at 20:48:37 by Mats Lidell
+;; Last-Mod:     16-Aug-24 at 20:59:19 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -444,7 +444,7 @@ Its default value is `smart-scroll-down'.  To disable it, set it to
     ;;
     ;; Python files - ensure this comes before Imenu for more advanced
     ;; definition lookups
-    ((and (or (and (derived-mode-p 'python-mode) buffer-file-name)
+    ((and (or (and (derived-mode-p '(python-mode python-ts-mode)) buffer-file-name)
 	      (and (featurep 'hsys-org) (hsys-org-mode-p)
 		   (equal (hsys-org-get-value :language) "python"))
 	      (let ((case-fold-search))
@@ -452,11 +452,11 @@ Its default value is `smart-scroll-down'.  To disable it, set it to
 	  (setq hkey-value (smart-python-at-tag-p)))
      . ((smart-python hkey-value) . (smart-python hkey-value 'next-tag)))
     ;;
-    ((and (eq major-mode 'c-mode)
+    ((and (memq major-mode '(c-mode c-ts-mode))
 	  buffer-file-name (smart-c-at-tag-p))
      . ((smart-c) . (smart-c nil 'next-tag)))
     ;;
-    ((and (eq major-mode 'c++-mode) buffer-file-name
+    ((and (memq major-mode '(c++-mode c++-ts-mode)) buffer-file-name
 	  ;; Don't use smart-c++-at-tag-p here since it will prevent #include
 	  ;; lines from matching.
 	  (smart-c-at-tag-p))
@@ -479,7 +479,7 @@ Its default value is `smart-scroll-down'.  To disable it, set it to
      . ((smart-lisp) . (smart-lisp 'show-doc)))
     ;;
     ;;
-    ((and (eq major-mode 'java-mode) buffer-file-name
+    ((and (memq major-mode '(java-mode java-ts-mode)) buffer-file-name
 	  (or (smart-java-at-tag-p)
 	      ;; Also handle Java @see cross-references.
 	      (looking-at "@see[ \t]+")
@@ -488,7 +488,7 @@ Its default value is `smart-scroll-down'.  To disable it, set it to
 		     (looking-at "@see[ \t]+")))))
      . ((smart-java) . (smart-java nil 'next-tag)))
     ;;
-    ((and (memq major-mode '(js2-mode js-mode js3-mode javascript-mode html-mode web-mode))
+    ((and (memq major-mode '(js2-mode js-mode js3-mode javascript-mode html-mode web-mode js-ts-mode))
 	  buffer-file-name
 	  (smart-javascript-at-tag-p))
      . ((smart-javascript) . (smart-javascript nil 'next-tag)))

--- a/hui-mouse.el
+++ b/hui-mouse.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-89
-;; Last-Mod:     16-Aug-24 at 20:59:19 by Mats Lidell
+;; Last-Mod:     18-Aug-24 at 09:35:51 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -488,7 +488,7 @@ Its default value is `smart-scroll-down'.  To disable it, set it to
 		     (looking-at "@see[ \t]+")))))
      . ((smart-java) . (smart-java nil 'next-tag)))
     ;;
-    ((and (memq major-mode '(js2-mode js-mode js3-mode javascript-mode html-mode web-mode js-ts-mode))
+    ((and (memq major-mode '(html-mode javascript-mode js-mode js-ts-mode js2-mode js3-mode web-mode))
 	  buffer-file-name
 	  (smart-javascript-at-tag-p))
      . ((smart-javascript) . (smart-javascript nil 'next-tag)))

--- a/hui-select.el
+++ b/hui-select.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Oct-96 at 02:25:27
-;; Last-Mod:     16-Aug-24 at 22:28:45 by Mats Lidell
+;; Last-Mod:     18-Aug-24 at 09:44:46 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -119,8 +119,8 @@
 ;;; ************************************************************************
 
 (defcustom hui-select-brace-modes
-  '(c++-mode c-mode java-mode objc-mode perl-mode tcl-mode
-             c++-ts-mode c-ts-mode java-ts-mode)
+  '(c++-mode c++-ts-mode c-mode c-ts-mode java-mode java-ts-mode objc-mode
+             perl-mode tcl-mode)
   "*List of language major modes which define things with brace delimiters."
   :type '(repeat (function :tag "Mode"))
   :group 'hyperbole-commands)
@@ -138,9 +138,8 @@
   :group 'hyperbole-commands)
 
 (defcustom hui-select-indent-modes
-  (append '(altmath-mode asm-mode csh-mode eiffel-mode ksh-mode
-                         math-mode miranda-mode python-mode pascal-mode sather-mode
-                         python-ts-mode)
+  (append '(altmath-mode asm-mode csh-mode eiffel-mode ksh-mode math-mode miranda-mode
+                         pascal-mode python-mode python-ts-mode sather-mode)
 	  hui-select-text-modes)
   "*List of modes that use indentation mostly to define syntactic structure.
 Use for language major modes."

--- a/hui-select.el
+++ b/hui-select.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Oct-96 at 02:25:27
-;; Last-Mod:     20-Apr-24 at 12:02:16 by Bob Weiner
+;; Last-Mod:     16-Aug-24 at 22:28:45 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -119,7 +119,8 @@
 ;;; ************************************************************************
 
 (defcustom hui-select-brace-modes
-  '(c++-mode c-mode java-mode objc-mode perl-mode tcl-mode)
+  '(c++-mode c-mode java-mode objc-mode perl-mode tcl-mode
+             c++-ts-mode c-ts-mode java-ts-mode)
   "*List of language major modes which define things with brace delimiters."
   :type '(repeat (function :tag "Mode"))
   :group 'hyperbole-commands)
@@ -138,7 +139,8 @@
 
 (defcustom hui-select-indent-modes
   (append '(altmath-mode asm-mode csh-mode eiffel-mode ksh-mode
-                         math-mode miranda-mode python-mode pascal-mode sather-mode)
+                         math-mode miranda-mode python-mode pascal-mode sather-mode
+                         python-ts-mode)
 	  hui-select-text-modes)
   "*List of modes that use indentation mostly to define syntactic structure.
 Use for language major modes."
@@ -1157,7 +1159,7 @@ language must be included in the list, hui-select-brace-modes."
 	    (setq eod (save-excursion
 			(condition-case ()
 			    (progn
-			      (if (and (eq major-mode 'java-mode)
+			      (if (and (memq major-mode '(java-mode java-ts-mode))
 				       (fboundp 'id-java-end-of-defun))
 				  (id-java-end-of-defun)
 				(end-of-defun))

--- a/kotl/klink.el
+++ b/kotl/klink.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Nov-93 at 12:15:16
-;; Last-Mod:     14-Jul-24 at 23:32:32 by Bob Weiner
+;; Last-Mod:     16-Aug-24 at 20:53:57 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -72,13 +72,13 @@
 ;;; ************************************************************************
 
 (defcustom klink:ignore-modes
-  '(occur-mode moccur-mode amoccur-mode shell-mode telnet-mode ssh-mode term-mode)
+  '(occur-mode moccur-mode amoccur-mode shell-mode telnet-mode ssh-mode term-mode bash-ts-mode)
   "Major modes in which to ignore potential klinks to avoid false positives."
   :type '(list function)
   :group 'hyperbole-koutliner)
 
 (defcustom klink:c-style-modes
-  '(c-mode c++-mode objc-mode java-mode)
+  '(c-mode c++-mode objc-mode java-mode c++-ts-mode c-ts-mode java-ts-mode)
   "C-related major modes with where klinks appear only within comments."
   :type '(list function)
   :group 'hyperbole-koutliner)

--- a/kotl/klink.el
+++ b/kotl/klink.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Nov-93 at 12:15:16
-;; Last-Mod:     16-Aug-24 at 20:53:57 by Mats Lidell
+;; Last-Mod:     18-Aug-24 at 09:42:48 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -72,13 +72,14 @@
 ;;; ************************************************************************
 
 (defcustom klink:ignore-modes
-  '(occur-mode moccur-mode amoccur-mode shell-mode telnet-mode ssh-mode term-mode bash-ts-mode)
+  '(amoccur-mode bash-ts-mode moccur-mode occur-mode shell-mode ssh-mode
+                 telnet-mode term-mode)
   "Major modes in which to ignore potential klinks to avoid false positives."
   :type '(list function)
   :group 'hyperbole-koutliner)
 
 (defcustom klink:c-style-modes
-  '(c-mode c++-mode objc-mode java-mode c++-ts-mode c-ts-mode java-ts-mode)
+  '(c++-mode c++-ts-mode c-mode c-ts-mode java-mode java-ts-mode objc-mode)
   "C-related major modes with where klinks appear only within comments."
   :type '(list function)
   :group 'hyperbole-koutliner)


### PR DESCRIPTION
# What

Add tree-sitter based modes for the programming modes currently
supported by Hyperbole.

# Why

Hyperbole uses buffers current major mode for checking if some
functionality shall be available in the buffer. With tree-sitter comes
modes for many programming languages and those can be used instead of
the old programming modes. These new modes are not recognized by
Hyperbole and if they are used the programming language specific
buttons are not recognized.

# Note

*Was looking into tree-sitter and to use the c++-ts-mode in a c++
file only to realize that Hyperbole smart-c++ was not available in
that case because we don't understand what c++-ts-mode is.*

This just blindly adds the tree-sitter modes to the program language
checks. There are no automatic tests that this works for all cases. On
the other hand we have no tests that it works for all the old modes
either.

It seems some old modes and tree sitter modes use the same base
mode. It could be possible to use that in Hyperbole to check for the
base mode instead to limit the modes to check for. This is not a
general pattern though so can only be applied after checking for each
programming language.

No analysis have been done if there are tree-sitter features that
Hyperbole utilized. This PR only allows the programming language to
derived by looking at the tree-sitter modes.
