### PR TITLE
Use link-to-Info-index-item for info index display

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,7 @@
-2025-01-01  Mats Lidell  <matsl@gnu.org>
+2025-01-02  Mats Lidell  <matsl@gnu.org>
+
+* test/hactypes-tests.el (hactypes-tests--link-to-Info-index-item): Verify
+    actypes::link-to-Info-index-item.
 
 * test/hywiki-tests.el (hywiki-tests--add-info-index): Update test to
     verify Info index display.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2025-01-01  Mats Lidell  <matsl@gnu.org>
+
+* test/hywiki-tests.el (hywiki-tests--add-info-index): Update test to
+    verify Info index display.
+
+* hywiki.el (hywiki-display-info-index): Use link-to-Info-index-item.
+
 2024-12-30  Mats Lidell  <matsl@gnu.org>
 
 * test/hypb-tests.el (hypb--verify-info-index-is-correct): Ensure info

--- a/hywiki.el
+++ b/hywiki.el
@@ -931,8 +931,8 @@ calling this function."
 	(setq item (format "(%s)%s" (Info-current-filename-sans-extension) item)))
       (hywiki-add-referent wikiword (cons 'info-index item)))))
 
-(defun hywiki-display-info-index (_wikiword referent)
-  (Info-goto-node (cdr referent)))
+(defun hywiki-display-info-index (_wikiword item-name)
+  (hact 'link-to-Info-index-item item-name))
 
 (defun hywiki-add-info-node (wikiword)
   "Make WIKIWORD display an Info manual node and return it.

--- a/test/hactypes-tests.el
+++ b/test/hactypes-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:      2-Jan-25 at 22:32:05 by Mats Lidell
+;; Last-Mod:      3-Jan-25 at 23:52:37 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -44,7 +44,8 @@
         (actypes::link-to-Info-index-item "(hyperbole)hyperb:dir")
         (should (string-prefix-p "*info*" (buffer-name)))
         (should (string= "hyperbole" (file-name-nondirectory Info-current-file)))
-        (should (string= "Documentation" Info-current-node)))
+        (should (string= "Documentation" Info-current-node))
+        (should (looking-at-p "The Hyperbole Manual is a reference manual, not a simple introduction\\.")))
     (kill-matching-buffers "^\\*info\\*" nil t)))
 
 (provide 'hactypes-tests)

--- a/test/hactypes-tests.el
+++ b/test/hactypes-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:      8-Jul-23 at 14:11:49 by Bob Weiner
+;; Last-Mod:      2-Jan-25 at 22:32:05 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -19,6 +19,7 @@
 ;;; Code:
 
 (require 'ert)
+(require 'el-mock)
 (require 'hactypes)
 (require 'hy-test-helpers "test/hy-test-helpers")
 
@@ -31,6 +32,20 @@
 (ert-deftest display-boolean-false-test ()
   (should (actypes::display-boolean nil))
     (hy-test-helpers:should-last-message "Result = nil; Boolean value = False"))
+
+(ert-deftest hactypes-tests--link-to-Info-index-item ()
+  "Verify `actypes::link-to-Info-index-item'."
+  (should-error (actypes::link-to-Info-index-item "wrong-format") :type 'error)
+  (should-error (actypes::link-to-Info-index-item "(unknown-file)unknown-index-item") :type 'error)
+  (mocklet (((id-info-item "(infofile)index-item") => t))
+    (actypes::link-to-Info-index-item "(infofile)index-item"))
+  (unwind-protect
+      (progn
+        (actypes::link-to-Info-index-item "(hyperbole)hyperb:dir")
+        (should (string-prefix-p "*info*" (buffer-name)))
+        (should (string= "hyperbole" (file-name-nondirectory Info-current-file)))
+        (should (string= "Documentation" Info-current-node)))
+    (kill-matching-buffers "^\\*info\\*" nil t)))
 
 (provide 'hactypes-tests)
 ;;; hactypes-tests.el ends here

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -725,11 +725,15 @@ Note special meaning of `hywiki-allow-plurals-flag'."
   "Verify `hywiki-add-info-index'."
   (let ((hywiki-directory (make-temp-file "hywiki" t)))
     (unwind-protect
-	(mocklet (((info) => t)
-		  ((Info-read-index-item-name "Info index item: ") => "index-name")
-		  ((Info-current-filename-sans-extension) => "info"))
-	  (hywiki-add-info-index "WikiWord")
-	  (should (equal '(info-index . "(info)index-name") (hywiki-get-referent "WikiWord"))))
+        (progn
+	  (mocklet (((info) => t)
+		    ((Info-read-index-item-name "Info index item: ") => "index-name")
+		    ((Info-current-filename-sans-extension) => "info"))
+	    (hywiki-add-info-index "WikiWord")
+	    (should (equal '(info-index . "(info)index-name") (hywiki-get-referent "WikiWord"))))
+          ;; Verify display of referent
+          (mocklet (((hact 'link-to-Info-index-item "(info)index-name") => t))
+            (hywiki-display-referent "WikiWord")))
       (hy-delete-dir-and-buffer hywiki-directory))))
 
 (ert-deftest hywiki-tests--add-info-node ()


### PR DESCRIPTION
# What

Use link-to-Info-index-item.

Add test that verifies link-to-Info-index-item is called for
displaying the referent.

# Why

Bug fix.
