### PR TITLE
fix small byte comoile warnings

### DIFF
--- a/hui-mini.el
+++ b/hui-mini.el
@@ -33,6 +33,7 @@
 (defvar hui:menu-hywiki nil)            ; "hui-mini.el"
 (defvar hui:menu-mode-map)              ; "hui-mini.el"
 (defvar hui:menu-rolo nil)              ; "hui-mini.el"
+(defvar hui:menu-highlight-flag)        ; "hui-mini.el"
 (defvar hyperbole-mode-map)             ; "hyperbole.el"
 (defvar hyrolo-add-hook)                ; "hyrolo.el"
 (defvar hyrolo-edit-hook)               ; "hyrolo.el"

--- a/hui-mini.el
+++ b/hui-mini.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Oct-91 at 20:13:17
-;; Last-Mod:      9-Sep-24 at 01:27:12 by Bob Weiner
+;; Last-Mod:     10-Sep-24 at 23:12:50 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;

--- a/hywiki.el
+++ b/hywiki.el
@@ -138,6 +138,7 @@
 
 (defvar org-agenda-buffer-tmp-name)  ;; "org-agenda.el"
 (defvar org-publish-project-alist)   ;; "ox-publish.el"
+(defvar org-export-with-broken-links);; "ox.el"
 (declare-function hsys-org-at-tags-p "hsys-org")
 (declare-function org-link-store-props "ol" (&rest plist))
 (declare-function org-publish-property "ox-publish" (property project &optional default))

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Apr-24 at 22:41:13
-;; Last-Mod:     10-Sep-24 at 01:28:06 by Bob Weiner
+;; Last-Mod:     10-Sep-24 at 23:21:09 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;

--- a/hywiki.el
+++ b/hywiki.el
@@ -234,10 +234,10 @@ override standard Org link lookups.  See \"(org)Internal Links\".")
 
 (defcustom hywiki-org-publishing-broken-links 'mark
   "HyWiki Org publish option that determines how invalid links are handled.
-The default is 'mark.
+The default is \\='mark.
 
 When this option is non-nil, broken HyWiki links are ignored,
-without stopping the export process.  If it is set to 'mark,
+without stopping the export process.  If it is set to \\='mark,
 broken links are marked with a string like:
 
   [BROKEN LINK: path]


### PR DESCRIPTION
# What

- Add defvar for new dynamic vars, silence compile warning
- Use \\=' for single quote in docstring, silence byte compile warning
- Update file time stamp

# Why

Warning messages shall be kept at a minimum.

# Note

Each type of change is in its own commit for easy review.
