### PR TITLE
Dispatch smart-eolp case to smart-org

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2024-11-16  Mats Lidell  <matsl@gnu.org>
+
+* test/hsys-org-tests.el (hsys-org--meta-return-on-end-of-line): Add test
+    case for eol action in org-mode.
+
+* hui-mouse.el (hkey-alist): Guard action-key-eol-function from acting
+    when we should be delegate to org-mode.
+
 2024-11-13  Bob Weiner  <rsw@gnu.org>
 
 * hywiki.el (hywiki-maybe-dehighlight-page-name,

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,7 +4,7 @@
     case for eol action in org-mode.
 
 * hui-mouse.el (hkey-alist): Guard action-key-eol-function from acting
-    when we should be delegate to org-mode.
+    when we should delegate to org-mode.
 
 2024-11-13  Bob Weiner  <rsw@gnu.org>
 

--- a/hui-mouse.el
+++ b/hui-mouse.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-89
-;; Last-Mod:     19-Aug-24 at 22:17:10 by Bob Weiner
+;; Last-Mod:     15-Nov-24 at 23:01:31 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -298,7 +298,9 @@ Its default value is `smart-scroll-down'.  To disable it, set it to
      . ((funcall (key-binding (kbd "RET"))) . (funcall (key-binding (kbd "RET")))))
     ;;
     ;; If at the end of a line (eol), invoke the associated Smart Key handler EOL handler.
-    ((smart-eolp)
+    ((and (smart-eolp)
+          (not (and (funcall hsys-org-mode-function)
+                    (not (equal hsys-org-enable-smart-keys t)))))
      . ((funcall action-key-eol-function) . (funcall assist-key-eol-function)))
     ;;
     ;; Handle any Org mode-specific contexts but give priority to Hyperbole

--- a/test/hsys-org-tests.el
+++ b/test/hsys-org-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    23-Apr-21 at 20:55:00
-;; Last-Mod:     16-Nov-24 at 00:14:35 by Mats Lidell
+;; Last-Mod:     16-Nov-24 at 09:45:51 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -266,7 +266,7 @@ This is independent of the setting of `hsys-org-enable-smart-keys'."
         (should (equal hsys-org-enable-smart-keys v)) ; Ert traceability
         (should (action-key))))
     ;;; Two lines
-    ;; Hyperbole context is active an smart scroll is triggered.
+    ;; Hyperbole context is active and smart scroll is triggered.
     (with-temp-buffer
       (org-mode)
       (insert "* h1\n* h2\n")

--- a/test/hsys-org-tests.el
+++ b/test/hsys-org-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    23-Apr-21 at 20:55:00
-;; Last-Mod:     31-Jul-24 at 01:46:48 by Bob Weiner
+;; Last-Mod:     16-Nov-24 at 00:14:35 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -224,6 +224,58 @@ This is independent of the setting of `hsys-org-enable-smart-keys'."
             (hsys-org-at-tags-p => t)
             (hsys-org--agenda-tags-string => ":tag"))
     (should (string= "agenda-func" (hsys-org-get-agenda-tags #'agenda-func)))))
+
+(ert-deftest hsys-org--meta-return-on-end-of-line ()
+  "Verify end-of-line behaves as `org-mode' when smart keys not enabled."
+  (dolist (v '(nil :buttons))
+    (let ((hsys-org-enable-smart-keys v))
+      ;;; One line no return
+      (with-temp-buffer
+        (org-mode)
+        (insert "* h1")
+        (goto-char 1)
+        (end-of-line)
+        (with-mock
+          (mock (hsys-org-meta-return) => t)
+          (should (equal hsys-org-enable-smart-keys v)) ; Ert traceability
+          (should (action-key))))
+      ;;; Two lines
+      (with-temp-buffer
+        (org-mode)
+        (insert "* h1\n* h2\n")
+        (goto-char 1)
+        (end-of-line)
+        (with-mock
+          (mock (hsys-org-meta-return) => t)
+          (should (equal hsys-org-enable-smart-keys v)) ; Ert traceability
+          (should (action-key))))))
+  (let ((hsys-org-enable-smart-keys t)
+        (v t))
+    ;;; One line no return
+    ;; At end of line is also end of file so smart-eolp filters out
+    ;; this as a Hyperbole context and org instead picks it
+    ;; up. Possibly a confusing behavior!? Should eof only be when
+    ;; action is below last visible line to avoid this case?
+    (with-temp-buffer
+      (org-mode)
+      (insert "* h1")
+      (goto-char 1)
+      (end-of-line)
+      (with-mock
+        (mock (hsys-org-meta-return) => t)
+        (should (equal hsys-org-enable-smart-keys v)) ; Ert traceability
+        (should (action-key))))
+    ;;; Two lines
+    ;; Hyperbole context is active an smart scroll is triggered.
+    (with-temp-buffer
+      (org-mode)
+      (insert "* h1\n* h2\n")
+      (goto-char 1)
+      (end-of-line)
+      (with-mock
+        (mock (smart-scroll-up) => t)
+        (should (equal hsys-org-enable-smart-keys v)) ; Ert traceability
+        (should (action-key))))))
 
 (provide 'hsys-org-tests)
 


### PR DESCRIPTION
# What

When Hyperbole context in org-mode should not be active, drop to later
handlers in hkey-alist i.e. possibly smart-org handler.

# Why

When we say that a nil value `hsys-org-enable-smart-keys` make M-RET
behave as it normally does is suggests that the smart-eol function
should not be active in org mode. Or!?

# Note

Issue comes from report in #603.
