### PR TITLE
add more hywiki tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18,8 +18,7 @@
     (hywiki-tests--verify-face-property-when-editing-wikiword-first-char): Add hywiki
     tests.
 
-* hywiki.el (hywiki-directory-edit): Remove character classes. Not
-    supported by all shells.
+* test/hywiki-tests.el (hywiki-tests--word-is-p): Add hywiki test.
 
 2024-10-28  Bob Weiner  <rsw@gnu.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,7 +2,8 @@
 
 * test/hywiki-tests.el (hywiki-tests--word-is-p)
     (hywiki-tests--directory-edit)
-    (hywiki-tests--verify-face-property-when-editing-wikiword): Add hywiki
+    (hywiki-tests--verify-face-property-when-editing-wikiword)
+    (hywiki-tests--verify-face-property-when-editing-wikiword-first-char): Add hywiki
     tests.
 
 * hywiki.el (hywiki-directory-edit): Remove character classes. Not

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2024-11-01  Mats Lidell  <matsl@gnu.org>
+
+* test/hywiki-tests.el (hywiki-tests--word-is-p): Add hywiki test.
+
 2024-10-28  Bob Weiner  <rsw@gnu.org>
 
 * hibtypes.el (hywiki-existing-word): Call action with the singular version

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+2024-11-10  Mats Lidell  <matsl@gnu.org>
+
+* test/hywiki-tests.el (hywiki-tests--add-hywiki-hooks)
+    (hywiki-tests--remove-hywiki-hooks, with-hywiki-buttonize-hooks)
+    (with-hywiki-buttonize-and-insert-hooks): Add functions and macros for
+    mimicking redisplay hook behavior and use these in the highlighting tests.
+    (hywiki-tests--face-property-for-wikiword-with-wikipage)
+    (hywiki-tests--no-face-property-for-no-wikipage)
+    (hywiki-tests--verify-face-property-when-editing-wikiword)
+    (hywiki-tests--verify-face-property-when-editing-wikiword-first-char):
+    Tests using the hook mimicking functions.
+
 2024-11-02  Mats Lidell  <matsl@gnu.org>
 
 * test/hywiki-tests.el (hywiki-tests--word-is-p)

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,10 @@
 2024-11-01  Mats Lidell  <matsl@gnu.org>
 
-* test/hywiki-tests.el (hywiki-tests--word-is-p): Add hywiki test.
+* hywiki.el (hywiki-directory-edit): Remove character classes. Not
+    supported by all shells.
+
+* test/hywiki-tests.el (hywiki-tests--word-is-p):
+    (hywiki-tests--directory-edit):  Add hywiki test.
 
 2024-10-28  Bob Weiner  <rsw@gnu.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,10 +1,12 @@
-2024-11-01  Mats Lidell  <matsl@gnu.org>
+2024-11-02  Mats Lidell  <matsl@gnu.org>
+
+* test/hywiki-tests.el (hywiki-tests--word-is-p)
+    (hywiki-tests--directory-edit)
+    (hywiki-tests--verify-face-property-when-editing-wikiword): Add hywiki
+    tests.
 
 * hywiki.el (hywiki-directory-edit): Remove character classes. Not
     supported by all shells.
-
-* test/hywiki-tests.el (hywiki-tests--word-is-p):
-    (hywiki-tests--directory-edit):  Add hywiki test.
 
 2024-10-28  Bob Weiner  <rsw@gnu.org>
 

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Apr-24 at 22:41:13
-;; Last-Mod:     28-Oct-24 at 01:43:34 by Bob Weiner
+;; Last-Mod:      1-Nov-24 at 00:00:19 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -836,7 +836,7 @@ these are handled by the Org mode link handler."
 (defun hywiki-directory-edit ()
   "Display and edit HyWiki pages in current `hywiki-directory'."
   (interactive)
-  (dired (concat hywiki-directory "[[:upper:]][[:alpha:]]*"
+  (dired (concat hywiki-directory "*"
 		 (regexp-quote hywiki-file-suffix))))
 
 (defun hywiki-directory-get-checksum ()

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Apr-24 at 22:41:13
-;; Last-Mod:      1-Nov-24 at 00:00:19 by Mats Lidell
+;; Last-Mod:     28-Oct-24 at 01:43:34 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -836,7 +836,7 @@ these are handled by the Org mode link handler."
 (defun hywiki-directory-edit ()
   "Display and edit HyWiki pages in current `hywiki-directory'."
   (interactive)
-  (dired (concat hywiki-directory "*"
+  (dired (concat hywiki-directory "[[:upper:]][[:alpha:]]*"
 		 (regexp-quote hywiki-file-suffix))))
 
 (defun hywiki-directory-get-checksum ()

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    18-May-24 at 23:59:48
-;; Last-Mod:     18-Oct-24 at 22:44:05 by Mats Lidell
+;; Last-Mod:      1-Nov-24 at 00:00:19 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -111,6 +111,17 @@
   (should (hywiki-word-is-p "WikiWord#section"))
   (should-not (hywiki-word-is-p "hy:WikiWord"))
   (should-not (hywiki-word-is-p "wikiWord")))
+
+(ert-deftest hywiki-tests--directory-edit ()
+  "Verify `hywiki-directory-edit' opens dired in right folder."
+  (let* ((hywiki-directory (file-name-as-directory (make-temp-file "hywiki" t)))
+         (wiki-page (hywiki-add-page "WikiWord")))
+    (unwind-protect
+        (progn
+          (hywiki-directory-edit)
+          (should (string= default-directory hywiki-directory)))
+      (hy-delete-file-and-buffer wiki-page)
+      (hy-delete-dir-and-buffer hywiki-directory))))
 
 (ert-deftest hywiki-tests--maybe-at-wikiword-beginning ()
   "Verify `hywiki-maybe-at-wikiword-beginning' identifies if maybe at beginning of WikiWord."

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    18-May-24 at 23:59:48
-;; Last-Mod:      1-Nov-24 at 00:00:19 by Mats Lidell
+;; Last-Mod:      2-Nov-24 at 18:23:22 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -299,6 +299,31 @@ Both mod-time and checksum must be changed for a test to return true."
 	  (newline nil t)
           (goto-char 4)
           (should-not (hproperty:but-get (point) 'face hywiki-word-face)))
+      (hy-delete-dir-and-buffer hywiki-directory))))
+
+(ert-deftest hywiki-tests--verify-face-property-when-editing-wikiword ()
+  "Verify that the face property is added and removed when the WikiWord is edited."
+  :expected-result :failed
+  (skip-unless (not noninteractive))
+  (let* ((hywiki-directory (make-temp-file "hywiki" t))
+         (wikipage (hywiki-add-page "WikiWord"))
+         (wikipage2 (hywiki-add-page "AnyWord")))
+    (unwind-protect
+        (progn
+          (find-file wikipage2)
+          (hywiki-mode 1)
+          (insert "Wikiord")
+	  (newline nil t)
+          (goto-char 5)
+          (should (looking-at-p "ord"))
+          (should-not (hproperty:but-get (point) 'face hywiki-word-face))
+
+          (insert "W")
+          (goto-char 5)
+          (should (looking-at-p "Word"))
+          (should (hproperty:but-get (point) 'face hywiki-word-face)))
+      (hywiki-mode 0)
+      (hy-delete-files-and-buffers (list wikipage wikipage2))
       (hy-delete-dir-and-buffer hywiki-directory))))
 
 (ert-deftest hywiki-tests--convert-words-to-org-link ()

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    18-May-24 at 23:59:48
-;; Last-Mod:     10-Nov-24 at 22:54:09 by Mats Lidell
+;; Last-Mod:     10-Nov-24 at 23:05:28 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -111,17 +111,6 @@
   (should (hywiki-word-is-p "WikiWord#section"))
   (should-not (hywiki-word-is-p "hy:WikiWord"))
   (should-not (hywiki-word-is-p "wikiWord")))
-
-(ert-deftest hywiki-tests--directory-edit ()
-  "Verify `hywiki-directory-edit' opens dired in right folder."
-  (let* ((hywiki-directory (file-name-as-directory (make-temp-file "hywiki" t)))
-         (wiki-page (hywiki-add-page "WikiWord")))
-    (unwind-protect
-        (progn
-          (hywiki-directory-edit)
-          (should (string= default-directory hywiki-directory)))
-      (hy-delete-file-and-buffer wiki-page)
-      (hy-delete-dir-and-buffer hywiki-directory))))
 
 (ert-deftest hywiki-tests--maybe-at-wikiword-beginning ()
   "Verify `hywiki-maybe-at-wikiword-beginning' identifies if maybe at beginning of WikiWord."

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    18-May-24 at 23:59:48
-;; Last-Mod:      2-Nov-24 at 18:23:22 by Mats Lidell
+;; Last-Mod:      2-Nov-24 at 23:29:41 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -272,7 +272,6 @@ Both mod-time and checksum must be changed for a test to return true."
 
 (ert-deftest hywiki-tests--face-property-for-wikiword-with-wikipage ()
   "Verify WikiWord for a wiki page gets face property hywiki-word-face."
-  (skip-unless (not noninteractive))
   (let* ((hsys-org-enable-smart-keys t)
          (hywiki-directory (make-temp-file "hywiki" t))
          (wikipage (hywiki-add-page "WikiWord")))
@@ -282,6 +281,7 @@ Both mod-time and checksum must be changed for a test to return true."
           (insert "WikiWord")
 	  (newline nil t)
           (goto-char 4)
+          (hywiki-maybe-highlight-page-names (point-min) (point-max))
           (should (hproperty:but-get (point) 'face hywiki-word-face)))
       (hywiki-mode 0)
       (hy-delete-file-and-buffer wikipage)
@@ -289,7 +289,6 @@ Both mod-time and checksum must be changed for a test to return true."
 
 (ert-deftest hywiki-tests--no-face-property-for-no-wikipage ()
   "Verify WikiWord for no wiki page does not get face property hywiki-word-face."
-  (skip-unless (not noninteractive))
   (let* ((hsys-org-enable-smart-keys t)
          (hywiki-directory (make-temp-file "hywiki" t)))
     (unwind-protect
@@ -298,32 +297,62 @@ Both mod-time and checksum must be changed for a test to return true."
           (insert "WikiWord")
 	  (newline nil t)
           (goto-char 4)
+          (hywiki-maybe-highlight-page-names (point-min) (point-max))
           (should-not (hproperty:but-get (point) 'face hywiki-word-face)))
       (hy-delete-dir-and-buffer hywiki-directory))))
 
 (ert-deftest hywiki-tests--verify-face-property-when-editing-wikiword ()
-  "Verify that the face property is added and removed when the WikiWord is edited."
-  :expected-result :failed
-  (skip-unless (not noninteractive))
+  "Verify face property changes when WikiWord is edited."
   (let* ((hywiki-directory (make-temp-file "hywiki" t))
-         (wikipage (hywiki-add-page "WikiWord"))
-         (wikipage2 (hywiki-add-page "AnyWord")))
+         (wikipage (hywiki-add-page "WikiWord")))
     (unwind-protect
-        (progn
-          (find-file wikipage2)
+        (with-temp-buffer
           (hywiki-mode 1)
-          (insert "Wikiord")
-	  (newline nil t)
+          (insert "Wikiord ")
           (goto-char 5)
           (should (looking-at-p "ord"))
+          (hywiki-maybe-highlight-page-names (point-min) (point-max))
           (should-not (hproperty:but-get (point) 'face hywiki-word-face))
 
           (insert "W")
           (goto-char 5)
           (should (looking-at-p "Word"))
+          (hywiki-maybe-highlight-page-names (point-min) (point-max))
+          (should (hproperty:but-get (point) 'face hywiki-word-face))
+
+          (delete-char 1)
+          (should (looking-at-p "ord"))
+          (hywiki-maybe-highlight-page-names (point-min) (point-max))
+          (should-not (hproperty:but-get (point) 'face hywiki-word-face)))
+      (hywiki-mode 0)
+      (hy-delete-files-and-buffers (list wikipage))
+      (hy-delete-dir-and-buffer hywiki-directory))))
+
+(ert-deftest hywiki-tests--verify-face-property-when-editing-wikiword-first-char ()
+  "Verify face property changes when WikiWord is edited in the first char position."
+  (let* ((hywiki-directory (make-temp-file "hywiki" t))
+         (wikipage (hywiki-add-page "WikiWord")))
+    (unwind-protect
+        (with-temp-buffer
+          (hywiki-mode 1)
+          (insert "WikiWord ")
+          (goto-char 1)
+          (should (looking-at-p "Wiki"))
+          (hywiki-maybe-highlight-page-names (point-min) (point-max))
+          (should (hproperty:but-get (point) 'face hywiki-word-face))
+
+          (delete-char 1)
+          (should (looking-at-p "iki"))
+          (hywiki-maybe-highlight-page-names (point-min) (point-max))
+          (should-not (hproperty:but-get (point) 'face hywiki-word-face))
+
+          (insert "W")
+          (goto-char 1)
+          (should (looking-at-p "Wiki"))
+          (hywiki-maybe-highlight-page-names (point-min) (point-max))
           (should (hproperty:but-get (point) 'face hywiki-word-face)))
       (hywiki-mode 0)
-      (hy-delete-files-and-buffers (list wikipage wikipage2))
+      (hy-delete-files-and-buffers (list wikipage))
       (hy-delete-dir-and-buffer hywiki-directory))))
 
 (ert-deftest hywiki-tests--convert-words-to-org-link ()

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -105,6 +105,13 @@
       (hywiki-mode -1)
       (hy-delete-dir-and-buffer hywiki-directory))))
 
+(ert-deftest hywiki-tests--word-is-p ()
+  "Verify `hywiki-word-is-p' identifies WikiWords."
+  (should (hywiki-word-is-p "WikiWord"))
+  (should (hywiki-word-is-p "WikiWord#section"))
+  (should-not (hywiki-word-is-p "hy:WikiWord"))
+  (should-not (hywiki-word-is-p "wikiWord")))
+
 (ert-deftest hywiki-tests--maybe-at-wikiword-beginning ()
   "Verify `hywiki-maybe-at-wikiword-beginning' identifies if maybe at beginning of WikiWord."
   (with-temp-buffer


### PR DESCRIPTION
# What

- Add hywiki-word-is-p test
- ~Use plain star wildcard and add a test~
- Add test case for verifying property is updated on edit
- Add macros and functions for handling hooks functions to emulate redisplay behavior.

# Why

Tests are good.

# Note 

@rswgnu For just picking a file from a PR and run it locally you can click on `Files changed` / View file / Download.
