### PR TITLE
Changed to merge to master -- Rsw branch add hywiki tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,7 +2,8 @@
 
 * hywiki.el (hywiki-add-referent-hook): Add defvar for hywiki-add-referent-hook.
 
-* test/hywiki-tests.el (hywiki-tests--get-singular-wikiword)
+* test/hywiki-tests.el (hywiki-tests--sections-with-dash-space)
+   (hywiki-tests--get-singular-wikiword)
    (hywiki-tests--get-plural-wikiword, hywiki-tests--add-referent)
    (hywiki-tests--add-bookmark, hywiki-tests--add-command)
    (hywiki-tests--add-find, hywiki-tests--add-global-button)

--- a/ChangeLog
+++ b/ChangeLog
@@ -9,7 +9,7 @@
    (hywiki-tests--add-hyrolo, hywiki-tests--add-info-index)
    (hywiki-tests--add-info-node, hywiki-tests--add-key-series)
    (hywiki-tests--add-link, hywiki-tests--add-org-id)
-   (hywiki-tests--get-page-list-for-new-wiki-directory-after-added--referent):
+   (hywiki-tests--get-page-list-for-new-wiki-directory-after-added-referent):
    Tests.
 
 2024-12-16  Bob Weiner  <rsw@gnu.org>

--- a/ChangeLog
+++ b/ChangeLog
@@ -8,7 +8,9 @@
    (hywiki-tests--add-find, hywiki-tests--add-global-button)
    (hywiki-tests--add-hyrolo, hywiki-tests--add-info-index)
    (hywiki-tests--add-info-node, hywiki-tests--add-key-series)
-   (hywiki-tests--add-link, hywiki-test--add-org-id): Tests.
+   (hywiki-tests--add-link, hywiki-tests--add-org-id)
+   (hywiki-tests--get-page-list-for-new-wiki-directory-after-added--referent):
+   Tests.
 
 2024-12-16  Bob Weiner  <rsw@gnu.org>
 
@@ -107,7 +109,7 @@
 
 2024-11-25  Mats Lidell  <matsl@gnu.org>
 
-* kotl/kmenu.el (kotl-menu-common-body): Use kotl-kview. 
+* kotl/kmenu.el (kotl-menu-common-body): Use kotl-kview.
 
 * .github/workflows/static.yaml: Static workflow for publishing the manual
     to a static site using GitHub Pages.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+2024-12-16  Mats Lidell  <matsl@gnu.org>
+
+* hywiki.el (hywiki-add-referent-hook): Add defvar for hywiki-add-referent-hook.
+
+* test/hywiki-tests.el (hywiki-tests--get-singular-wikiword)
+   (hywiki-tests--get-plural-wikiword, hywiki-tests--add-referent)
+   (hywiki-tests--add-bookmark, hywiki-tests--add-command)
+   (hywiki-tests--add-find, hywiki-tests--add-global-button)
+   (hywiki-tests--add-hyrolo, hywiki-tests--add-info-index)
+   (hywiki-tests--add-info-node, hywiki-tests--add-key-series)
+   (hywiki-tests--add-link, hywiki-test--add-org-id): Tests.
+
 2024-12-16  Bob Weiner  <rsw@gnu.org>
 
 * test/hbut-tests.el: Change most "/tmp" to "/tmp/" for ease of comparison

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,5 @@
 2024-12-16  Mats Lidell  <matsl@gnu.org>
 
-* hywiki.el (hywiki-add-referent-hook): Add defvar for hywiki-add-referent-hook.
-
 * test/hywiki-tests.el (hywiki-tests--sections-with-dash-space)
    (hywiki-tests--get-singular-wikiword)
    (hywiki-tests--get-plural-wikiword, hywiki-tests--add-referent)

--- a/hywiki.el
+++ b/hywiki.el
@@ -446,8 +446,6 @@ Only argument is the page name concatenated with optional #section."
   :type 'boolean
   :group 'hyperbole-hywiki)
 
-(defvar hywiki-add-referent-hook nil)
-
 ;;; ************************************************************************
 ;;; hywiki minor mode
 ;;; ************************************************************************

--- a/hywiki.el
+++ b/hywiki.el
@@ -446,6 +446,8 @@ Only argument is the page name concatenated with optional #section."
   :type 'boolean
   :group 'hyperbole-hywiki)
 
+(defvar hywiki-add-referent-hook nil)
+
 ;;; ************************************************************************
 ;;; hywiki minor mode
 ;;; ************************************************************************

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -273,6 +273,22 @@ Both mod-time and checksum must be changed for a test to return true."
       (hy-delete-file-and-buffer wikipage)
       (hy-delete-dir-and-buffer hywiki-directory))))
 
+(ert-deftest hywiki-tests--get-page-list-for-new-wiki-directory-after-added--referent ()
+  "Verify `hywiki-get-page-list' is empty for new `hywiki-directory'."
+  (defvar hywiki-add-referent-hook)
+  (let ((hywiki-directory (make-temp-file "hywiki" t))
+        (hywiki-add-referent-hook 'test-func))
+    (unwind-protect
+        (progn
+          (mocklet (((test-func) => t))
+            (should (eq 'referent (hywiki-add-referent "WikiWord" 'referent))))
+          (should (= 1 (length (hywiki-get-page-list))))
+          (let ((hywiki-directory (make-temp-file "hywiki" t)))
+            (unwind-protect
+                (should (= 0 (length (hywiki-get-page-list))))
+              (hy-delete-dir-and-buffer hywiki-directory))))
+      (hy-delete-dir-and-buffer hywiki-directory))))
+
 ;; Following three test cases for verifying proper face is some what
 ;; experimental. They need to be run in interactive mode.
 

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -273,7 +273,7 @@ Both mod-time and checksum must be changed for a test to return true."
       (hy-delete-file-and-buffer wikipage)
       (hy-delete-dir-and-buffer hywiki-directory))))
 
-(ert-deftest hywiki-tests--get-page-list-for-new-wiki-directory-after-added--referent ()
+(ert-deftest hywiki-tests--get-page-list-for-new-wiki-directory-after-added-referent ()
   "Verify `hywiki-get-page-list' is empty for new `hywiki-directory'."
   (defvar hywiki-add-referent-hook)
   (let ((hywiki-directory (make-temp-file "hywiki" t))

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    18-May-24 at 23:59:48
-;; Last-Mod:     16-Dec-24 at 21:58:16 by Mats Lidell
+;; Last-Mod:     16-Dec-24 at 21:59:57 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -118,6 +118,31 @@
           (insert "-subsection")
           (goto-char 4)
           (should (string= "WikiWord#section-subsection" (hywiki-word-at))))
+      (hywiki-mode -1)
+      (hy-delete-dir-and-buffer hywiki-directory))))
+
+(ert-deftest hywiki-tests--sections-with-dash-space ()
+  "Verify `hywiki-word-at' finds sections with dash and space."
+  (let ((hywiki-directory (make-temp-file "hywiki" t)))
+    (unwind-protect
+        (progn
+          (with-temp-buffer
+            (hywiki-mode)
+            (insert "WikiWord#section rest is ignored")
+            (goto-char 4)
+            (should (string= "WikiWord#section" (hywiki-word-at))))
+
+          (with-temp-buffer
+            (hywiki-mode)
+            (insert "WikiWord#section-with-dash")
+            (goto-char 4)
+            (should (string= "WikiWord#section-with-dash" (hywiki-word-at))))
+
+          (with-temp-buffer
+            (hywiki-mode)
+            (insert "WikiWord#\"section-within-quotes\"")
+            (goto-char 4)
+            (should (string= "WikiWord#\"section-within-quotes\"" (hywiki-word-at)))))
       (hywiki-mode -1)
       (hy-delete-dir-and-buffer hywiki-directory))))
 

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -545,6 +545,7 @@ Note special meaning of `hywiki-allow-plurals-flag'."
 
 (ert-deftest hywiki-tests--add-referent ()
   "Verify `hywiki-add-referent'."
+  (defvar hywiki-add-referent-hook)
   (let ((hywiki-directory (make-temp-file "hywiki" t))
         (hywiki-add-referent-hook 'test-func))
     (unwind-protect
@@ -618,7 +619,7 @@ Note special meaning of `hywiki-allow-plurals-flag'."
   "Verify `hywiki-add-link'."
   (mocklet (((hactypes:link-to-file-interactively) => '("file" 20))
             ((hpath:file-position-to-line-and-column "file" 20) => "file:L2:C3")
-            ((hywiki-add-referent "WikiWord" "file:L1:C3") => 'path-referent))
+            ((hywiki-add-referent "WikiWord" "file:L2:C3") => 'path-referent))
     (should (equal 'path-referent (hywiki-add-link "WikiWord")))))
 
 (ert-deftest hywiki-test--add-org-id ()

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    18-May-24 at 23:59:48
-;; Last-Mod:     16-Dec-24 at 00:07:45 by Bob Weiner
+;; Last-Mod:     16-Dec-24 at 21:58:16 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -19,6 +19,7 @@
 
 (require 'ert)
 (require 'el-mock)
+(require 'with-simulated-input)
 (require 'hy-test-helpers)
 (require 'hywiki)
 (require 'ox-publish)
@@ -522,6 +523,140 @@ Both mod-time and checksum must be changed for a test to return true."
           (should (string= "NotAWikiPage" (hywiki-org-link-export "NotAWikiPage" "doc" 'ascii))))
       (hy-delete-file-and-buffer wikipage)
       (hy-delete-dir-and-buffer hywiki-directory))))
+
+(ert-deftest hywiki-tests--get-singular-wikiword ()
+  "Verify plural WikiWord is converted to singular.
+Note special meaning of `hywiki-allow-plurals-flag'."
+  (let ((hywiki-allow-plurals-flag t))
+    (should (string= "WikiWord" (hywiki-get-singular-wikiword "WikiWord")))
+    (should (string= "WikiWord" (hywiki-get-singular-wikiword "WikiWords"))))
+  (let ((hywiki-allow-plurals-flag nil))
+    (should (string= "WikiWord" (hywiki-get-singular-wikiword "WikiWord")))
+    (should (string= "WikiWords" (hywiki-get-singular-wikiword "WikiWords")))))
+
+(ert-deftest hywiki-tests--get-plural-wikiword ()
+  "Verify singular WikiWord is converted to plural."
+  ;; Note: Should not this also respect `hywiki-allow-plurals-flag' so
+  ;; this can be disabled completely?
+  (should (string= "WikiWords" (hywiki-get-plural-wikiword "WikiWord")))
+  (should (string= "Taxes" (hywiki-get-plural-wikiword "Tax")))
+  ;; Exceptions
+  (should (string= "Monarchs" (hywiki-get-plural-wikiword "Monarchs"))))
+
+(ert-deftest hywiki-tests--add-referent ()
+  "Verify `hywiki-add-referent'."
+  (let ((hywiki-directory (make-temp-file "hywiki" t))
+        (hywiki-add-referent-hook 'test-func))
+    (unwind-protect
+        (progn
+          (should-not (hywiki-add-referent "notawikiword" 'referent))
+          (mocklet (((test-func) => t))
+            (should (eq 'referent (hywiki-add-referent "WikiWord" 'referent))))
+          (should (eq 'referent (hywiki-get-referent "WikiWord"))))
+      (hy-delete-dir-and-buffer hywiki-directory))))
+
+;; hywiki-add-activity -- Requires activities
+
+(ert-deftest hywiki-tests--add-bookmark ()
+  "Verify `hywiki-add-bookmark'."
+  (let ((hywiki-directory (make-temp-file "hywiki" t)))
+    (unwind-protect
+        (progn
+          (mocklet ((bookmark-completing-read => ""))
+            (should-error (hywiki-add-bookmark "WikiWord"))))
+          (mocklet ((bookmark-completing-read => 'bkmark))
+            (should (equal '(bookmark-jump bkmark) (caddr (hywiki-add-bookmark "WikiWord")))))
+      (hy-delete-dir-and-buffer hywiki-directory))))
+
+(ert-deftest hywiki-tests--add-command ()
+  "Verify `hywiki-add-command'."
+  (mocklet ((hui:actype => 'command)
+            ((hywiki-add-referent "WikiWord" 'command) => 'command))
+    (should (eq 'command (hywiki-add-command "WikiWord")))))
+
+(ert-deftest hywiki-tests--add-find ()
+  "Verify `hywiki-add-find'."
+  (mocklet (((hywiki-add-referent "WikiWord" #'hywiki-word-grep) => 'word-grep))
+    (should (eq 'word-grep (hywiki-add-find "WikiWord")))))
+
+(ert-deftest hywiki-tests--add-global-button ()
+  "Verify `hywiki-add-global-button'."
+  (mocklet ((hargs:read-match => "gbtn")
+            ((hywiki-add-referent "WikiWord" '(gbut:act "gbtn")) => 'gbut-referent))
+    (should (equal 'gbut-referent (hywiki-add-global-button "WikiWord")))))
+
+(ert-deftest hywiki-tests--add-hyrolo ()
+  "Verify `hywiki-add-hyrolo'."
+  (mocklet (((hywiki-add-referent "WikiWord" '(hyrolo-fgrep "WikiWord")) => 'hyrolo-referent))
+    (should (equal 'hyrolo-referent (hywiki-add-hyrolo "WikiWord")))))
+
+(ert-deftest hywiki-tests--add-info-index ()
+  "Verify `hywiki-add-info-index'."
+  (mocklet (((info) => t)
+	    ((Info-read-index-item-name "Info index item: ") => "index-name")
+            ((Info-current-filename-sans-extension) => "info")
+            ((hywiki-add-referent "WikiWord" '(Info-goto-node "(info)index-name")) => 'info-referent))
+    (should (equal 'info-referent (hywiki-add-info-index "WikiWord")))))
+
+(ert-deftest hywiki-tests--add-info-node ()
+  "Verify `hywiki-add-info-node'."
+  (mocklet (((info) => t)
+	    ((Info-read-node-name "Info node: ") => "node-name")
+            ((Info-current-filename-sans-extension) => "info")
+            ((hywiki-add-referent "WikiWord" '(Info-goto-node "(info)node-name")) => 'info-referent))
+    (should (equal 'info-referent (hywiki-add-info-node "WikiWord")))))
+
+(ert-deftest hywiki-tests--add-key-series ()
+  "Verify `hywiki-add-key-series'."
+  (mocklet (((hywiki-add-referent "WikiWord" "{ABC}") => 'key-series-referent))
+    (with-simulated-input "ABC RET"
+      (should (equal 'key-series-referent (hywiki-add-key-series "WikiWord"))))
+    (with-simulated-input "{ABC} RET"
+      (should (equal 'key-series-referent (hywiki-add-key-series "WikiWord"))))))
+
+(ert-deftest hywiki-tests--add-link ()
+  "Verify `hywiki-add-link'."
+  (mocklet (((hactypes:link-to-file-interactively) => '("file" 20))
+            ((hpath:file-position-to-line-and-column "file" 20) => "file:L2:C3")
+            ((hywiki-add-referent "WikiWord" "file:L1:C3") => 'path-referent))
+    (should (equal 'path-referent (hywiki-add-link "WikiWord")))))
+
+(ert-deftest hywiki-test--add-org-id ()
+  "Verify `hywiki-add-org-id'."
+  ;; Error case - Non org-mode buffer
+  (let ((filea (make-temp-file "hypb" nil ".txt")))
+    (unwind-protect
+        (with-current-buffer (find-file filea)
+          (mocklet (((hmouse-choose-link-and-referent-windows) => (list nil (get-buffer-window))))
+            (let ((err (should-error (hywiki-add-org-id "WikiWord") :type 'error)))
+              (should (string=
+                       (format "(hywiki-add-org-id): Referent buffer <%s> must be in org-mode, not %s" (buffer-name) major-mode)
+                       (cadr err))))))
+      (hy-delete-file-and-buffer filea)))
+
+  (let ((filea (make-temp-file "hypb" nil ".org")))
+    (unwind-protect
+        (with-current-buffer (find-file filea)
+          (insert "* header\n")
+
+          ;; Error-case - No Org ID and read only
+          (setq buffer-read-only t)
+          (mocklet (((hmouse-choose-link-and-referent-windows) => (list nil (get-buffer-window))))
+            (let ((err (should-error (hywiki-add-org-id "WikiWord") :type 'error)))
+              (should (string=
+                       (format "(hywiki-add-org-id): Referent buffer <%s> point has no Org ID and buffer is read-only" (buffer-name))
+                       (cadr err))))
+
+            ;; Normal case - Org-mode with Org ID
+            (goto-char (point-max))
+            (setq buffer-read-only nil)
+            (defvar hywiki-test--org-id)
+            (let ((hywiki-test--org-id (org-id-get-create)))
+              (mocklet (((hywiki-add-referent "WikiWord" (concat "ID: " hywiki-test--org-id)) => 'org-id-referent))
+                (should (equal 'org-id-referent (hywiki-add-org-id "WikiWord")))))))
+      (hy-delete-file-and-buffer filea))))
+
+;; hywiki-add-org-roam-node -- Requires org-roam
 
 (provide 'hywiki-tests)
 ;;; hywiki-tests.el ends here

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -622,7 +622,7 @@ Note special meaning of `hywiki-allow-plurals-flag'."
             ((hywiki-add-referent "WikiWord" "file:L2:C3") => 'path-referent))
     (should (equal 'path-referent (hywiki-add-link "WikiWord")))))
 
-(ert-deftest hywiki-test--add-org-id ()
+(ert-deftest hywiki-tests--add-org-id ()
   "Verify `hywiki-add-org-id'."
   ;; Error case - Non org-mode buffer
   (let ((filea (make-temp-file "hypb" nil ".txt")))


### PR DESCRIPTION
# What

Add hywiki tests.

# Note

Problem with ` hywiki--pages-hasht` still containing referent "pages" after switching to a new wiki-directory remains causing a few test cases to fail.
