### PR TITLE
correcting recent warnings

### DIFF
--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:     23-Aug-24 at 21:38:08 by Bob Weiner
+;; Last-Mod:     24-Aug-24 at 11:40:56 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1565,7 +1565,7 @@ include delimiters when INCLUDE-DELIMS is non-nil)."
     (error "(hbut:map-type): `start-delim' must be a string, not '%s'"
 	   start-delim))
   (unless end-delim
-    (error "(hbut:map-type): `end-delim' must be non-nil" end-delim))
+    (error "(hbut:map-type): `end-delim' must be non-nil"))
 
   (let* ((match-to-start-delim (when end-delim (symbolp end-delim)))
 	 (end-char (unless match-to-start-delim

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:     23-Aug-24 at 21:32:09 by Mats Lidell
+;; Last-Mod:     24-Aug-24 at 11:32:31 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1669,7 +1669,7 @@ If a boolean function or variable, display its value."
 ;;; ========================================================================
 
 (defib hywiki-existing-word ()
-  "When on a HyWiki word with an existing page, display its page and optional section."
+  "On a HyWiki word with an existing page, display its page and optional section."
   (cl-destructuring-bind (page-name start end)
       (hywiki-page-exists-p 'range)
     (when page-name

--- a/hywiki.el
+++ b/hywiki.el
@@ -669,7 +669,7 @@ If found, return the full path of the page.
 If not on a wiki word and optional prefix ARG is null, emulate an
 Action Key press; with a prefix ARG, emulate an Assist Key press."
   (interactive "P")
-  (let ((word hywiki-word-at))
+  (let ((word (hywiki-word-at)))
     (if word
 	(hywiki-find-page word)
       (hkey-either arg))))

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Apr-24 at 22:41:13
-;; Last-Mod:     18-Aug-24 at 18:02:28 by Bob Weiner
+;; Last-Mod:     24-Aug-24 at 11:36:20 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1297,7 +1297,7 @@ variables."
 Word may be of form: HyWikiWord#section with an optional #section.
 If no such page exists, return nil.
 
-If WORD is the symbol, 'range, rather than a string, and there is a
+If WORD is the symbol, \\='range, rather than a string, and there is a
 HyWikiWord at point with an existing page, then return the tuple of
 values: (word word-start word-end).
 


### PR DESCRIPTION
# What

- end-delim is not used and not needed since it is nil
- hywiki-word-at is undefined var, should be a function call
- Bad quote in docstring
- Shorten too long docstring

# Why

Fixing a set of warnings introduced by recent merges.

# Note

Each change is in its own commit.