### PR TITLE
Control abbreviation of backtrace

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2024-08-24  Mats Lidell  <matsl@gnu.org>
+
+* Makefile (HYPB_ERT_BATCH_BT): Control abbreviation of backtrace.
+
 2024-08-24  Bob Weiner  <rsw@gnu.org>
 
 * hpath.el (hpath:to-Info-ref): Add.

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:     15-Aug-24 at 00:32:27 by Bob Weiner
+# Last-Mod:     24-Aug-24 at 10:41:04 by Mats Lidell
 #
 # Copyright (C) 1994-2023  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -512,9 +512,9 @@ endif
 
 # For full backtrace run make test FULL_BT=<anything or even empty>
 ifeq ($(origin FULL_BT), command line)
-HYPB_ERT_BATCH_BT = (ert-batch-backtrace-line-length nil)
+HYPB_ERT_BATCH_BT = (ert-batch-backtrace-line-length t) (backtrace-line-length nil)
 else
-HYPB_ERT_BATCH_BT = (ert-batch-backtrace-line-length 256)
+HYPB_ERT_BATCH_BT = (ert-batch-backtrace-line-length 256) (backtrace-line-length 5000)
 endif
 
 # Run non-interactive tests in batch mode
@@ -522,7 +522,7 @@ test-ert:
 	@echo "# Tests: $(TEST_ERT_FILES)"
 	$(EMACS_BATCH) --eval "(load-file \"test/hy-test-dependencies.el\")" \
 	--eval "(let ((auto-save-default) (ert-batch-print-level 10) \
-	              (ert-batch-print-length nil) (backtrace-line-length 5000) \
+	              (ert-batch-print-length nil) \
 	              $(HYPB_ERT_BATCH_BT) (ert-batch-backtrace-right-margin 2048)) \
 	           $(LOAD_TEST_ERT_FILES) $(HYPB_ERT_BATCH))"
 


### PR DESCRIPTION
# What

Change settings of backtrace vars to get a full backtrace when
"FULL_BT=" is set on the make command line.

# Why

The previous configuration using `FULL_BT=` did not achieve the desired
result. This seems to work better.

# Note

Tested by forcing a call to (debug) in a test case. Please try it out
and see if it works as expected in real cases where backtraces are
produced.

The usage is:

```
make FULL_BT= <regular make targets>
```
