### PR TITLE
Quit hycontrol before displaying error message

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,6 @@
-2025-01-08  Mats Lidell  <matsl@gnu.org>
+2025-01-09  Mats Lidell  <matsl@gnu.org>
+
+* test/MANIFEST: Add hycontrol-tests.el
 
 * hycontrol.el (hycontrol-framemove-direction): Quit hycontrol before
     displaying error message.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2025-01-08  Mats Lidell  <matsl@gnu.org>
+
+* hycontrol.el (hycontrol-framemove-direction): Quit hycontrol before
+    displaying error message.
+
+* test/hycontrol-tests.el
+    (hycontrol-tests--framemove-direction-error-message): Test.
+
 2025-01-05  Bob Weiner  <rsw@gnu.org>
 
 * hywiki.el (hywiki-org-link-resolve, hywiki-org-link-export): Handle

--- a/hycontrol.el
+++ b/hycontrol.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Jun-16 at 15:35:36
-;; Last-Mod:      5-Jan-25 at 11:15:09 by Bob Weiner
+;; Last-Mod:      8-Jan-25 at 22:49:42 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1542,6 +1542,7 @@ Heights are given in screen percentages by the list
   ;; The framemove package is no longer available via a package archive;
   ;; it must be installed manually if you want to use this function.
   (unless (featurep 'framemove)
+    (hycontrol-quit)
     (error "(hycontrol-framemove-direction): Requires manual installation of:\n  %s"
 	   "https://github.com/emacsmirror/framemove/blob/master/framemove.el"))
   (fm-next-frame direction))

--- a/test/MANIFEST
+++ b/test/MANIFEST
@@ -18,11 +18,12 @@ hui-tests.el            - tests for hui.el Hyperbole UI
 hy-test-coverage.el     - provide test coverage information
 hy-test-dependencies.el - Hyperbole test dependencies
 hy-test-helpers.el      - unit test helpers
+hycontrol-tests.el      - hycontrol unit tests
 hypb-tests.el           - tests for hypb.el utility functions
 hyperbole-tests.el      - tests for hyperbole.el
 hyrolo-tests.el         - unit tests for hyrolo.el
-kcell-tests.el          - test for kcells in Koutlines
 hywconfig-tests.el      - tests for hyperbole window configuration management
+kcell-tests.el          - test for kcells in Koutlines
 kexport-tests.el        - test exporting Koutlines to file types
 kimport-tests.el        - test importing file types to Koutlines
 kotl-mode-tests.el      - kotl-mode-el tests

--- a/test/hycontrol-tests.el
+++ b/test/hycontrol-tests.el
@@ -1,0 +1,33 @@
+;;; hycontrol-tests.el --- verify hycontrol -*- lexical-binding: t; -*-
+;;
+;; Author:       Mats Lidell
+;;
+;; Orig-Date:     8-Jan-25 at 22:52:00
+;; Last-Mod:      8-Jan-25 at 23:13:27 by Mats Lidell
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
+;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
+;; See the "HY-COPY" file for license information.
+;;
+;; This file is part of GNU Hyperbole.
+
+;;; Commentary:
+;;
+;; Verify functions and features provided by "hycontrol.el".
+
+;;; Code:
+
+(require 'hycontrol)
+(require 'ert)
+(require 'el-mock)
+
+(ert-deftest hycontrol-tests--framemove-direction-error-message ()
+  "Verify `hycontrol-framemove-direction' shows message when `framemove' is not available."
+  (mocklet (((featurep 'framemove) => nil)
+            ((hycontrol-quit) => t))
+    (let ((err (should-error (hycontrol-framemove-direction 'up) :type 'error)))
+      (should (string-match "Requires manual installation" (cadr err))))))
+
+(provide 'hycontrol-tests)
+;;; hycontrol-tests.el ends here


### PR DESCRIPTION
# What

Quit hycontrol before displaying error message.

# Why

The message is not shown to the user otherwise.
