### PR TITLE
Use Github Pages for the manual

### DIFF
--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -1,0 +1,46 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["master"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Create index.html for the manual
+        run: |
+          ln -s hyperbole.html man/index.html
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Upload entire repository
+          path: 'man'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2024-11-25  Mats Lidell  <matsl@gnu.org>
+
+* .github/workflows/static.yaml: Static workflow for publishing the manual
+    to a static site using GitHub Pages.
+
 2024-11-24  Mats Lidell  <matsl@gnu.org>
 
 * Makefile (website-local-devel): Update the website files locally for


### PR DESCRIPTION
# What

Use Github Pages for the manual.

# Why

We want to publish the development version of the manual quickly.

# Note

Seems to work from my repo: [https://matsl.github.io/hyperbole/](https://matsl.github.io/hyperbole/)
