### PR TITLE
Update website for development version

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2024-11-24  Mats Lidell  <matsl@gnu.org>
+
+* Makefile (website-local-devel): Update the website files locally for
+    development version.
+    (website-devel): Push local updates to go live at
+    https:/www.gnu.org/software/hyperbole/devel.
+
 2024-11-23  Mats Lidell  <matsl@gnu.org>
 
 * Makefile (BATCHFLAGS): Use debug-on-error's default value nil. Emacs 31

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:     23-Nov-24 at 11:23:02 by Mats Lidell
+# Last-Mod:     24-Nov-24 at 22:28:43 by Mats Lidell
 #
 # Copyright (C) 1994-2023  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -177,7 +177,8 @@ pkg_hyperbole = $(pkg_parent)/hyperbole-$(HYPB_VERSION)
 ELISP_TO_COMPILE = $(pkg_parent)/elc-${USER}
 
 # Path to dir where the web repository is located i.e. hypb:web-repo-location
-HYPB_WEB_REPO_LOCATION = "../hyweb/hyperbole/"
+HYPB_WEB_REPO_LOCATION = ../hyweb/hyperbole/
+HYPB_WEB_REPO_LOCATION_DEVEL = $(HYPB_WEB_REPO_LOCATION)devel/
 
 # CI/CD Emacs versions for local docker based tests
 DOCKER_VERSIONS=27.2 28.2 29.4 master
@@ -420,11 +421,19 @@ README.md.html: README.md README.toc.md
 # website maintenance: "https://www.gnu.org/software/hyperbole/"
 # Locally update Hyperbole website
 website-local: README.md.html
-	$(EMACS_BATCH) --debug -l hypb-maintenance --eval '(let ((hypb:web-repo-location $(HYPB_WEB_REPO_LOCATION))) (hypb:web-repo-update))'
+	$(EMACS_BATCH) --debug -l hypb-maintenance --eval '(let ((hypb:web-repo-location "$(HYPB_WEB_REPO_LOCATION)")) (hypb:web-repo-update))'
 
 # Push to public Hyperbole website
 website: website-local
 	cd $(HYPB_WEB_REPO_LOCATION) && $(CVS) commit -m "Hyperbole release $(HYPB_VERSION)"
+	@echo "Website for Hyperbole $(HYPB_VERSION) is updated."
+
+# Locally update development website
+website-local-devel: README.md.html
+	$(EMACS_BATCH) --debug -l hypb-maintenance --eval '(let ((hypb:web-repo-location "$(HYPB_WEB_REPO_LOCATION_DEVEL)")) (hypb:web-repo-update))'
+
+website-devel: website-local-devel
+	cd $(HYPB_WEB_REPO_LOCATION_DEVEL) && $(CVS) commit -m "Hyperbole development update $(HYPB_VERSION)"
 	@echo "Website for Hyperbole $(HYPB_VERSION) is updated."
 
 # Generate a Hyperbole package suitable for distribution via the Emacs package manager.


### PR DESCRIPTION
# What

Update website for development version.

# Why

The development version requires docs too.

# Note

This is the first attempt to create a development version website
using a subfolder in the regular website. There can be issues we need
to address over time.

There is no index-file in the devel folder so the full path has to be
given for the default page.

[https://www.gnu.org/software/hyperbole/devel/hyperbole.html](https://www.gnu.org/software/hyperbole/devel/hyperbole.html)
    
Maybe something we want to fix!?

You need to do a cvs update before trying to update files.

We might want to put some guard against pushing changes. Like ask user
if we really want to publish or so.

Oh, and yes, the link above works since I have pushed the first version so it is live already. :laughing: 
