### PR TITLE
remove warnings

### DIFF
--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:     12-Nov-24 at 20:12:49 by Mats Lidell
+;; Last-Mod:     13-Nov-24 at 13:08:00 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -50,41 +50,36 @@
 ;;; Public declarations
 ;;; ************************************************************************
 
-(declare-function markdown-footnote-goto-text "ext:markdown")
-(declare-function markdown-footnote-marker-positions "ext:markdown")
-(declare-function markdown-footnote-return "ext:markdown")
-(declare-function markdown-link-p "ext:markdown")
-(declare-function markdown-link-url "ext:markdown")
-(declare-function markdown-reference-goto-definition "ext:markdown")
-(declare-function markdown-reference-goto-link "ext:markdown")
-(declare-function markdown-wiki-link-p "ext:markdown")
-(declare-function markdown-footnote-text-positions "ext:markdown")
-(declare-function org-roam-id-find "ext:org-roam")
+(defvar cscope-output-line-regexp)
+(defvar id-cflow-repeated-indicator)
 (defvar markdown-regex-link-reference)
 (defvar markdown-regex-reference-definition)
-
-(defvar id-cflow-repeated-indicator)
-
-(defvar cscope-output-line-regexp)
-
 (defvar org-uuid-regexp)
 
 (declare-function actype:eval "hact")
 (declare-function actype:identity "hact")
+(declare-function ert-test-boundp "ert")
 (declare-function hact "hact")
 (declare-function hpath:display-buffer "hpath")
 (declare-function htype:def-symbol "hact")
 (declare-function hui:help-ebut-highlight "hui")
 (declare-function hyperb:stack-frame "hversion")
+(declare-function hyrolo-get-file-list "hyrolo")
 (declare-function hywiki-get-singular-page-name "hywiki")
 (declare-function hywiki-page-exists-p "hywiki")
-
+(declare-function markdown-footnote-goto-text "ext:markdown")
+(declare-function markdown-footnote-marker-positions "ext:markdown")
+(declare-function markdown-footnote-return "ext:markdown")
+(declare-function markdown-footnote-text-positions "ext:markdown")
+(declare-function markdown-link-p "ext:markdown")
+(declare-function markdown-link-url "ext:markdown")
+(declare-function markdown-reference-goto-definition "ext:markdown")
+(declare-function markdown-reference-goto-link "ext:markdown")
+(declare-function markdown-wiki-link-p "ext:markdown")
+(declare-function org-roam-id-find "ext:org-roam")
 (declare-function set:member "set")
 (declare-function symset:add "hact")
 (declare-function symtable:add "hact")
-
-(declare-function hyrolo-get-file-list "hyrolo")
-(declare-function ert-test-boundp "ert")
 
 ;;; ************************************************************************
 ;;; Public implicit button types

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:     28-Oct-24 at 01:32:59 by Bob Weiner
+;; Last-Mod:     12-Nov-24 at 20:12:49 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -76,6 +76,7 @@
 (declare-function htype:def-symbol "hact")
 (declare-function hui:help-ebut-highlight "hui")
 (declare-function hyperb:stack-frame "hversion")
+(declare-function hywiki-get-singular-page-name "hywiki")
 (declare-function hywiki-page-exists-p "hywiki")
 
 (declare-function set:member "set")

--- a/hui-treemacs.el
+++ b/hui-treemacs.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Nov-17
-;; Last-Mod:     10-Nov-24 at 17:27:30 by Bob Weiner
+;; Last-Mod:     12-Nov-24 at 20:17:24 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -45,6 +45,8 @@
 (declare-function treemacs-node-buffer-and-position "ext:treemacs-mouse-interface")
 (declare-function treemacs-quit "ext:treemacs-interface")
 (declare-function treemacs-toggle-node "ext:treemacs-interface")
+(declare-function treemacs-add-and-display-current-project-exclusively "ext:treemacs")
+(declare-function treemacs-display-current-project-exclusively "ext:treemacs")
 (defvar aw-ignored-buffers)
 
 (defvar assist-flag)                    ; "hmouse-drv.el"
@@ -56,6 +58,7 @@
 (declare-function last-line-p "hui-mouse")
 (declare-function hact "hact")
 (declare-function package-activate "package")
+(declare-function hypb:require-package "hypb")
 
 ;;; ************************************************************************
 ;;; smart-treemacs functions

--- a/hui-treemacs.el
+++ b/hui-treemacs.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Nov-17
-;; Last-Mod:     12-Nov-24 at 20:17:24 by Mats Lidell
+;; Last-Mod:     13-Nov-24 at 13:09:22 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -37,28 +37,27 @@
 ;;; ************************************************************************
 ;;; Public declarations
 ;;; ************************************************************************
+(defvar action-key-depress-window)      ; "hmouse-drv.el"
+(defvar action-key-eol-function)        ; "hmouse-drv.el"
+(defvar assist-flag)                    ; "hmouse-drv.el"
+(defvar assist-key-eol-function)        ; "hmouse-drv.el"
+(defvar aw-ignored-buffers)
+
+(declare-function first-line-p "hui-mouse")
+(declare-function hact "hact")
+(declare-function hypb:require-package "hypb")
+(declare-function last-line-p "hui-mouse")
+(declare-function package-activate "package")
 (declare-function treemacs "ext:treemacs")
+(declare-function treemacs-add-and-display-current-project-exclusively "ext:treemacs")
 (declare-function treemacs-current-button "ext:treemacs-core-utils")
 (declare-function treemacs-current-visibility "ext:treemacs-scope")
+(declare-function treemacs-display-current-project-exclusively "ext:treemacs")
 (declare-function treemacs-get-local-window "ext:treemacs-scope")
 (declare-function treemacs-is-treemacs-window? "ext:treemacs-core-utils")
 (declare-function treemacs-node-buffer-and-position "ext:treemacs-mouse-interface")
 (declare-function treemacs-quit "ext:treemacs-interface")
 (declare-function treemacs-toggle-node "ext:treemacs-interface")
-(declare-function treemacs-add-and-display-current-project-exclusively "ext:treemacs")
-(declare-function treemacs-display-current-project-exclusively "ext:treemacs")
-(defvar aw-ignored-buffers)
-
-(defvar assist-flag)                    ; "hmouse-drv.el"
-(defvar action-key-eol-function)        ; "hmouse-drv.el"
-(defvar assist-key-eol-function)        ; "hmouse-drv.el"
-(defvar action-key-depress-window)      ; "hmouse-drv.el"
-
-(declare-function first-line-p "hui-mouse")
-(declare-function last-line-p "hui-mouse")
-(declare-function hact "hact")
-(declare-function package-activate "package")
-(declare-function hypb:require-package "hypb")
 
 ;;; ************************************************************************
 ;;; smart-treemacs functions

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Jun-89 at 22:08:29
-;; Last-Mod:      3-Nov-24 at 09:37:58 by Bob Weiner
+;; Last-Mod:     12-Nov-24 at 20:21:19 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1973,7 +1973,8 @@ Return number of matching entries found."
   ;; Save pattern as last rolo search expression.
   (setq hyrolo-match-regexp pattern)
   ;;
-  (let ((new-buf-flag) (actual-buf)
+  (let (;;(new-buf-flag)
+        (actual-buf)
 	;; Temporarily disable magit-auto-revert-mode-enable-in-buffers for hyrolo
 	;; buffers; not needed and can slow/hang file loading
 	(after-change-major-mode-hook
@@ -1982,7 +1983,8 @@ Return number of matching entries found."
 	     (or (setq actual-buf (hyrolo-buffer-exists-p hyrolo-file-or-buf))
 		 (when (file-exists-p hyrolo-file-or-buf)
 		   (setq actual-buf (hyrolo-find-file-noselect hyrolo-file-or-buf)
-			 new-buf-flag t))))
+			 ;; new-buf-flag t
+                         ))))
 	(let ((num-found 0)
 	      (incl-hdr t)
 	      (stuck-negative-point 0)

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Jun-89 at 22:08:29
-;; Last-Mod:     12-Nov-24 at 20:21:19 by Mats Lidell
+;; Last-Mod:     13-Nov-24 at 13:17:36 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1973,8 +1973,7 @@ Return number of matching entries found."
   ;; Save pattern as last rolo search expression.
   (setq hyrolo-match-regexp pattern)
   ;;
-  (let (;;(new-buf-flag)
-        (actual-buf)
+  (let ((actual-buf)
 	;; Temporarily disable magit-auto-revert-mode-enable-in-buffers for hyrolo
 	;; buffers; not needed and can slow/hang file loading
 	(after-change-major-mode-hook
@@ -1982,9 +1981,7 @@ Return number of matching entries found."
     (if (and (or (null max-matches) (eq max-matches t) (integerp max-matches))
 	     (or (setq actual-buf (hyrolo-buffer-exists-p hyrolo-file-or-buf))
 		 (when (file-exists-p hyrolo-file-or-buf)
-		   (setq actual-buf (hyrolo-find-file-noselect hyrolo-file-or-buf)
-			 ;; new-buf-flag t
-                         ))))
+		   (setq actual-buf (hyrolo-find-file-noselect hyrolo-file-or-buf)))))
 	(let ((num-found 0)
 	      (incl-hdr t)
 	      (stuck-negative-point 0)
@@ -1998,12 +1995,6 @@ Return number of matching entries found."
 		   (setq incl-hdr nil
 			 max-matches (- max-matches)))))
 	  (set-buffer actual-buf)
-
-	  ;; Comment out next two lines that could set source buffer
-	  ;; to read-only since this can break org-capture into the
-	  ;; buffer.  -- rsw, 2024-11-03
-	  ;; (when new-buf-flag
-	  ;;  (setq buffer-read-only t))
 
 	  (when (and headline-only
 		     (not (string-match (concat "\\`\\(" (regexp-quote "^") "\\|" (regexp-quote "\\`") "\\)") pattern)))

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Apr-24 at 22:41:13
-;; Last-Mod:     10-Nov-24 at 15:44:27 by Bob Weiner
+;; Last-Mod:     12-Nov-24 at 20:24:25 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -139,6 +139,7 @@
 (defvar org-agenda-buffer-tmp-name)  ;; "org-agenda.el"
 (defvar org-export-with-broken-links);; "ox.el"
 (defvar org-publish-project-alist)   ;; "ox-publish.el"
+(defvar action-key-modeline-buffer-id-function)  ;; "hui-mouse"
 (declare-function hsys-org-at-tags-p "hsys-org")
 (declare-function org-link-store-props "ol" (&rest plist))
 (declare-function org-publish-property "ox-publish" (property project &optional default))

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Apr-24 at 22:41:13
-;; Last-Mod:     12-Nov-24 at 20:24:25 by Mats Lidell
+;; Last-Mod:     13-Nov-24 at 13:13:51 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -136,10 +136,11 @@
 ;;; Public declarations
 ;;; ************************************************************************
 
+(defvar action-key-modeline-buffer-id-function)  ;; "hui-mouse"
 (defvar org-agenda-buffer-tmp-name)  ;; "org-agenda.el"
 (defvar org-export-with-broken-links);; "ox.el"
 (defvar org-publish-project-alist)   ;; "ox-publish.el"
-(defvar action-key-modeline-buffer-id-function)  ;; "hui-mouse"
+
 (declare-function hsys-org-at-tags-p "hsys-org")
 (declare-function org-link-store-props "ol" (&rest plist))
 (declare-function org-publish-property "ox-publish" (property project &optional default))


### PR DESCRIPTION
# What

- Remove unused warning, comment out all occurences of new-buf-flag
- Add defvar and declare-function to silence warnings

# Why

We should minimize the number of warnings.

# Note

I'm keeping the new-buf-flag but commenting it put everywhere to be in
company with the comment later in the code. I would opt for removing
all of these comments.
