### PR TITLE
hkey-initialize - Override {C-w} in 'hyperbole-mode-map' like {M-w}

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,25 @@
+2025-01-05  Bob Weiner  <rsw@gnu.org>
+
+* hyperbole.el (hkey-initialize): Override {C-w} in 'hyperbole-mode-map'
+    as has long been done with {M-w}.
+  hui.el (hui:kill-region, hui-kill-region): Add to kill delimited things
+    at point without the need to visually select them.
+
 2025-01-04  Bob Weiner  <rsw@gnu.org>
+
+* hbut.el (ibut:create):
+  hywiki.el (hywiki-display-page):
+  hbdata.el (hbdata:ebut-build): Change referent to referent-type and
+    referent-value.
+
+* hbut.el (ibut:label-set): Set 'loc attribute and 'save-match-data'.
+
+* hib-debbugs.el (debbugs-query:at-p): Simplify to use word separators
+    and thus support double quoted "bug#123".
+
+* hycontrol.el (hycontrol-framemove-direction): If "framemove.el" is not
+    manually installed (no package available), trigger an error that shows
+    where to get it from.
 
 * hbut.el (ibut:set-name-and-label-key-p): Revert some changes to avoid
     failures in recognition of ibuttons.

--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:      4-Jan-25 at 20:05:31 by Bob Weiner
+;; Last-Mod:      5-Jan-25 at 01:12:45 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -2119,8 +2119,9 @@ If a new button is created, store its attributes in the symbol,
 
 	      (when (and lbl-key (eq actype #'hywiki-find-referent))
 		;; If a HyWikiWord ibut, save its referent as an attribute
-		(hattr:set 'hbut:current 'referent (hywiki-get-referent lbl-key)))
-
+		(let ((referent (hywiki-get-referent lbl-key)))
+		  (hattr:set 'hbut:current 'referent-type (car referent))
+		  (hattr:set 'hbut:current 'referent-value (cdr referent))))
 	      (when lbl-key
 		(when (called-interactively-p 'any)
 		  (let (help-window-select)
@@ -2327,16 +2328,21 @@ If LABEL is a list, it is assumed to contain all arguments.
 For legacy reasons, the label here is actually the text of the
 implicit button matched contextually and never the optional <[name]>
 preceding the text."
-  (cond ((stringp label)
-	 (hattr:set 'hbut:current 'lbl-key (hbut:label-to-key label))
-	 (when start (hattr:set    'hbut:current 'lbl-start start))
-	 (when end   (hattr:set    'hbut:current 'lbl-end   end)))
-	((and label (listp label))
-	 (hattr:set 'hbut:current 'lbl-key (hbut:label-to-key (car label)))
-	 (hattr:set 'hbut:current 'lbl-start (nth 1 label))
-	 (hattr:set 'hbut:current 'lbl-end (nth 2 label)))
-	(t (error "(ibut:label-set): Invalid label arg: `%s'" label)))
-  label)
+  (save-match-data
+    (cond ((stringp label)
+	   (hattr:set 'hbut:current 'loc (save-excursion
+					   (hbut:to-key-src 'full)))
+	   (hattr:set 'hbut:current 'lbl-key (hbut:label-to-key label))
+	   (when start (hattr:set    'hbut:current 'lbl-start start))
+	   (when end   (hattr:set    'hbut:current 'lbl-end   end)))
+	  ((and label (listp label))
+	   (hattr:set 'hbut:current 'loc (save-excursion
+					   (hbut:to-key-src 'full)))
+	   (hattr:set 'hbut:current 'lbl-key (hbut:label-to-key (car label)))
+	   (hattr:set 'hbut:current 'lbl-start (nth 1 label))
+	   (hattr:set 'hbut:current 'lbl-end (nth 2 label)))
+	  (t (error "(ibut:label-set): Invalid label arg: `%s'" label)))
+    label))
 
 (defun    ibut:label-sort-keys (lbl-keys)
   "Return a sorted list of ibutton LBL-KEYS with highest instance number first."

--- a/hib-debbugs.el
+++ b/hib-debbugs.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Jun-16 at 14:24:53
-;; Last-Mod:     30-Jun-24 at 03:16:07 by Bob Weiner
+;; Last-Mod:      4-Jan-25 at 21:57:09 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -118,11 +118,11 @@ Note that `issue' or `debbugs' may be used as well in place of `bug'."
 		       (match-beginning 1) (match-end 2))
 		      (match-beginning 1)
 		      (match-end 2))
-      (if (and (match-beginning 3) (string-equal "?" (match-string 3)))
+      (if (and (match-beginning 3) (string-equal "?" (match-string-no-properties 3)))
 	  (hact 'debbugs-gnu-query:string (buffer-substring-no-properties
 					   (or (match-beginning 1) (match-beginning 2))
 					   (match-end 4)))
-	(hact 'debbugs-gnu-query (string-to-number (match-string 2)))))))
+	(hact 'debbugs-gnu-query (string-to-number (match-string-no-properties 2)))))))
 
 (defact debbugs-gnu-query (id)
   "Display the discussion of Gnu debbugs ID (a positive integer)."
@@ -237,8 +237,8 @@ attributes."
 	  (skip-chars-backward " \t\n\r\f")
 	  (skip-chars-backward "bugdiseBUGDISE#") ;; bug, debbugs or issue
 	  ;; Allow for bug#222?package=hyperbole&severity=high as well as bug222, or bug#222.
-	  (or (looking-at "[ \t\n\r\f]*\\(bug#?\\|debbugs#?\\|issue#?\\)[ \t\n\r\f]*#?\\([1-9][0-9]*\\)?\\(\\?\\)\\([a-z=&0-9%;()]+\\)")
-	      (looking-at "[ \t\n\r\f]*\\(bug#?\\|debbugs#?\\|issue#?\\)[ \t\n\r\f]*#?\\([1-9][0-9]*\\)[\].,;?:!\)\>\}]?\\([ \t\n\r\f]\\|\\'\\)"))))))
+	  (or (looking-at "\\<\\(bug#?\\|debbugs#?\\|issue#?\\)[ \t\n\r\f]*#?\\([1-9][0-9]*\\)?\\(\\?\\)\\([a-z=&0-9%;()]+\\)\\>")
+	      (looking-at "\\<\\(bug#?\\|debbugs#?\\|issue#?\\)[ \t\n\r\f]*#?\\([1-9][0-9]*\\)\\>\\(\\)\\(\\)"))))))
 	      ;; Ignore matches like  #222, so this is not confused with "hib-social.el" social references.
 	      ;; (looking-at "[ \t\n\r\f]*\\(bug\\|debbugs\\|issue\\)?[ \t\n\r\f]*#\\([1-9][0-9]*\\)[\].,;?!\)\>\}]?\\([ \t\n\r\f]\\|\\'\\)")
 

--- a/hycontrol.el
+++ b/hycontrol.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Jun-16 at 15:35:36
-;; Last-Mod:     10-Nov-24 at 14:57:49 by Bob Weiner
+;; Last-Mod:      4-Jan-25 at 21:04:54 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -130,7 +130,8 @@
 ;; Avoid any potential library name conflict by giving the load directory.
 (require 'set (expand-file-name "set" hyperb:dir))
 (eval-and-compile
-  (require 'framemove nil t) ;; Elpa package
+  ;; Get from: https://github.com/emacsmirror/framemove/blob/master/framemove.el
+  (require 'framemove nil t)
   (require 'windmove))
 ;; Frame face enlarging/shrinking (zooming) requires this separately available library.
 ;; Everything else works fine without it, so don't make it a required dependency.
@@ -1538,7 +1539,11 @@ Heights are given in screen percentages by the list
 
 ;;; Move among frames
 (defun hycontrol-framemove-direction (direction)
-  (hypb:require-package 'framemove)
+  ;; The framemove package is no longer available via a package archive;
+  ;; it must be installed manually if you want to use this function.
+  (unless (featurep 'framemove)
+    (error "(hycontrol-framemove-direction): Requires manual installation of:\n  %s"
+	   "https://github.com/emacsmirror/framemove/blob/master/framemove.el"))
   (fm-next-frame direction))
 
 (defun hycontrol-framemove-up ()

--- a/hyperbole.el
+++ b/hyperbole.el
@@ -9,7 +9,7 @@
 ;; Maintainer:   Robert Weiner <rsw@gnu.org>
 ;; Maintainers:  Robert Weiner <rsw@gnu.org>, Mats Lidell <matsl@gnu.org>
 ;; Created:      06-Oct-92 at 11:52:51
-;; Last-Mod:     11-Nov-24 at 00:03:01 by Bob Weiner
+;; Last-Mod:      5-Jan-25 at 00:55:48 by Bob Weiner
 ;; Released:     10-Mar-24
 ;; Version:      9.0.2pre
 ;; Keywords:     comm, convenience, files, frames, hypermedia, languages, mail, matching, mouse, multimedia, outlines, tools, wp
@@ -309,9 +309,17 @@ of the commands."
     ;; of unit selected each time.
     (hkey-maybe-set-key "\C-c\C-m" #'hui-select-thing)
     ;;
-    ;; Override the {M-w} command from "simple.el" when hyperbole-mode is active
-    ;; to allow copying delimited things, kcell references or regions to the kill ring.
-    (hkey-set-key [remap kill-ring-save] #'hui-kill-ring-save)
+    ;; Override the {C-w} command from either "completion.el" or
+    ;; "simple.el" when hyperbole-mode is active to allow killing
+    ;; kcell references, active regions and delimited areas (like
+    ;; sexpressions).
+    (hkey-set-key [remap completion-kill-region] #'hui-kill-region)
+    (hkey-set-key [remap kill-region]            #'hui-kill-region)
+    ;;
+    ;; Override the {M-w} command from "simple.el" when hyperbole-mode
+    ;; is active to allow copying delimited things, kcell references
+    ;; or regions to the kill ring.
+    (hkey-set-key [remap kill-ring-save]         #'hui-kill-ring-save)
     ;;
     ;; Override the {C-x r s} command from "register.el" when hyperbole-mode is active
     ;; to allow copying delimited things, kcell references or regions to a register.

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Apr-24 at 22:41:13
-;; Last-Mod:      4-Jan-25 at 16:36:48 by Bob Weiner
+;; Last-Mod:      4-Jan-25 at 22:24:25 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1136,8 +1136,9 @@ an existing or new HyWikiWord."
       (setq wikiword (hywiki-word-read-new "Find HyWiki page: ")))
     (let ((file (hywiki-get-file (or file-name wikiword))))
       (funcall hywiki-display-page-function file)
-      ;; Set 'referent attribute of current implicit button
-      (hattr:set 'hbut:current 'referent (cons 'page file))
+      ;; Set referent attributes of current implicit button
+      (hattr:set 'hbut:current 'referent-type 'page)
+      (hattr:set 'hbut:current 'referent-value file)
       file)))
 
 (defun hywiki-add-path-link (wikiword &optional file pos)


### PR DESCRIPTION
- hui.el (hui:kill-region, hui-kill-region): Add to kill delimited things
  at point without the need to visually select them.

- hbut.el (ibut:create):
hywiki.el (hywiki-display-page):
hbdata.el (hbdata:ebut-build): Change referent to referent-type and
   referent-value.

- hbut.el (ibut:label-set): Set 'loc attribute and 'save-match-data'.

- hib-debbugs.el (debbugs-query:at-p): Simplify to use word separators
  and thus support double quoted "bug#123".

- hycontrol.el (hycontrol-framemove-direction): If "framemove.el" is not
   manually installed (no package available), trigger an error that shows
   where to get it from.

- hbut.el (ibut:set-name-and-label-key-p): Revert some changes to avoid
   failures in recognition of ibuttons.