### PR TITLE
Verify hyrolo--expanded-file-list is updated when a file is added

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2024-09-11  Mats Lidell  <matsl@gnu.org>
+
+* test/hyrolo-tests.el (hyrolo-tests--get-file-list): Verify
+    `hyrolo--expanded-file-list' is updated when a file is added.
+
 2024-09-10  Bob Weiner  <rsw@gnu.org>
 
 * hywiki.el (hywiki-org-make-publish-project-alist): Add

--- a/test/hyrolo-tests.el
+++ b/test/hyrolo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    19-Jun-21 at 22:42:00
-;; Last-Mod:      5-Aug-24 at 22:16:27 by Mats Lidell
+;; Last-Mod:     11-Sep-24 at 23:56:02 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -469,6 +469,24 @@ Match a string in the second cell."
 		(hyrolo-file-list (list tmp-file)))
            ()))
       (hy-delete-file-and-buffer tmp-file))))
+
+(ert-deftest hyrolo-tests--get-file-list ()
+  "Verify `hyrolo-get-file-list` includes added files."
+  :expected-result :failed
+  (let* ((folder (make-temp-file "hypb" t))
+         (prefix (expand-file-name "hypb" folder))
+         (org-file (make-temp-file prefix nil ".org"))
+         (hyrolo-file-list (list folder)))
+    (unwind-protect
+        (progn
+          (should (= 1 (length (hyrolo-get-file-list))))
+          (let ((org2-file (make-temp-file prefix nil ".org")))
+            (unwind-protect
+                (should (= 2 (length (hyrolo-get-file-list))))
+              (hy-delete-file-and-buffer org2-file))))
+      (dolist (f (list org-file))
+        (hy-delete-file-and-buffer f))
+      (delete-directory folder))))
 
 ;; Outline movement tests
 (defun hyrolo-tests--level-number (section depth)


### PR DESCRIPTION
# What

Verify `hyrolo--expanded-file-list` is updated when a file is added.

# Why

Test marked as expected-result failed since cache currently is not
updated which seems like an error. Or what do you say?

# Note

Noticed this when I was adding a file to a directory in my
`hyrolo-file-list` and it was not found when I searched for things in
it a moment later. Surprising effect.

Caching is hard, and this is one of the subtle user problems it can
cause. Currently the cache is updated when `hyrolo-file-list` is
changed but the cache is on the file level so adding or removing a
file is not noticed.

Maybe there is a hook that can be used to invalidate the cache when a
file is created within folders in the `hyrolo-file-list`? (But feels a
bit clumsy.)
