### PR TITLE
hywiki.el - Rewrite to standardize all referents to (type . value)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,9 @@
     in Hyperbole.
             (hash-deep-copy): Add deep copy of cons cells.
 
+* hbut.el (ibut:create): When debug on error, display *Messages* buffer
+    with error message.
+
 2024-12-22  Bob Weiner  <rsw@gnu.org>
 
 * test/hywiki-tests.el (hywiki-tests--add-org-id): Fix so :type

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+* test/hy-test-dependencies.el (load "pcomplete"): Only on rsw's linux
+    system, load this library to eliminate cyclic dependency errors in
+    11 tests.
+
 2024-12-22  Bob Weiner  <rsw@gnu.org>
 
 * test/hywiki-tests.el (hywiki-tests--add-org-id): Fix so :type

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,15 @@
     system, load this library to eliminate cyclic dependency errors in
     11 tests.
 
+* hasht.el: Rewrite to use Emacs built-in hash tables while keeping the
+    same calling interace as before.
+            (hash-map): Fix bug where 'func' was not quoted when embedded
+    within lambda function.
+            (hash-resize, hash-resize-p, hash-next-prime, hash-obarray,
+             hash-prime-p): Remove, no longer needed nor used
+    in Hyperbole.
+            (hash-deep-copy): Add deep copy of cons cells.
+
 2024-12-22  Bob Weiner  <rsw@gnu.org>
 
 * test/hywiki-tests.el (hywiki-tests--add-org-id): Fix so :type

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2024-12-26  Bob Weiner  <rsw@gnu.org>
+
+* hywiki.el (hywiki-add-path-link): Add optional FILE and POS arguments
+    to better evaluate intermittent test bug in 'hywiki-tests--add-path-link'.
+    It fails on a call to this function only when all tests are run; never
+    fails interactively.
+
 * test/hy-test-dependencies.el (load "pcomplete"): Only on rsw's linux
     system, load this library to eliminate cyclic dependency errors in
     11 tests.
@@ -14,8 +21,74 @@
 * hbut.el (ibut:create): When debug on error, display *Messages* buffer
     with error message.
 
+* hywiki.el (hywiki-make-referent-hasht): Optimize when no non-page
+    entries.
+
+* hywiki.el (hywiki-add-page): Return '(page . "<page-file-path>")
+    rather than just "<page-file-path>".  Update doc string.
+            (hywiki-add-to-referent): Update doc string.
+	    (hywiki-display-referent): Remove unneeded clauses
+    due to new typed referents.  Update doc string.
+            (hywiki-find-referent): Update doc string.
+            (hywiki-display-referent-type): Update doc string with
+    computed display function name.
+	    (hywiki-get-referent): Rewrite to handled typed referents.
+            (hywiki-display-page): Fix to allow both typed referents
+    and file-name alone as referent input.
+            (hywiki-add-referent): Trigger error if 'hash-add' call fails
+    and fix doc string to cover all return values.
+            (hywiki-validate-referent): Add to validate referents before
+    adding to the HyWiki hash table.  Use in 'hywiki-add-referent'.
+
+2024-12-25  Bob Weiner  <rsw@gnu.org>
+
+* hywiki.el (hywiki-org-link-resolve): Fix doc to include all possible
+    return value types and rewrite to new typed referents.
+
+2024-12-24  Bob Weiner  <rsw@gnu.org>
+
+* hywiki.el: Rename all 'page(s)-hasht' to 'referent-hasht'.
+             (hywiki-non-page-elts): Rewrite to new typed
+    referents and inline the function.
+             Rename 'hywiki--any-page-regexp-list' to
+    'hywiki--any-wikiword-regexp-list'.
+             Rename 'hywiki-maybe-highlight-page-names-in-frame'
+    to 'hywiki-maybe-highlight-wikiwords-in-frame'.
+             Rename 'hywiki-get-page-list' to 'hywiki-get-wikiword-list'.
+
+2024-12-23  Bob Weiner  <rsw@gnu.org>
+
+* test/hywiki-tests.el (hywiki-tests--add-*): Rewrite to handle typed
+    referents.
+
+* hywiki.el (hywiki-add-link): Rename to 'hywiki-add-path-link'.
+            (hywiki-add-page): Document optional 'force-flag' arg.
+	    (hywiki-add-page-and-display): Improve doc on prompting
+    for a referent type.
+            (hywiki-add-page-and-display): Rename to
+    'hywiki-create-page-and-display'.
+            (hywiki-referent-prompt-flag): Add this new customization.
+            (hywiki-create-page-and-display): Set prompt-flag t if
+    call-interactively and 'hywiki-referent-prompt-flag' is non-nil.
+            (hywiki-display-referent-type): Add to display referents
+    other than pages.
+            (hywiki-display-referent): Call above function.
+	    (hywiki-add-*): Rewrite all referent add functions to just
+    store the referent value and add hywiki-display-* functions to perform
+    the referent display instead.  This allows for easy addition of new
+    referent types.
+            (hywiki-display-page-function): Fix doc to say function takes
+    a pathname, not a HyWiki page name.
+            (hywiki-create-page): Add type to hash value so is a cons of
+    (page . <page-file-path>).
+
 2024-12-22  Bob Weiner  <rsw@gnu.org>
 
+* hywiki.el (hywiki-find-referent): Fix doc string to describe how
+    a prefix arg prompts for the type of referent to link to.
+            (hywiki-add-prompted-referent, hywiki-referent-menu):
+    Set 'hkey-value' to wikiword to pass to expressions in this menu,
+    invoked via the Smart Keys.
 * test/hywiki-tests.el (hywiki-tests--add-org-id): Fix so :type
     argument is a list as required, not a symbol.
 

--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:     15-Dec-24 at 22:35:20 by Bob Weiner
+;; Last-Mod:     26-Dec-24 at 13:22:18 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -2006,6 +2006,7 @@ If a new button is created, store its attributes in the symbol,
 			   (when (condition-case err
 				     (and itype (setq args (funcall itype)))
 				   (error (progn (message "%S: %S" itype err)
+						 (switch-to-buffer "*Messages*")
 						 ;; Show full stack trace
 						 (debug))))
 			     (setq is-type itype)

--- a/hui-menu.el
+++ b/hui-menu.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    28-Oct-94 at 10:59:44
-;; Last-Mod:     24-Nov-24 at 16:38:36 by Bob Weiner
+;; Last-Mod:     23-Dec-24 at 14:18:08 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -307,7 +307,7 @@ Return t if cutoff, else nil."
 	 ["Manual"               (id-info "(hyperbole)HyWiki") t]
 	 "----"
 	 ["Activate-HyWiki-Word" hywiki-word-activate t]
-	 ["Create-HyWiki-Page"   hywiki-add-page-and-display t]
+	 ["Create-HyWiki-Page"   hywiki-create-page-and-display t]
 	 ["Edit-HyWiki-Pages"    hywiki-directory-edit t]
 	 ["Find-HyWiki-Referent" hywiki-find-referent t]
 	 (when (fboundp 'consult-grep) ;; allow for autoloading

--- a/hui-mini.el
+++ b/hui-mini.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Oct-91 at 20:13:17
-;; Last-Mod:     15-Dec-24 at 22:43:50 by Bob Weiner
+;; Last-Mod:     23-Dec-24 at 14:18:06 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1030,7 +1030,7 @@ support underlined faces as well."
 	 '("HyWiki>")
 	 '("Act"            hywiki-word-activate
 	   "Activate HyWikiWord link at point or emulate a press of a Smart Key.")
-	 '("Create"         hywiki-add-page-and-display
+	 '("Create"         hywiki-create-page-and-display
 	    "Create and display a new HyWiki page.  Shows existing page names to aid in new naming.")
 	 '("EditPages"      hywiki-directory-edit
 	   "Display and edit HyWiki directory.")
@@ -1043,7 +1043,7 @@ support underlined faces as well."
 	   "Report on a HyWikiWord's attributes.")
 	 '("Info"           (id-info "(hyperbole)HyWiki")
 	   "Display Hyperbole manual section on HyWiki.")
-	 '("Link"           hywiki-add-link
+	 '("Link"           hywiki-add-path-link
 	   "Prompt for and add a HyWikiWord that links to a path and possible position.")
          '("ModeToggle"     hywiki-mode
 	   "Toggle whether HyWikiWords are highlighted and active in buffers outside of the HyWiki page directory.")

--- a/test/hy-test-dependencies.el
+++ b/test/hy-test-dependencies.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    20-Feb-21 at 23:16:00
-;; Last-Mod:     10-Mar-24 at 20:56:45 by Bob Weiner
+;; Last-Mod:     26-Dec-24 at 22:40:40 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -24,6 +24,10 @@
 (require 'hload-path)
 (require 'hyperbole)
 (add-to-list 'load-path (expand-file-name "test" hyperb:dir))
+(when (equal (system-name) "norlinux")
+  ;; Next load line resolves a cyclic dependency issue that breaks 11 tests
+  ;; on rsw's linux system; please leave it here.
+  (load "pcomplete"))
 
 (defun hy-test-ensure-package-installed (pkg-symbol)
   (unless (package-installed-p pkg-symbol)

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    18-May-24 at 23:59:48
-;; Last-Mod:     22-Dec-24 at 16:22:44 by Bob Weiner
+;; Last-Mod:     26-Dec-24 at 22:49:26 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -24,7 +24,7 @@
 (require 'hywiki)
 (require 'ox-publish)
 
-(ert-deftest hywiki-tests--hywiki-add-page--adds-file-in-wiki-folder ()
+(ert-deftest hywiki-tests--hywiki-create-page--adds-file-in-wiki-folder ()
   "Verify add page creates file in wiki folder and sets hash table."
   (let* ((hsys-org-enable-smart-keys t)
          (hywiki-directory (make-temp-file "hywiki" t))
@@ -32,16 +32,16 @@
     (unwind-protect
 	(progn
           (should (string= hywiki-page-file
-                           (hywiki-add-page "WikiWord")))
+                           (cdr (hywiki-add-page "WikiWord"))))
           ;; Verify hash table is updated
           (with-mock
-            (not-called hywiki-add-page)
-            (should (string= hywiki-page-file
-                             (hywiki-get-referent "WikiWord")))))
+            (not-called hywiki-create-page)
+            (should (string= (file-name-nondirectory hywiki-page-file)
+			     (cdr (hywiki-get-referent "WikiWord"))))))
       (hy-delete-file-and-buffer hywiki-page-file)
       (hy-delete-dir-and-buffer hywiki-directory))))
 
-(ert-deftest hywiki-tests--hywiki-add-page--adds-no-wiki-word-fails ()
+(ert-deftest hywiki-tests--hywiki-create-page--adds-no-wiki-word-fails ()
   "Verify add page requires a WikiWord."
   ;; Should not leave erroneously created file after test but leaving
   ;; added error cleanup till later if it is even needed!? No file
@@ -49,27 +49,25 @@
   ;; considered an error case that is.)
   (let ((hywiki-directory (make-temp-file "hywiki" t)))
     (unwind-protect
-        (should-not (hywiki-add-page "notawikiword"))
+        (should-not (cdr (hywiki-add-page "notawikiword")))
       (hy-delete-dir-and-buffer hywiki-directory))))
 
 (ert-deftest hywiki-tests--action-key-on-wikiword-displays-page ()
   "Verify `action-key' on a prefixed WikiWord, outside of hywiki-directory, creates a new page."
-  (defvar wikifile)
   (let ((hsys-org-enable-smart-keys t)
         (hywiki-directory (make-temp-file "hywiki" t))
-        (wikifile (make-temp-file "wikifile" nil ".org")))
+        (wikifile "WikiWord.org"))
     (unwind-protect
         (with-temp-buffer
 	  (hywiki-mode 1)
           (insert "[[hy:WikiWord]]")
           (goto-char 4)
-          (mocklet (((hywiki-display-referent "WikiWord" nil) => wikifile))
-            (action-key)))
+          (action-key)
+	  (should (equal (cons 'page wikifile) (hywiki-get-referent "WikiWord"))))
       (hy-delete-file-and-buffer wikifile))))
 
 (ert-deftest hywiki-tests--assist-key-on-wikiword-displays-help ()
   "Verify `assist-key' on a prefixed WikiWord, outside of hywiki-directory, displays help for the WikiWord link."
-  (defvar wikifile)
   (let ((hsys-org-enable-smart-keys t)
         (hywiki-directory (make-temp-file "hywiki" t))
         (wikifile (make-temp-file "wikifile" nil ".org")))
@@ -170,7 +168,7 @@
 (ert-deftest hywiki-tests--in-page-p ()
   "Verify `hywiki-in-page-p' identifies a page in and outside of the wiki directory."
   (let* ((hywiki-directory (make-temp-file "hywiki" t))
-         (wiki-page (hywiki-add-page "WikiWord"))
+         (wiki-page (cdr (hywiki-add-page "WikiWord")))
          (no-wiki-page (make-temp-file "hypb")))
     (unwind-protect
         (progn
@@ -184,7 +182,7 @@
 (ert-deftest hywiki-tests--active-in-current-buffer-p ()
   "Verify `hywiki-active-in-current-buffer-p'."
   (let* ((hywiki-directory (make-temp-file "hywiki" t))
-         (wiki-page (hywiki-add-page "WikiWord"))
+         (wiki-page (cdr (hywiki-add-page "WikiWord")))
          (hywiki-word-highlight-flag t))
     (unwind-protect
         (with-current-buffer (find-file-noselect wiki-page)
@@ -241,76 +239,78 @@ Both mod-time and checksum must be changed for a test to return true."
       (should (hywiki-directory-modified-p)))))
 
 (ert-deftest hywiki-tests--get-page-list ()
-  "Verify `hywiki-get-page-list' returns one WikiWord."
+  "Verify `hywiki-get-wikiword-list' returns one WikiWord."
   (let* ((hywiki-directory (make-temp-file "hywiki" t))
-         (wiki-page (hywiki-add-page "WikiWord")))
+         (wiki-page (cdr (hywiki-add-page "WikiWord"))))
     (unwind-protect
         (progn
-          (should (equal '("WikiWord") (hywiki-get-page-list)))
-          (should (equal wiki-page (hywiki-add-page "WikiWord")))
-          (should (equal '("WikiWord") (hywiki-get-page-list))))
+          (should (equal '("WikiWord") (hywiki-get-wikiword-list)))
+          (should (equal wiki-page (cdr (hywiki-add-page "WikiWord"))))
+          (should (equal '("WikiWord") (hywiki-get-wikiword-list))))
       (hy-delete-file-and-buffer wiki-page)
       (hy-delete-dir-and-buffer hywiki-directory))))
 
 (ert-deftest hywiki-tests--get-page-list-after-add-and-delete ()
-  "Verify `hywiki-get-page-list' is updated when a page is added and removed."
+  "Verify `hywiki-get-wikiword-list' is updated when a page is added and removed."
   (let* ((hywiki-directory (make-temp-file "hywiki" t))
-         (wiki-page (hywiki-add-page "WordOne")))
+         (wiki-page (cdr (hywiki-add-page "WordOne"))))
     (unwind-protect
-        (let ((wiki-page2 (hywiki-add-page "WordTwo")))
+        (let ((wiki-page2 (cdr (hywiki-add-page "WordTwo"))))
 	  (unwind-protect
               (should (set:equal '("WordOne" "WordTwo")
-				 (hywiki-get-page-list)))
+				 (hywiki-get-wikiword-list)))
 	    ;; This delay is necessary or the test can fail sporadically
 	    (sit-for 0.01)
             (hy-delete-file-and-buffer wiki-page2))
-	  (should (set:equal '("WordOne") (hywiki-get-page-list))))
+	  (should (set:equal '("WordOne") (hywiki-get-wikiword-list))))
       (hy-delete-file-and-buffer wiki-page)
       (hy-delete-dir-and-buffer hywiki-directory))))
 
 (ert-deftest hywiki-tests--get-page-list-multiple-words ()
-  "Verify `hywiki-get-page-list' returns multiple WikiWords."
+  "Verify `hywiki-get-wikiword-list' returns multiple WikiWords."
   (let* ((hywiki-directory (make-temp-file "hywiki" t))
          (basename "WikiWord")
          (wiki-page-list nil))
     (unwind-protect
         (progn
           (dolist (char '("A" "B" "C" "D" "E" "F" "G" "H" "I" "J"))
-            (push (hywiki-add-page (format "%s%s" basename char)) wiki-page-list))
+            (push (cdr (hywiki-add-page (format "%s%s" basename char)))
+		  wiki-page-list))
           (should (= 10 (length wiki-page-list)))
-          (should (= 10 (length (hywiki-get-page-list))))
-          (should (= 10 (length (seq-uniq (hywiki-get-page-list))))))
+          (should (= 10 (length (hywiki-get-wikiword-list))))
+          (should (= 10 (length (seq-uniq (hywiki-get-wikiword-list))))))
       (hy-delete-files-and-buffers wiki-page-list)
       (hy-delete-dir-and-buffer hywiki-directory))))
 
 (ert-deftest hywiki-tests--get-page-list-when-new-wiki-directory ()
-  "Verify `hywiki-get-page-list' is empty for new `hywiki-directory'."
+  "Verify `hywiki-get-wikiword-list' is empty for new `hywiki-directory'."
   (let* ((hywiki-directory (make-temp-file "hywiki" t))
-         (wikipage (hywiki-add-page "WikiWord")))
+         (wikipage (cdr (hywiki-add-page "WikiWord"))))
     (unwind-protect
         (progn
-          (should (= 1 (length (hywiki-get-page-list))))
+          (should (= 1 (length (hywiki-get-wikiword-list))))
           (let ((hywiki-directory (make-temp-file "hywiki" t)))
             (unwind-protect
                 (progn
-                  (should (= 0 (length (hywiki-get-page-list)))))
+                  (should (= 0 (length (hywiki-get-wikiword-list)))))
               (hy-delete-dir-and-buffer hywiki-directory))))
       (hy-delete-file-and-buffer wikipage)
       (hy-delete-dir-and-buffer hywiki-directory))))
 
 (ert-deftest hywiki-tests--get-page-list-for-new-wiki-directory-after-added-referent ()
-  "Verify `hywiki-get-page-list' is empty for new `hywiki-directory'."
+  "Verify `hywiki-get-wikiword-list' is empty for new `hywiki-directory'."
   (defvar hywiki-add-referent-hook)
   (let ((hywiki-directory (make-temp-file "hywiki" t))
+	(referent '(page . "/tmp/a.org"))
         (hywiki-add-referent-hook 'test-func))
     (unwind-protect
         (progn
           (mocklet (((test-func) => t))
-            (should (eq 'referent (hywiki-add-referent "WikiWord" 'referent))))
-          (should (= 1 (length (hywiki-get-page-list))))
+            (should (equal referent (hywiki-add-referent "WikiWord" referent))))
+          (should (= 1 (length (hywiki-get-wikiword-list))))
           (let ((hywiki-directory (make-temp-file "hywiki" t)))
             (unwind-protect
-                (should (= 0 (length (hywiki-get-page-list))))
+                (should (zerop (length (hywiki-get-wikiword-list))))
               (hy-delete-dir-and-buffer hywiki-directory))))
       (hy-delete-dir-and-buffer hywiki-directory))))
 
@@ -323,7 +323,7 @@ Both mod-time and checksum must be changed for a test to return true."
   (add-hook 'post-command-hook     'hywiki-buttonize-non-character-commands 95)
   (add-hook 'post-self-insert-hook 'hywiki-buttonize-character-commands)
   (add-hook 'window-buffer-change-functions
-	    'hywiki-maybe-highlight-page-names-in-frame)
+	    'hywiki-maybe-highlight-wikiwords-in-frame)
   (add-to-list 'yank-handled-properties
 	       '(hywiki-word-face . hywiki-highlight-on-yank)))
 
@@ -333,7 +333,7 @@ Both mod-time and checksum must be changed for a test to return true."
   (remove-hook 'post-command-hook     'hywiki-buttonize-non-character-commands)
   (remove-hook 'post-self-insert-hook 'hywiki-buttonize-character-commands)
   (remove-hook 'window-buffer-change-functions
-	       'hywiki-maybe-highlight-page-names-in-frame)
+	       'hywiki-maybe-highlight-wikiwords-in-frame)
   (setq yank-handled-properties
 	(delete '(hywiki-word-face . hywiki-highlight-on-yank)
 		yank-handled-properties)))
@@ -360,7 +360,7 @@ Both mod-time and checksum must be changed for a test to return true."
   (skip-unless (not noninteractive))
   (let* ((hsys-org-enable-smart-keys t)
          (hywiki-directory (make-temp-file "hywiki" t))
-         (wikipage (hywiki-add-page "WikiWord")))
+         (wikipage (cdr (hywiki-add-page "WikiWord"))))
     (unwind-protect
         (progn
           (hywiki-tests--remove-hywiki-hooks)
@@ -403,7 +403,7 @@ Both mod-time and checksum must be changed for a test to return true."
   "Verify face property changes when WikiWord is edited."
   (skip-unless (not noninteractive))
   (let* ((hywiki-directory (make-temp-file "hywiki" t))
-         (wikipage (hywiki-add-page "WikiWord")))
+         (wikipage (cdr (hywiki-add-page "WikiWord"))))
     (unwind-protect
         (progn
           (hywiki-tests--remove-hywiki-hooks)
@@ -430,7 +430,7 @@ Both mod-time and checksum must be changed for a test to return true."
 (ert-deftest hywiki-tests--verify-face-property-when-editing-wikiword-first-char ()
   "Verify face property changes when WikiWord is edited in the first char position."
   (let* ((hywiki-directory (make-temp-file "hywiki" t))
-         (wikipage (hywiki-add-page "WikiWord")))
+         (wikipage (cdr (hywiki-add-page "WikiWord"))))
     (skip-unless (not noninteractive))
     (unwind-protect
         (progn
@@ -460,7 +460,7 @@ Both mod-time and checksum must be changed for a test to return true."
   "Verify `hywiki-convert-words-to-org-links' converts WikiWords to org links."
   (skip-unless (not noninteractive))
   (let* ((hywiki-directory (make-temp-file "hywiki" t))
-         (wikipage (hywiki-add-page "WikiWord")))
+         (wikipage (cdr (hywiki-add-page "WikiWord"))))
     (unwind-protect
         (progn
           (hywiki-tests--remove-hywiki-hooks)
@@ -526,40 +526,43 @@ Both mod-time and checksum must be changed for a test to return true."
   (should-not (hywiki-org-link-resolve 88)) ; Number
   (should-not (hywiki-org-link-resolve '("string"))) ; List
   (let* ((hywiki-directory (make-temp-file "hywiki" t))
-         (wikipage (hywiki-add-page "WikiWord")))
+         (wikipage (cdr (hywiki-add-page "WikiWord")))
+	 (filename (when wikipage (file-name-nondirectory wikipage))))
     (unwind-protect
         (progn
           (should-not (hywiki-org-link-resolve "NoWikiWord"))
-          (should (string= wikipage (hywiki-org-link-resolve "WikiWord")))
-          (should (string= wikipage (hywiki-org-link-resolve "hy:WikiWord")))
-          (should (string= (concat wikipage "::section") (hywiki-org-link-resolve "WikiWord#section"))))
+          (should (when filename (string= filename (hywiki-org-link-resolve "WikiWord"))))
+          (should (when filename (string= filename (hywiki-org-link-resolve "hy:WikiWord"))))
+          (should (when filename (string= (concat filename "::section")
+					  (hywiki-org-link-resolve "WikiWord#section")))))
       (hy-delete-file-and-buffer wikipage)
       (hy-delete-dir-and-buffer hywiki-directory))))
 
 (ert-deftest hywiki-tests--org-link-export ()
   "Verify `hywiki-org-link-export' output for different formats."
   (let* ((hywiki-directory (make-temp-file "hywiki" t))
-         (wikipage (hywiki-add-page "WikiWord")))
+         (wikipage (cdr (hywiki-add-page "WikiWord")))
+	 (filename (when wikipage (file-name-nondirectory wikipage))))
     (unwind-protect
         (progn
           (should (string-match-p
-                   (format "\\[hy\\] <doc:.*%s>" wikipage)
+                   (format "\\[hy\\] <doc:.*%s>" filename)
                    (hywiki-org-link-export "WikiWord" "doc" 'ascii)))
           (should (string-match-p
                    (format "<a href=\".*%s\">doc</a>"
-                           (replace-regexp-in-string "\\.org" ".html" wikipage))
+                           (replace-regexp-in-string "\\.org" ".html" filename))
                    (hywiki-org-link-export "WikiWord" "doc" 'html)))
           (should (string-match-p
-                   (format "\\[doc\\](.*%s)" wikipage)
+                   (format "\\[doc\\](.*%s)" filename)
                    (hywiki-org-link-export "WikiWord" "doc" 'md)))
           (should (string-match-p
-                   (format "\\href{.*%s}{doc}" wikipage)
+                   (format "\\href{.*%s}{doc}" filename)
                    (hywiki-org-link-export "WikiWord" "doc" 'latex)))
           (should (string-match-p
-                   (format "@uref{.*%s,doc}" wikipage)
+                   (format "@uref{.*%s,doc}" filename)
                    (hywiki-org-link-export "WikiWord" "doc" 'texinfo)))
           (should (string-match-p
-                   (format ".*%s" wikipage)
+                   (format ".*%s" filename)
                    (hywiki-org-link-export "WikiWord" "doc" 'unknown)))
           (should (string= "NotAWikiPage" (hywiki-org-link-export "NotAWikiPage" "doc" 'ascii))))
       (hy-delete-file-and-buffer wikipage)
@@ -587,14 +590,14 @@ Note special meaning of `hywiki-allow-plurals-flag'."
 (ert-deftest hywiki-tests--add-referent ()
   "Verify `hywiki-add-referent'."
   (defvar hywiki-add-referent-hook)
-  (let ((hywiki-directory (make-temp-file "hywiki" t))
-        (hywiki-add-referent-hook 'test-func))
+  (let* ((hywiki-directory (make-temp-file "hywiki" t))
+	 (file "/tmp/a.org")
+	 (referent (cons 'page file)))
     (unwind-protect
         (progn
-          (should-not (hywiki-add-referent "notawikiword" 'referent))
-          (mocklet (((test-func) => t))
-            (should (eq 'referent (hywiki-add-referent "WikiWord" 'referent))))
-          (should (eq 'referent (hywiki-get-referent "WikiWord"))))
+          (should-not (hywiki-add-referent "notawikiword" referent))
+          (should (hywiki-add-referent "WikiWord" referent))
+          (should (equal referent (hywiki-get-referent "WikiWord"))))
       (hy-delete-dir-and-buffer hywiki-directory))))
 
 ;; hywiki-add-activity -- Requires activities
@@ -605,63 +608,90 @@ Note special meaning of `hywiki-allow-plurals-flag'."
     (unwind-protect
         (progn
           (mocklet ((bookmark-completing-read => ""))
-            (should-error (hywiki-add-bookmark "WikiWord"))))
-          (mocklet ((bookmark-completing-read => 'bkmark))
-            (should (equal '(bookmark-jump bkmark) (caddr (hywiki-add-bookmark "WikiWord")))))
+            (should-error (hywiki-add-bookmark "WikiWord")))
+          (mocklet ((bookmark-completing-read => "bkmark"))
+            (should (equal '(bookmark . "bkmark") (hywiki-add-bookmark "WikiWord")))))
       (hy-delete-dir-and-buffer hywiki-directory))))
 
 (ert-deftest hywiki-tests--add-command ()
   "Verify `hywiki-add-command'."
-  (mocklet ((hui:actype => 'command)
-            ((hywiki-add-referent "WikiWord" 'command) => 'command))
-    (should (eq 'command (hywiki-add-command "WikiWord")))))
+  (let ((hywiki-directory (make-temp-file "hywiki" t))
+	(wikiword "WikiWord"))
+    (unwind-protect
+	(mocklet ((hui:actype => 'hpath:find))
+	  (hywiki-add-command wikiword)
+	  (should (equal '(command . hpath:find)
+			 (hywiki-get-referent wikiword))))
+      (hy-delete-dir-and-buffer hywiki-directory))))
 
 (ert-deftest hywiki-tests--add-find ()
   "Verify `hywiki-add-find'."
-  (mocklet (((hywiki-add-referent "WikiWord" #'hywiki-word-grep) => 'word-grep))
-    (should (eq 'word-grep (hywiki-add-find "WikiWord")))))
+  (let* ((wikiword "WikiWord")
+	 (referent '(find . hywiki-word-grep)))
+    (hywiki-add-find wikiword)
+    (should (equal referent (hywiki-get-referent wikiword)))))
 
 (ert-deftest hywiki-tests--add-global-button ()
   "Verify `hywiki-add-global-button'."
-  (mocklet ((hargs:read-match => "gbtn")
-            ((hywiki-add-referent "WikiWord" '(gbut:act "gbtn")) => 'gbut-referent))
-    (should (equal 'gbut-referent (hywiki-add-global-button "WikiWord")))))
+  (let ((hywiki-directory (make-temp-file "hywiki" t)))
+    (unwind-protect
+	(mocklet ((hargs:read-match => "gbtn"))
+	  (should (equal '(global-button . "gbtn") (hywiki-add-global-button "WikiWord"))))
+      (hy-delete-dir-and-buffer hywiki-directory))))
 
 (ert-deftest hywiki-tests--add-hyrolo ()
   "Verify `hywiki-add-hyrolo'."
-  (mocklet (((hywiki-add-referent "WikiWord" '(hyrolo-fgrep "WikiWord")) => 'hyrolo-referent))
-    (should (equal 'hyrolo-referent (hywiki-add-hyrolo "WikiWord")))))
+  (let ((hywiki-directory (make-temp-file "hywiki" t)))
+    (unwind-protect
+	(progn
+	  (hywiki-add-hyrolo "WikiWord")
+	  (should (equal '(hyrolo . hyrolo-fgrep) (hywiki-get-referent "WikiWord"))))
+      (hy-delete-dir-and-buffer hywiki-directory))))
 
 (ert-deftest hywiki-tests--add-info-index ()
   "Verify `hywiki-add-info-index'."
-  (mocklet (((info) => t)
-	    ((Info-read-index-item-name "Info index item: ") => "index-name")
-            ((Info-current-filename-sans-extension) => "info")
-            ((hywiki-add-referent "WikiWord" '(Info-goto-node "(info)index-name")) => 'info-referent))
-    (should (equal 'info-referent (hywiki-add-info-index "WikiWord")))))
+  (let ((hywiki-directory (make-temp-file "hywiki" t)))
+    (unwind-protect
+	(mocklet (((info) => t)
+		  ((Info-read-index-item-name "Info index item: ") => "index-name")
+		  ((Info-current-filename-sans-extension) => "info"))
+	  (hywiki-add-info-index "WikiWord")
+	  (should (equal '(info-index . "(info)index-name") (hywiki-get-referent "WikiWord"))))
+      (hy-delete-dir-and-buffer hywiki-directory))))
 
 (ert-deftest hywiki-tests--add-info-node ()
   "Verify `hywiki-add-info-node'."
-  (mocklet (((info) => t)
-	    ((Info-read-node-name "Info node: ") => "node-name")
-            ((Info-current-filename-sans-extension) => "info")
-            ((hywiki-add-referent "WikiWord" '(Info-goto-node "(info)node-name")) => 'info-referent))
-    (should (equal 'info-referent (hywiki-add-info-node "WikiWord")))))
+  (let ((hywiki-directory (make-temp-file "hywiki" t)))
+    (unwind-protect
+	(mocklet (((info) => t)
+		  ((Info-read-node-name "Info node: ") => "node-name")
+		  ((Info-current-filename-sans-extension) => "info"))
+	  (hywiki-add-info-node "WikiWord")
+	  (should (equal '(info-node . "(info)node-name") (hywiki-get-referent "WikiWord"))))
+      (hy-delete-dir-and-buffer hywiki-directory))))
 
 (ert-deftest hywiki-tests--add-key-series ()
   "Verify `hywiki-add-key-series'."
-  (mocklet (((hywiki-add-referent "WikiWord" "{ABC}") => 'key-series-referent))
-    (with-simulated-input "ABC RET"
-      (should (equal 'key-series-referent (hywiki-add-key-series "WikiWord"))))
-    (with-simulated-input "{ABC} RET"
-      (should (equal 'key-series-referent (hywiki-add-key-series "WikiWord"))))))
+  (let ((hywiki-directory (make-temp-file "hywiki" t)))
+    (unwind-protect
+	(progn
+	  (with-simulated-input "ABC RET"
+	    (hywiki-add-key-series "WikiWord")
+	    (should (equal '(key-series . "{ABC}") (hywiki-get-referent "WikiWord"))))
+	  (with-simulated-input "{ABC} RET"
+	    (hywiki-add-key-series "WikiWord")
+	    (should (equal '(key-series . "{ABC}") (hywiki-get-referent "WikiWord")))))
+      (hy-delete-dir-and-buffer hywiki-directory))))
 
-(ert-deftest hywiki-tests--add-link ()
-  "Verify `hywiki-add-link'."
-  (mocklet (((hactypes:link-to-file-interactively) => '("file" 20))
-            ((hpath:file-position-to-line-and-column "file" 20) => "file:L2:C3")
-            ((hywiki-add-referent "WikiWord" "file:L2:C3") => 'path-referent))
-    (should (equal 'path-referent (hywiki-add-link "WikiWord")))))
+(ert-deftest hywiki-tests--add-path-link ()
+  "Verify `hywiki-add-path-link'."
+  (let ((hywiki-directory (make-temp-file "hywiki" t))
+	(wikiword "WikiWord"))
+    (unwind-protect
+	(progn (hywiki-add-path-link wikiword "file" 20)
+	       (should (equal '(path-link . "file:L1")
+			      (hywiki-get-referent wikiword))))
+      (hy-delete-dir-and-buffer hywiki-directory))))
 
 (ert-deftest hywiki-tests--add-org-id ()
   "Verify `hywiki-add-org-id'."
@@ -687,10 +717,10 @@ Note special meaning of `hywiki-allow-plurals-flag'."
             (goto-char (point-max))
             (setq buffer-read-only nil)
             (defvar hywiki-test--org-id)
-	    (let ((result (hywiki-add-org-id "WikiWord")))
-	      (if (stringp result)
-		  (should (string-prefix-p "ID: " result))
-		(error "(hywiki-tests--add-org-id): result value is a non-string: %s" result)))))
+	    (let ((referent-value (cdr (hywiki-add-org-id "WikiWord"))))
+	      (if (stringp referent-value)
+		  (should (string-prefix-p "ID: " referent-value))
+		(error "(hywiki-tests--add-org-id): referent value is a non-string: %s" referent-value)))))
       (hy-delete-file-and-buffer filea))))
 
 ;; hywiki-add-org-roam-node -- Requires org-roam


### PR DESCRIPTION
- Fix "pcomplete" cyclic dep errors in Hyperbole tests on on rsw sys

- hasht.el - Rewrite to use Emacs built-in hash tables

- ibut:create - Display any itype error in *Messages* buffer

- Merge branch 'master' into rsw and fix a few tests
