### PR TITLE
Use when-let* due to deprecation of when-let in Emacs 31

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2024-12-27  Mats Lidell  <matsl@gnu.org>
+
+* hywiki.el (hywiki-add-to-referent): Use when-let*.
+
+* hproperty.el (hproperty:char-property-start)
+    (hproperty:char-property-end): Use when-let*.
+
 2024-12-27  Bob Weiner  <rsw@gnu.org>
 
 * test/hywiki-tests.el (hywiki-tests--add-activity,

--- a/hproperty.el
+++ b/hproperty.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Aug-92
-;; Last-Mod:     17-Nov-24 at 10:31:59 by Bob Weiner
+;; Last-Mod:     27-Dec-24 at 23:15:05 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -283,8 +283,8 @@ See `hproperty:but-get'."
 (defun hproperty:char-property-start (pos property value)
   "From POS, return the start of text PROPERTY with VALUE overlapping POS.
 Otherwise, return nil.  Value must be a symbol."
-  (when-let ((val (hproperty:char-property-contains-p pos property value))
-	     (prev pos))
+  (when-let* ((val (hproperty:char-property-contains-p pos property value))
+	      (prev pos))
     ;; Can't use `previous-single-char-property-change' below
     ;; because it checks for any change in the property value, not
     ;; just if the property contains the value desired.
@@ -296,8 +296,8 @@ Otherwise, return nil.  Value must be a symbol."
 (defun hproperty:char-property-end (pos property value)
   "From POS, return the end of text PROPERTY with VALUE overlapping POS.
 Otherwise, return nil.  Value must be a symbol."
-  (when-let ((val (hproperty:char-property-contains-p pos property value))
-	     (next pos))
+  (when-let* ((val (hproperty:char-property-contains-p pos property value))
+	      (next pos))
     ;; Can't use `next-single-char-property-change' below
     ;; because it checks for any change in the property value, not
     ;; just if the property contains the value desired.

--- a/hywiki.el
+++ b/hywiki.el
@@ -1163,7 +1163,7 @@ calling this function."
   "Display WIKIWORD referent and insert TEXT at POSITION.
 Create page if it does not exist.  If WIKIWORD is invalid, return
 nil, else return '(page . \"<page-file-path>\")."
-  (when-let ((referent (hywiki-add-page wikiword)))
+  (when-let* ((referent (hywiki-add-page wikiword)))
     (hywiki-find-referent wikiword)
     (barf-if-buffer-read-only)
     (save-excursion


### PR DESCRIPTION
# What

when-let is deprecated in Emacs 31. Use when-let* instead.
