### PR TITLE
Showing problems with handling sections.

### DIFF
--- a/hywiki.el
+++ b/hywiki.el
@@ -614,8 +614,10 @@ an existing or new HyWikiWord."
       (call-interactively hywiki-display-page-function)
     (when (null wikiword)
       (setq wikiword (hywiki-word-read-new "Find HyWiki page: ")))
-    (let ((referent (hywiki-get-file wikiword)))
-      (funcall hywiki-display-page-function referent)
+    (let ((referent (hywiki-get-file wikiword))
+          (section (when (string-match "#[^#]+$" wikiword)
+                     (substring wikiword (match-beginning 0)))))
+      (funcall hywiki-display-page-function (concat referent section))
       ;; Set 'referent attribute of current implicit button
       (hattr:set 'hbut:current 'referent referent)
       referent)))
@@ -639,10 +641,11 @@ After successfully finding a page and reading it into a buffer, run
 	    (unless buffer-file-name
 	      (error "(hywiki-display-referent): No `wikiword' given; buffer must have an attached file"))
 	    (setq wikiword (file-name-sans-extension (file-name-nondirectory buffer-file-name))))
-	  (when (string-match "#[^#]+$" wikiword)
-	    (setq wikiword (substring wikiword 0 (match-beginning 0))))
 	  (let* ((section (when (string-match "#[^#]+$" wikiword)
 			    (substring wikiword (match-beginning 0))))
+                 (wikiword (if (string-match "#[^#]+$" wikiword)
+	                       (substring wikiword 0 (match-beginning 0))
+                             wikiword))
 		 (referent (cond (prompt-flag
 				  (hywiki-add-prompted-referent wikiword))
 				 ((hywiki-get-referent wikiword))


### PR DESCRIPTION
# What

Showing problems with handling of sections.

# Why

I have started to look at writing tests for WikiWords with sections
and found that the movement to sections is broken. So before writing
tests I tried to understand what was the issue. 

Two problematic parts were found and they are described in this PR. I
want to share it with you before hacking away on the tests.

# Note

Observations:
 - Maybe the code can be refactored so that there is less need to string-match possible section part. Like early noticing this and pass the wikiword and section as a tuple?
 - The parameter name wikiword is less ideal when it also can contain sections. Maybe another parameter name can be used for those functions?
