### PR TITLE
HyWiki Updates - handle plurals of HyWikiWords, removing empty HyWiki files, track hywiki-directory updates

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,11 +1,43 @@
+2024-09-22  Bob Weiner  <rsw@gnu.org>
+
+* hywiki.el (hywiki-find-page): Move prompt tests to 'hywiki-add-page'.
+            (hywiki-add-page): Add and run 'hywiki-add-page-hook'.  Add
+    optional second arg 'prompt-flag' that 'hywiki-find-page' passes.
+
+* test/hywiki-tests.el (hywiki-tests--directory-modified-p):
+    Update to set checksum which is needed now and expand
+    test scenarios.
+                       (hywiki-tests--wikiword-with-prefix-creates-a-new-page):
+    Update to add optional 2nd arg of nil to 'hywiki-add-page' call.
+                       (hywiki-tests--hywiki-add-page--adds-file-in-wiki-folder):
+   Actually create empty file and then delete it, fixing
+   hywiki-add-page call failure.
+  hywiki.el (hywiki-add-page): Fix issue where hash table
+    value was set before empty page file is created so
+    did not have correct value.
+
+* hywiki.el (hywiki-maybe-highlight-page-names-in-frame,
+             hywiki-maybe-highlight-page-names): Move set of
+    mod-time and checksum here from 'hywiki-get-page-hasht' to
+    make work with 'hywiki-kill-buffer-hook'.
+
 2024-09-21  Bob Weiner  <rsw@gnu.org>
 
 * hywiki.el (hywiki-kill-buffer-hook): Add for use as a global
     'kill-buffer-hook'.
   hypb.el (hypb:empty-file-p): Add and use in 'hywiki-kill-buffer-hook'.
 
+* hywiki.el (hywiki-maybe-highlight-page-names): Dehighlight HyWikiWords
+    before re-highlighting new set.
+
 * hywiki.el (hywiki-find-page): Prompt when creating the first HyWiki page
     so user is not surprised by this Action Key behavior.
+            (hywiki-maybe-highlight-page-names): Add 3rd optional arg,
+    'skip-lookups-update-flag'.
+            (hywiki-maybe-highlight-page-names-in-frame): Add optional 2nd arg,
+    'skip-lookups-update-flag'
+            (hywiki-get-page-hasht): Call above function when update
+    lookup tables so use new data to highlight HyWikiWords.
 
 * man/hyperbole.texi (Manual Overview): Add links for HyWiki and HyNote.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2024-09-16  Bob Weiner  <rsw@gnu.org>
+
+* hsys-org.el {C-c C-@} Bind this key in Org mode to
+   'hycontrol-windows-grid' unless already bound.
+  hycontrol.el (hycontrol-windows-grid): Fix infinite recursive call
+    when 'mode-binding' is the same as the current command, e.g. org-mode.
+
 2024-09-10  Bob Weiner  <rsw@gnu.org>
 
 * hywiki.el (hywiki-org-make-publish-project-alist): Add

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 2024-09-21  Bob Weiner  <rsw@gnu.org>
 
+* hypb.el (hypb:empty-file-p): Add and use in 'hywiki-kill-buffer-hook'.
+
 * hywiki.el (hywiki-find-page): Prompt when creating the first HyWiki page
     so user is not surprised by this Action Key behavior.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2024-09-22  Bob Weiner  <rsw@gnu.org>
 
+* test/hywiki-tests.el (hywiki-tests--get-page-list-when-new-wiki-directory):
+    Remove 'hash-empty-p' test that fails exclusively on Emacs master.
+
 * hywiki.el (hywiki-find-page): Move prompt tests to 'hywiki-add-page'.
             (hywiki-add-page): Add and run 'hywiki-add-page-hook'.  Add
     optional second arg 'prompt-flag' that 'hywiki-find-page' passes.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,22 @@
+2024-09-21  Bob Weiner  <rsw@gnu.org>
+
+* hywiki.el (hywiki-maybe-highlight-balanced-pairs): Separate balanced
+    pair delimited expression highlighting into this function to allow
+    for more general handling.  Expand range from one line to two.
+            (hywiki-maybe-highlight-page-name): Call above function.
+	    (hywiki-get-page): Auto-link standard pluralizations of HyWikiWords
+    that end 's' when not preceded by an 's' or in 'es'.
+            (hywiki-directory-set-mod-time): Add.
+	    (hywiki--directory-checksum): Add for checking if any HyWiki page file
+    names have changed.
+	    (hywiki-directory-get-checksum, hywiki-directory-set-checksum): Add.
+	    (hywiki-directory-modified-p): Additionally test if dir checksum changed.
+            (hywiki-get-page-hasht): Fix to update pages hash table and page name
+    and page name regexp lookups if any page file name changes.
+            (hywiki-maybe-highlight-page-names): Force rebuild of pages hash table
+    if any page file names have changed in 'hywiki-directory' and move mod-time
+    update to 'hywiki-get-page-hasht'.
+
 2024-09-16  Bob Weiner  <rsw@gnu.org>
 
 * hsys-org.el {C-c C-@} Bind this key in Org mode to

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,8 @@
 2024-09-21  Bob Weiner  <rsw@gnu.org>
 
-* hypb.el (hypb:empty-file-p): Add and use in 'hywiki-kill-buffer-hook'.
+* hywiki.el (hywiki-kill-buffer-hook): Add for use as a global
+    'kill-buffer-hook'.
+  hypb.el (hypb:empty-file-p): Add and use in 'hywiki-kill-buffer-hook'.
 
 * hywiki.el (hywiki-find-page): Prompt when creating the first HyWiki page
     so user is not surprised by this Action Key behavior.

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,9 @@
 * hywiki.el (hywiki-find-page): Move prompt tests to 'hywiki-add-page'.
             (hywiki-add-page): Add and run 'hywiki-add-page-hook'.  Add
     optional second arg 'prompt-flag' that 'hywiki-find-page' passes.
+            (hywiki-directory-get-checksum): Update to use 'hywiki-get-page-files'.
+	    (hywiki-get-files): Remove, essentially duplicate of
+    'hywiki-get-page-files'.
 
 * test/hywiki-tests.el (hywiki-tests--directory-modified-p):
     Update to set checksum which is needed now and expand

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 2024-09-21  Bob Weiner  <rsw@gnu.org>
 
+* hywiki.el (hywiki-find-page): Prompt when creating the first HyWiki page
+    so user is not surprised by this Action Key behavior.
+
+* man/hyperbole.texi (Manual Overview): Add links for HyWiki and HyNote.
+
 * hywiki.el (hywiki-maybe-highlight-balanced-pairs): Separate balanced
     pair delimited expression highlighting into this function to allow
     for more general handling.  Expand range from one line to two.

--- a/hsys-org.el
+++ b/hsys-org.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Jul-16 at 14:54:14
-;; Last-Mod:      8-Aug-24 at 23:51:10 by Mats Lidell
+;; Last-Mod:     16-Sep-24 at 22:19:53 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -44,6 +44,12 @@
 ;;; ************************************************************************
 ;;; Public declarations
 ;;; ************************************************************************
+
+;; Bind {C-c C-@} to create a user-specified sized grid of windows
+;; displaying different buffers.
+;; Don't override prior bindings of this key.
+(unless (lookup-key org-mode-map "\C-c\C-@")
+  (define-key org-mode-map "\C-c\C-@" #'hycontrol-windows-grid))
 
 (defvar hyperbole-mode-map)             ; "hyperbole.el"
 (defvar org--inhibit-version-check)     ; "org-macs.el"

--- a/hycontrol.el
+++ b/hycontrol.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Jun-16 at 15:35:36
-;; Last-Mod:     29-May-24 at 00:57:08 by Bob Weiner
+;; Last-Mod:     16-Sep-24 at 22:40:19 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1666,6 +1666,7 @@ command instead.  Typically prevents clashes over {\\`C-c' @}."
 	     (this-key-flag (and (called-interactively-p 'interactive)
 				 (equal (this-single-command-keys) key))))
 	(cond ((and mode-binding (not (integerp mode-binding))
+		    (not (eq this-command mode-binding))
 		    this-key-flag (if (eq major-mode #'outline-mode) (not arg) t))
 	       ;; If the key that invokes this command in `hyperbole-minor-mode'
 	       ;; is also bound in the current major mode map, then

--- a/hypb.el
+++ b/hypb.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     6-Oct-91 at 03:42:38
-;; Last-Mod:      8-Jun-24 at 19:54:44 by Bob Weiner
+;; Last-Mod:     21-Sep-24 at 23:20:56 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -464,6 +464,11 @@ This will install the Emacs devdocs package if not yet installed."
 		       (or src-buf-exists-p (kill-buffer nil))
 		       dname))))
       (concat "@" dname))))
+
+(defun hypb:empty-file-p ()
+  "Return non-nil if the current buffer has an attached file of zero size."
+  (when (and buffer-file-name (file-readable-p buffer-file-name))
+    (= (file-attribute-size (file-attributes buffer-file-name)) 0)))
 
 (defun hypb:error (&rest args)
   "Signal an error typically to be caught by `hyperbole'.

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Apr-24 at 22:41:13
-;; Last-Mod:     22-Sep-24 at 02:31:37 by Bob Weiner
+;; Last-Mod:     22-Sep-24 at 02:44:39 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -806,9 +806,9 @@ interactively), limit dehighlighting to the region."
 
 (defun hywiki-directory-get-checksum ()
   "Compute and return the checksum for the current set of HyWiki pages."
-  (let ((hywiki-file-regexp (concat hywiki-word-regexp (regexp-quote hywiki-file-suffix) "$")))
-    (md5 (apply #'concat (directory-files hywiki-directory nil hywiki-file-regexp))
-	 nil nil nil t)))
+  (let ((hywiki-page-files (hywiki-get-page-files)))
+    (when hywiki-page-files
+      (md5 (apply #'concat hywiki-page-files) nil nil nil t))))
 
 (defun hywiki-directory-get-mod-time ()
   "Return the last mod time for `hywiki-directory' or 0."
@@ -1156,17 +1156,6 @@ are typed in the buffer."
   "Extract the page name from the buffer file name or else buffer name."
   (file-name-sans-extension (file-name-nondirectory
 			     (or buffer-file-name (buffer-name)))))
-
-(defun hywiki-get-files ()
-  "Return the list of existing HyWiki files ending with `hywiki-file-suffix'.
-This includes both HyWiki page files and others.  File names returned are
-relative to `hywiki-directory'."
-  (when (stringp hywiki-directory)
-    (make-directory hywiki-directory t)
-    (when (file-readable-p hywiki-directory)
-      (directory-files
-       hywiki-directory nil
-       (concat "^[^#]+" (regexp-quote hywiki-file-suffix) "$")))))
 
 (defun hywiki-get-page (page-name)
   "Return the absolute path of HyWiki PAGE-NAME or nil if it does not exist."

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Apr-24 at 22:41:13
-;; Last-Mod:     21-Sep-24 at 16:39:32 by Bob Weiner
+;; Last-Mod:     21-Sep-24 at 18:36:13 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -521,10 +521,11 @@ failed or if displaying a regular file (read in via a `find-file'
 call).
 
 By default, create any non-existent page.  With optional
-PROMPT-FLAG t, prompt to create if non-existent.  If PROMPT-FLAG
-is :existing or with a prefix argument when called interactively,
-return nil unless the page already exists.  After successfully
-finding a page and reading it into a buffer, run
+PROMPT-FLAG t or if this is the first HyWiki page in
+`hywiki-directory', prompt to create if non-existent.  If
+PROMPT-FLAG is :existing or with a prefix argument when called
+interactively, return nil unless the page already exists.  After
+successfully finding a page and reading it into a buffer, run
 `hywiki-find-page-hook'."
   (interactive (list (if current-prefix-arg
 			 (hywiki-read-page-name "Find existing HyWiki page: ")
@@ -548,9 +549,9 @@ finding a page and reading it into a buffer, run
 				(substring page-name 0 (match-beginning 0))
 			      page-name))
 		 (page-file (or (hywiki-get-page page-name)
-				(if prompt-flag
+				(if (or prompt-flag (null (hywiki-get-page-list)))
 				    (unless (eq prompt-flag :existing)
-				      (when (y-or-n-p (concat "Create new `" page-name "' page? "))
+				      (when (y-or-n-p (concat "Create new HyWiki page `" page-name "'? "))
 					(hywiki-add-page page-name)))
 				  (hywiki-add-page page-name)))))
 	    (when page-file

--- a/hywiki.el
+++ b/hywiki.el
@@ -1217,6 +1217,17 @@ regexps of page names."
 (defun hywiki-get-page-list ()
   (hash-map #'cdr (hywiki-get-page-hasht)))
 
+(defun hywiki-kill-buffer-hook ()
+  "Delete file attached to HyWiki buffer if the file is zero-sized.
+If deleted, update HyWikiWord highlighting across all frames."
+  (when (hywiki-in-page-p)
+    (when (hypb:empty-file-p)
+      (delete-file buffer-file-name))
+    (when (hywiki-directory-modified-p)
+      ;; Rebuild lookup tables if any HyWiki page name has changed
+      (hywiki-get-page-hasht))
+    nil))
+
 (defun hywiki-make-pages-hasht ()
   (let* ((page-files (hywiki-get-page-files))
 	 (page-elts (mapcar (lambda (file)
@@ -1507,6 +1518,8 @@ Highlight/dehighlight HyWiki page names across all frames on change."
 ;;; ************************************************************************
 ;;; Public initializations
 ;;; ************************************************************************
+
+(add-hook 'kill-buffer-hook 'hywiki-kill-buffer-hook)
 
 (eval-after-load "org-element"
   '(advice-add 'org-element--generate-copy-script :before #'hywiki-org-export-function))

--- a/man/hyperbole.texi
+++ b/man/hyperbole.texi
@@ -7,7 +7,7 @@
 @c Author:       Bob Weiner
 @c
 @c Orig-Date:     6-Nov-91 at 11:18:03
-@c Last-Mod:     10-Sep-24 at 20:49:39 by Bob Weiner
+@c Last-Mod:     21-Sep-24 at 18:10:46 by Bob Weiner
 
 @c %**start of header (This is for running Texinfo on a region.)
 @setfilename hyperbole.info
@@ -159,7 +159,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.</P>
 
 <PRE>
 Edition 9.0.2pre
-Printed September 1, 2024.
+Printed September 21, 2024.
 
   Published by the Free Software Foundation, Inc.
   Author:    Bob Weiner
@@ -201,7 +201,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
 @example
 Edition 9.0.2pre
-September 1, 2024
+September 21, 2024
 
   Published by the Free Software Foundation, Inc.
   Author:    Bob Weiner
@@ -589,7 +589,7 @@ Hyperbole allows hypertext buttons to be embedded within unstructured and
 structured files, mail messages and news articles.  It offers intuitive
 keyboard and mouse-based control of information display within multiple
 windows.  It also provides point-and-click access to Info manuals, ftp
-archives, and the World-Wide Web.
+archives, the World-Wide Web and much more.
 
 @cindex file, FAST-DEMO
 @cindex Hyperbole demo
@@ -632,17 +632,33 @@ provides a number of overlapping interaction methods that support differing
 work styles.  In such instances, you need learn only one technique that suits
 you.
 
-@xref{Buttons}, for an overview of Hyperbole buttons and how to use them.
+@xref{Buttons}, for an overview of Hyperbole buttons and how to use
+them.  Hyperbole's action-oriented button support is enabled via the
+global minor mode, @code{hyperbole-mode).
+
 
 @xref{Menus}, for summaries of Hyperbole menu commands and how to use
 the minibuffer-based menus that work on any display that Emacs supports.
+
+@xref{HyWiki}, for Hyperbole's markup-free, personal Wiki system for
+note-taking and automatic WikiWord highlighting and hyperlinking.  It
+extends Org mode.  HyWikiWord hyperlink buttons are automatically
+enabled for wiki pages below @code{hywiki-directory}.  To enable them
+in text buffers outside of this directory, enable the global minor
+mode, @code{hywiki-mode}.
+
+@xref{HyNote}, for a start on the very early stages of Hyperbole's
+multi-format note taking system.  HyNote supports Org, Markdown,
+Koutline and Emacs Outline file formats.  HyNote works in any buffer
+where HyWiki support is active.
 
 @xref{HyControl}, for how to quickly and interactively control what your
 Emacs windows and frames display and where they appear.
 
 @xref{Koutliner}, for concept and usage information on the
-autonumbered, hypertextual outliner.  @xref{Koutliner Keys}, for a full
-summary of the outliner commands that are bound to keys.
+autonumbered, hypertextual outliner.  It uses its own major mode.
+@xref{Koutliner Keys}, for a full summary of the outliner commands
+that are bound to keys.
 
 @xref{HyRolo}, for concept and usage information on the rapid lookup,
 hierarchical, full-text record management system included with Hyperbole.
@@ -4668,7 +4684,7 @@ implicit button type that HyNote defines, @code{hynote-file}.
 In the future, HyNote will also provide a universal way to easily link to
 information across many file formats.
 
-See also @ref{HyWiki}.
+For more, @ref{HyWiki}.
 
 
 @node HyControl, Koutliner, HyNote, Top

--- a/man/hyperbole.texi
+++ b/man/hyperbole.texi
@@ -7,7 +7,7 @@
 @c Author:       Bob Weiner
 @c
 @c Orig-Date:     6-Nov-91 at 11:18:03
-@c Last-Mod:      2-Sep-24 at 19:50:16 by Bob Weiner
+@c Last-Mod:     10-Sep-24 at 20:49:39 by Bob Weiner
 
 @c %**start of header (This is for running Texinfo on a region.)
 @setfilename hyperbole.info
@@ -4487,10 +4487,10 @@ the following contexts:
 @cindex HyWikiWord highlighting
 As HyWikiWords are typed, highlighting occurs after a trailing
 whitespace or punctuation character is added, or when the HyWikiWord
-is surrounded by a matching pair of characters such as curly braces.
-Since Org links use double square brackets and Org targets use double
-or triple angle brackets, HyWikiWords within these delimiters are
-ignored once the brackets are in place.
+is surrounded by a matching pair of characters such as curly braces or
+single square brackets.  Since Org links use double square brackets
+and Org targets use double or triple angle brackets, HyWikiWords
+within these delimiters are ignored once the brackets are in place.
 
 @vindex hywiki-word-highlight-flag
 The custom setting, @code{hywiki-word-highlight-flag} (default =

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    18-May-24 at 23:59:48
-;; Last-Mod:     15-Aug-24 at 09:17:01 by Mats Lidell
+;; Last-Mod:     22-Sep-24 at 02:00:02 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -29,7 +29,7 @@
          (hywiki-directory (make-temp-file "hywiki" t))
 	 (hywiki-page-file (expand-file-name "WikiWord.org" hywiki-directory)))
     (unwind-protect
-        (mocklet (((make-empty-file (expand-file-name "WikiWord.org" hywiki-directory) t) => t))
+	(progn
           (should (string= hywiki-page-file
                            (hywiki-add-page "WikiWord")))
           ;; Verify hash table is updated
@@ -37,6 +37,7 @@
             (not-called hywiki-add-page)
             (should (string= hywiki-page-file
                              (hywiki-get-page "WikiWord")))))
+      (hy-delete-file-and-buffer hywiki-page-file)
       (hy-delete-dir-and-buffer hywiki-directory))))
 
 (ert-deftest hywiki-tests--hywiki-add-page--adds-no-wiki-word-fails ()
@@ -61,7 +62,7 @@
         (with-temp-buffer
           (insert "[[hy:WikiWord]]")
           (goto-char 4)
-          (mocklet (((hywiki-add-page "WikiWord") => wikifile))
+          (mocklet (((hywiki-add-page "WikiWord" nil) => wikifile))
             (action-key)))
       (hy-delete-file-and-buffer wikifile))))
 
@@ -163,10 +164,19 @@
   "Verify `hywiki-directory-modified-p'."
   (let ((hywiki--directory-mod-time 0))
     (should (hywiki-directory-modified-p)))
-  (let ((hywiki--directory-mod-time 2))
-    (mocklet ((hywiki-directory-get-mod-time => 2))
+  (let ((hywiki--directory-mod-time 2)
+	(hywiki--directory-checksum "3"))
+    (mocklet ((hywiki-directory-get-mod-time => 2)
+	      (hywiki-directory-get-checksum => "3"))
       (should-not (hywiki-directory-modified-p)))
-    (mocklet ((hywiki-directory-get-mod-time => 1))
+    (mocklet ((hywiki-directory-get-mod-time => 2)
+	      (hywiki-directory-get-checksum => "4"))
+      (should-not (hywiki-directory-modified-p)))
+    (mocklet ((hywiki-directory-get-mod-time => 1)
+	      (hywiki-directory-get-checksum => "3"))
+      (should-not (hywiki-directory-modified-p)))
+    (mocklet ((hywiki-directory-get-mod-time => 1)
+	      (hywiki-directory-get-checksum => "4"))
       (should (hywiki-directory-modified-p)))))
 
 (ert-deftest hywiki-tests--get-page-list ()

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    18-May-24 at 23:59:48
-;; Last-Mod:     22-Sep-24 at 02:00:02 by Bob Weiner
+;; Last-Mod:     22-Sep-24 at 03:00:21 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -216,8 +216,7 @@
           (let ((hywiki-directory (make-temp-file "hywiki" t)))
             (unwind-protect
                 (progn
-                  (should (hash-empty-p (hywiki-get-page-hasht)))
-                    (should (= 0 (length (hywiki-get-page-list)))))
+                  (should (= 0 (length (hywiki-get-page-list)))))
               (hy-delete-dir-and-buffer hywiki-directory))))
       (hy-delete-file-and-buffer wiki-page)
       (hy-delete-dir-and-buffer hywiki-directory))))


### PR DESCRIPTION
- hywiki.el - Fix so HyWikiWord highlighting tracks hywiki-dir updates
- hywiki.el - Add 'hywiki-kill-buffer-hook'
- hypb.el (hypb:empty-file-p): Add, use in 'hywiki-kill-buffer-hook'
- hywiki.el (hywiki-find-page): Prompt when creating first HyWiki page
- hywiki.el - Add support for page name plurals
