### PR TITLE
add test for add and remove wiki page

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 2024-10-04  Mats Lidell  <matsl@gnu.org>
 
+* hywiki.el (hywiki-add-page): Set mod time and checksum on file creation.
+
 * test/hywiki-tests.el (hywiki-tests--get-page-list-after-add-and-delete):
     Add test.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2024-10-04  Mats Lidell  <matsl@gnu.org>
+
+* test/hywiki-tests.el (hywiki-tests--get-page-list-after-add-and-delete):
+    Add test.
+
 2024-09-22  Bob Weiner  <rsw@gnu.org>
 
 * test/hywiki-tests.el (hywiki-tests--get-page-list-when-new-wiki-directory):

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Apr-24 at 22:41:13
-;; Last-Mod:     22-Sep-24 at 02:44:39 by Bob Weiner
+;; Last-Mod:      3-Oct-24 at 23:57:21 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -613,7 +613,9 @@ Use `hywiki-get-page' to determine whether a HyWiki page exists."
 	      pages-hasht)
 	  (unless (file-readable-p page-file)
 	    ;; Create any parent dirs necessary to create empty file
-	    (make-empty-file page-file t))
+	    (make-empty-file page-file t)
+            (hywiki-directory-set-mod-time)
+            (hywiki-directory-set-checksum))
 	  (setq pages-hasht (hywiki-get-page-hasht))
 	  (unless (hash-get page-name pages-hasht)
 	    (hash-add page-file page-name pages-hasht))

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    18-May-24 at 23:59:48
-;; Last-Mod:      4-Oct-24 at 00:03:00 by Mats Lidell
+;; Last-Mod:      4-Oct-24 at 00:08:17 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -203,13 +203,14 @@
                 (progn
                   (should-not
                    (cl-set-exclusive-or '("WordOne" "WordTwo") (hywiki-get-page-list) :test 'equal)))
-              ;; (sit-for 1) ; Wait before remove file or mock modified-p, see below.
+              (sit-for 1) ; Wait before remove file or mock modified-p, see below.
               (hy-delete-file-and-buffer wiki-page2)))
           ;; Add and remove is within the same time stamp of the
           ;; folder so removal is not noticed. We need to mock the
           ;; modified check to get the desired behavior.
-          (mocklet ((hywiki-directory-modified-p => t))
-            (should (equal '("WordOne") (hywiki-get-page-list)))))
+          ;; (mocklet ((hywiki-directory-modified-p => t))
+          (should (equal '("WordOne") (hywiki-get-page-list))))
+      ;;)
       (hy-delete-file-and-buffer wiki-page)
       (hy-delete-dir-and-buffer hywiki-directory))))
 


### PR DESCRIPTION
# What

- Add hywiki-tests--get-page-list-after-add-and-delete
- Set mod time and checksum on file creation

# Why

Did an attempt to write a test case that verifies that the pages
returned by hywiki-get-page-list when adding and removing pages. I
know removing might be something we are working on but it felt that
the caching is not perfect. So the test case might not be worth adding
in its present state but can be worth discussing. So filing it as PR
for review and discussion.
