### PR TITLE
Run Emacs as a make target for use with docker

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2024-11-17  Mats Lidell  <matsl@gnu.org>
+
+* Makefile (run-emacs): Run Emacs as a make target for use with docker.
+
 2024-11-16  Mats Lidell  <matsl@gnu.org>
 
 * test/hsys-org-tests.el (hsys-org--meta-return-on-end-of-line): Add test

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:     27-Oct-24 at 21:27:42 by Mats Lidell
+# Last-Mod:     17-Nov-24 at 00:02:09 by Mats Lidell
 #
 # Copyright (C) 1994-2023  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -628,6 +628,11 @@ docker-run: docker-update
 # Update the docker image for the specified version of Emacs
 docker-update:
 	docker pull silex/emacs:${DOCKER_VERSION}
+
+# Target for running emacs in the container with hyperbole loaded.
+# Example: make docker version=29.4 targets="clean bin run-emacs"
+run-emacs:
+	emacs --eval "(progn (add-to-list 'load-path \"/hyperbole\") (require 'hyperbole) (hyperbole-mode 1))"
 
 # Run with coverage. Run tests given by testspec and monitor the
 # coverage for the specified file.


### PR DESCRIPTION
# What

Run Emacs as a make target for use with docker.

# Why

Convenient to run make targets and then be able to start Emacs with
the result of that with hyperbole loaded and active.
