### PR TITLE
clean warnings

### DIFF
--- a/hasht.el
+++ b/hasht.el
@@ -317,9 +317,9 @@ if KEY or HASH-TABLE are of the wrong type."
       (let* ((key-sym (intern key))
 	     (key-val (gethash key-sym hash-table)))
 	(if key-sym
-	    (if (listp key-value) ;; allowed to be nil
-		(puthash key-sym (cons value key-value) hash-table)
-	      (error "(hash-prepend): `%s' key's value is not a list:" key key-val))
+	    (if (listp key-val) ;; allowed to be nil
+		(puthash key-sym (cons value key-val) hash-table)
+	      (error "(hash-prepend): `%s' key's value `%s' is not a list:" key key-val))
 	  (error "(hash-prepend): Invalid hash-table key: %s" key)))))
 
 (defun hash-prin1 (hash-table &optional stream)

--- a/hasht.el
+++ b/hasht.el
@@ -8,7 +8,7 @@
 ;; AUTHOR:       Bob Weiner
 ;;
 ;; ORIG-DATE:    16-Mar-90 at 03:38:48
-;; LAST-MOD:     26-Dec-24 at 22:08:52 by Bob Weiner
+;; LAST-MOD:     29-Dec-24 at 12:37:57 by Mats Lidell
 ;;
 ;; Copyright (C) 1990-1995, 1997, 2016  Free Software Foundation, Inc.
 ;; See the file BR-COPY for license information.
@@ -204,8 +204,9 @@ in reverse order of occurrence (they are prepended to the list).  See
   "Return list result of calling FUNC over each (<value> . <key>) in HASH-TABLE.
 <key> is a symbol.
 
-If FUNC is in '(cdr key second symbol-name), then return all <key>s as strings.
-If FUNC is in '(car value first symbol-value), then return all <value>s."
+If FUNC is in \\='(cdr key second symbol-name), then return all <key>s
+as strings.  If FUNC is in \\='(car value first symbol-value), then
+return all <value>s."
   (unless (hash-table-p hash-table)
     (error "(hash-map): Invalid hash-table: `%s'" hash-table))
   (cond ((memq func '(cdr key second symbol-name))

--- a/hui-mouse.el
+++ b/hui-mouse.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-89
-;; Last-Mod:     22-Dec-24 at 13:22:26 by Bob Weiner
+;; Last-Mod:     29-Dec-24 at 12:29:33 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -2220,7 +2220,7 @@ If key is pressed:
 
 ;;;###autoload
 (defun smart-eobp ()
-  "Return t if point is past the last visible buffer line with non-whitespace characters."
+  "Return t if point is past the last visible non-whitespace buffer line."
   (and (or (and (eobp) (bolp))
 	   ;; On a blank line and nothing but whitespace until eob
 	   (save-excursion

--- a/hywiki.el
+++ b/hywiki.el
@@ -1027,7 +1027,7 @@ calling this function."
 
 (defun hywiki-add-page (page-name &optional force-flag)
   "Add a new or return any existing HyWiki page path for PAGE-NAME.
-Returned format is: '(page . \"<page-file-path>\") or nil when none.
+Returned format is: \\='(page . \"<page-file-path>\") or nil when none.
 
 With optional FORCE-FLAG non-nil, force an update to the page's
 modification time.  If PAGE-NAME is invalid, trigger a
@@ -1162,7 +1162,7 @@ calling this function."
 (defun hywiki-add-to-referent (wikiword text position)
   "Display WIKIWORD referent and insert TEXT at POSITION.
 Create page if it does not exist.  If WIKIWORD is invalid, return
-nil, else return '(page . \"<page-file-path>\")."
+nil, else return \\='(page . \"<page-file-path>\")."
   (when-let* ((referent (hywiki-add-page wikiword)))
     (hywiki-find-referent wikiword)
     (barf-if-buffer-read-only)
@@ -1303,7 +1303,7 @@ Return the referent if successfully found or nil otherwise.
 A valid referent is a cons of (<referent-type> . <referent-value>).
 
 If the referent is a HyWiki page:
-    Return a cons of the symbol 'page and the absolute path
+    Return a cons of the symbol \\='page and the absolute path
     to any page successfully found.  Return nil if failed or
     if displaying a regular file (read in via a `find-file' call).
 
@@ -1752,8 +1752,9 @@ the current page unless they have sections attached."
 
 (defun hywiki-maybe-highlight-off-page-name ()
   "Highlight any non-Org link HyWiki page#section at or one char before point.
-If at bobp or any preceding char is non-whitespace and any following character is
-whitespace or at eobp, handle highlighting for any previous word or punctuation.
+If at bobp or any preceding char is non-whitespace and any following
+character is whitespace or at eobp, handle highlighting for any previous
+word or punctuation.
 
 If in a programming mode, must be within a comment.  Use
 `hywiki-word-face' to highlight.  Do not highlight references to


### PR DESCRIPTION
# What

- Remove warnings due to long doc strings and single quotes
- Fix undefined lexical var, use key-val from let*

# Why

We should keep warning messages from byte compiling to a minimum to
ensure we don't let any important warning slip through.
