### PR TITLE
add test for \C-w using prefix arg

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 2025-01-09  Mats Lidell  <matsl@gnu.org>
 
+* test/hui-tests.el (hui--kill-region): Test.
+
 * test/MANIFEST: Add hycontrol-tests.el
 
 * hycontrol.el (hycontrol-framemove-direction): Quit hycontrol before

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,9 @@
-2025-01-09  Mats Lidell  <matsl@gnu.org>
+2025-01-19  Mats Lidell  <matsl@gnu.org>
 
-* test/hui-tests.el (hui--kill-region): Test.
+* test/hui-tests.el (hui--kill-region-multiple-kill, hui--kill-region):
+    Test hui-kill-region. 
+
+2025-01-09  Mats Lidell  <matsl@gnu.org>
 
 * test/MANIFEST: Add hycontrol-tests.el
 

--- a/hui.el
+++ b/hui.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 21:42:03
-;; Last-Mod:     11-Jan-25 at 23:39:13 by Mats Lidell
+;; Last-Mod:     13-Jan-25 at 00:57:43 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -133,6 +133,7 @@ point; see `hui:delimited-selectable-thing'."
 ;; either "completion.el" or "simple.el" when hyperbole-mode is active
 ;; to allow killing kcell references, active regions and delimited
 ;; areas (like sexpressions).
+
 ;;;###autoload
 (defun hui-kill-region (&optional beg end interactive)
   "Kill between point and mark.
@@ -151,22 +152,20 @@ Patched to remove the most recent completion."
   (interactive "r\np")
   (cond ((eq last-command 'complete)
 	 (hui:kill-region beg end))
-	((or (use-region-p)
-	     (null transient-mark-mode)
-	     (not interactive))
+	((and transient-mark-mode
+              (or (use-region-p)
+	          (not interactive)))
 	 (unless (and beg end)
 	   (setq beg (region-beginning)
 		 end (region-end)))
 	 (hui:kill-region beg end))
-	(t (when (or (not (and beg end))
-                     interactive)
-	     (cond ((hui-select-delimited-thing)
-		    (setq beg (region-beginning)
-			  end (region-end)))
-		   ((let ((thing-beg-end (hui:delimited-selectable-thing-and-bounds)))
-		      (when thing-beg-end
-			(setq beg (nth 1 thing-beg-end)
-			      end (nth 2 thing-beg-end)))))))
+	(t (cond ((hui-select-delimited-thing)
+		  (setq beg (region-beginning)
+			end (region-end)))
+		 ((let ((thing-beg-end (hui:delimited-selectable-thing-and-bounds)))
+		    (when thing-beg-end
+		      (setq beg (nth 1 thing-beg-end)
+			    end (nth 2 thing-beg-end))))))
 	   (when (and beg end)
 	     (hui:kill-region beg end)))))
 

--- a/hui.el
+++ b/hui.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 21:42:03
-;; Last-Mod:      5-Jan-25 at 12:24:47 by Bob Weiner
+;; Last-Mod:     11-Jan-25 at 23:39:13 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -134,7 +134,7 @@ point; see `hui:delimited-selectable-thing'."
 ;; to allow killing kcell references, active regions and delimited
 ;; areas (like sexpressions).
 ;;;###autoload
-(defun hui-kill-region (&optional beg end)
+(defun hui-kill-region (&optional beg end interactive)
   "Kill between point and mark.
 The text is deleted but saved in the kill ring.
 The command \\[yank] can retrieve it from there.
@@ -148,18 +148,18 @@ If the previous command was also a kill command,
 the text killed this time appends to the text killed last time
 to make one entry in the kill ring.
 Patched to remove the most recent completion."
-  (interactive "r")
+  (interactive "r\np")
   (cond ((eq last-command 'complete)
 	 (hui:kill-region beg end))
 	((or (use-region-p)
 	     (null transient-mark-mode)
-	     (not (called-interactively-p 'interactive)))
+	     (not interactive))
 	 (unless (and beg end)
 	   (setq beg (region-beginning)
 		 end (region-end)))
 	 (hui:kill-region beg end))
 	(t (when (or (not (and beg end))
-		     (called-interactively-p 'interactive))
+                     interactive)
 	     (cond ((hui-select-delimited-thing)
 		    (setq beg (region-beginning)
 			  end (region-end)))

--- a/hui.el
+++ b/hui.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 21:42:03
-;; Last-Mod:     13-Jan-25 at 00:57:43 by Mats Lidell
+;; Last-Mod:     13-Jan-25 at 23:34:56 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -159,6 +159,8 @@ Patched to remove the most recent completion."
 	   (setq beg (region-beginning)
 		 end (region-end)))
 	 (hui:kill-region beg end))
+        ((and (not interactive) beg end)
+         (hui:kill-region beg end))
 	(t (cond ((hui-select-delimited-thing)
 		  (setq beg (region-beginning)
 			end (region-end)))

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:      9-Jan-25 at 23:03:37 by Mats Lidell
+;; Last-Mod:     11-Jan-25 at 01:10:02 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1175,116 +1175,49 @@ With point on label suggest that ibut for rename."
 (ert-deftest hui--kill-region ()
   "Verify `hui-kill-region'."
   (with-temp-buffer
-    (transient-mark-mode 1)
-    (insert "123")
-    (goto-char 1)
+    (let ((transient-mark-mode t))
+      (insert "abc{def}ghi")
+      (goto-char 1)
 
-    ;; No mark set
-    (should-error (hui-kill-region) :type 'error)
+      ;; No mark set
+      (should-error (hui-kill-region) :type 'error)
 
-    (set-mark (point))
-    (hui-kill-region)
-    (should (looking-at-p "123"))
+      (set-mark (point))
+      (goto-char 4)
+      (mocklet ((called-interactively-p => t))
+        (funcall-interactively 'hui-kill-region (region-beginning) (region-end)))
+      (should (string= "{def}ghi" (buffer-string)))
 
-    (goto-char (point-max))
-    (should (region-active-p))
-    (hui-kill-region)
-    (beginning-of-buffer)
-    (should (string= "" (buffer-string)))
+      (erase-buffer)
+      (insert "abc{def}ghi")
+      (goto-char 1)
+      (set-mark (point))
+      (goto-char 4)
+      (deactivate-mark)
+      (mocklet ((called-interactively-p => t))
+        (funcall-interactively 'hui-kill-region (region-beginning) (region-end)))
+      (should (string= "abcghi" (buffer-string)))
 
-    (insert "123(456)789")
-    (goto-char 1)
-    (set-mark (point))
-    (goto-char 4)
-    (deactivate-mark)
-    (should-not (region-active-p))
-    (funcall-interactively 'hui-kill-region)
-    (if noninteractive
-        (should (string= "(456)789" (buffer-string)))
-      (should (string= "123789" (buffer-string))))
+      (erase-buffer)
+      (insert "abc{def}ghi")
+      (goto-char 1)
+      (set-mark (point))
+      (goto-char 5)
+      (deactivate-mark)
+      (mocklet ((called-interactively-p => t))
+        (funcall-interactively 'hui-kill-region (region-beginning) (region-end)))
+      (should (string= "def}ghi" (buffer-string))))
 
-    (delete-region (point-min) (point-max))
-    (insert "123(456)789")
-    (goto-char 1)
-    (set-mark (point))
-    (goto-char 4)
-    (should (region-active-p))
-    (funcall-interactively 'hui-kill-region)
-    (should (string= "(456)789" (buffer-string)))
-
-    (delete-region (point-min) (point-max))
-    (insert "123(456)789")
-    (goto-char 1)
-    (set-mark (point))
-    (goto-char 4)
-    (deactivate-mark)
-    (should-not (region-active-p))
-    (hui-kill-region)
-    (should (string= "(456)789" (buffer-string)))
-
-    (delete-region (point-min) (point-max))
-    (insert "123(456)789")
-    (goto-char 1)
-    (set-mark (point))
-    (goto-char 4)
-    (should (region-active-p))
-    (hui-kill-region)
-    (should (string= "(456)789" (buffer-string))))
-
-  (with-temp-buffer
-    (transient-mark-mode 0)
-    (insert "123")
-    (goto-char 1)
-
-    ;; No mark set
-    (should-error (hui-kill-region) :type 'error)
-
-    (set-mark (point))
-    (hui-kill-region)
-    (should (looking-at-p "123"))
-
-    (goto-char (point-max))
-    (should-not (region-active-p))
-    (hui-kill-region)
-    (beginning-of-buffer)
-    (should (string= "" (buffer-string)))
-
-    (insert "123(456)789")
-    (goto-char 1)
-    (set-mark (point))
-    (goto-char 4)
-    (deactivate-mark)
-    (should-not (region-active-p))
-    (funcall-interactively 'hui-kill-region)
-    (should (string= "(456)789" (buffer-string)))
-
-    (delete-region (point-min) (point-max))
-    (insert "123(456)789")
-    (goto-char 1)
-    (set-mark (point))
-    (goto-char 4)
-    (should-not (region-active-p))
-    (funcall-interactively 'hui-kill-region)
-    (should (string= "(456)789" (buffer-string)))
-
-    (delete-region (point-min) (point-max))
-    (insert "123(456)789")
-    (goto-char 1)
-    (set-mark (point))
-    (goto-char 4)
-    (deactivate-mark)
-    (should-not (region-active-p))
-    (hui-kill-region)
-    (should (string= "(456)789" (buffer-string)))
-
-    (delete-region (point-min) (point-max))
-    (insert "123(456)789")
-    (goto-char 1)
-    (set-mark (point))
-    (goto-char 4)
-    (should-not (region-active-p))
-    (hui-kill-region)
-    (should (string= "(456)789" (buffer-string)))))
+    (let ((transient-mark-mode nil))
+      (erase-buffer)
+      (insert "abc{def}ghi")
+      (goto-char 1)
+      (set-mark (point))
+      (goto-char 4)
+      (deactivate-mark)
+      (mocklet ((called-interactively-p => t))
+        (funcall-interactively 'hui-kill-region (region-beginning) (region-end)))
+      (should (string= "{def}ghi" (buffer-string))))))
 
 ;; This file can't be byte-compiled without `with-simulated-input' which
 ;; is not part of the actual dependencies, so:

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     19-Jan-25 at 00:25:05 by Mats Lidell
+;; Last-Mod:     19-Jan-25 at 00:46:05 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -604,6 +604,7 @@ Ensure modifying the button but keeping the label does not create a double label
           (insert "a")
           (kotl-mode:newline 1)
           (insert "b")
+          (setq last-command #'ignore)
           (hui-kill-ring-save (region-beginning) (region-end))
           (should (string= (current-kill 0 t) "a\nb")))
       (hy-delete-file-and-buffer kotl-file))))

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     13-Jan-25 at 00:58:15 by Mats Lidell
+;; Last-Mod:     14-Jan-25 at 14:46:42 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1178,6 +1178,7 @@ With point on label suggest that ibut for rename."
     (let ((transient-mark-mode t))
       (insert "abc{def}ghi")
       (goto-char 1)
+      (set-mark nil)
 
       ;; No mark set
       (should-error (call-interactively #'hui-kill-region) :type 'error)
@@ -1203,7 +1204,25 @@ With point on label suggest that ibut for rename."
       (goto-char 5)
       (deactivate-mark)
       (call-interactively #'hui-kill-region)
-      (should (string= "def}ghi" (buffer-string))))
+      (should (string= "def}ghi" (buffer-string)))
+
+      ;; Not interactive
+      (erase-buffer)
+      (insert "abc{def}ghi")
+      (goto-char 1)
+      (set-mark (point))
+      (goto-char 4)
+      (hui-kill-region)
+      (should (string= "{def}ghi" (buffer-string)))
+
+      (erase-buffer)
+      (insert "abc{def}ghi")
+      (goto-char 1)
+      (set-mark (point))
+      (goto-char 4)
+      (deactivate-mark)
+      (hui-kill-region)
+      (should (string= "{def}ghi" (buffer-string))))
 
     (let ((transient-mark-mode nil))
       (erase-buffer)
@@ -1214,21 +1233,16 @@ With point on label suggest that ibut for rename."
       ;; No mark set
       (should-error (call-interactively #'hui-kill-region) :type 'error)
 
-      (erase-buffer)
-      (insert "abc{def}ghi")
-      (goto-char 1)
       (set-mark (point))
       (goto-char 4)
-      (activate-mark)
       (call-interactively #'hui-kill-region)
-      (should (string= "{def}ghi" (buffer-string)))
+      (should (string= "abcghi" (buffer-string)))
 
       (erase-buffer)
       (insert "abc{def}ghi")
       (goto-char 1)
       (set-mark (point))
       (goto-char 4)
-      (deactivate-mark)
       (call-interactively #'hui-kill-region)
       (should (string= "abcghi" (buffer-string)))
 
@@ -1237,8 +1251,36 @@ With point on label suggest that ibut for rename."
       (goto-char 1)
       (set-mark (point))
       (goto-char 5)
-      (deactivate-mark)
       (call-interactively #'hui-kill-region)
+      (should (string= "def}ghi" (buffer-string)))
+
+      ;; Not interactive
+
+      (erase-buffer)
+      (insert "abc{def}ghi")
+      (goto-char 1)
+      (set-mark (point))
+      (goto-char 4)
+      (hui-kill-region)
+      (should (string= "abcghi" (buffer-string)))
+
+      (erase-buffer)
+      (insert "abc{def}ghi")
+      (goto-char 1)
+      (set-mark (point))
+      (goto-char 4)
+      (hui-kill-region (region-beginning) (region-end))
+      (should (string= "{def}ghi" (buffer-string)))
+
+      (erase-buffer)
+      (insert "abc{def}ghi")
+      (goto-char 1)
+      (set-mark (point))
+      (goto-char 5)
+      (hui-kill-region)
+      (should (string= "abc{def}ghi" (buffer-string))) ;; Nothing
+
+      (hui-kill-region (region-beginning) (region-end))
       (should (string= "def}ghi" (buffer-string))))))
 
 ;; This file can't be byte-compiled without `with-simulated-input' which

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     11-Jan-25 at 23:40:55 by Mats Lidell
+;; Last-Mod:     13-Jan-25 at 00:58:15 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1180,7 +1180,7 @@ With point on label suggest that ibut for rename."
       (goto-char 1)
 
       ;; No mark set
-      (should-error (hui-kill-region) :type 'error)
+      (should-error (call-interactively #'hui-kill-region) :type 'error)
 
       (set-mark (point))
       (goto-char 4)
@@ -1209,11 +1209,37 @@ With point on label suggest that ibut for rename."
       (erase-buffer)
       (insert "abc{def}ghi")
       (goto-char 1)
+      (set-mark nil)
+
+      ;; No mark set
+      (should-error (call-interactively #'hui-kill-region) :type 'error)
+
+      (erase-buffer)
+      (insert "abc{def}ghi")
+      (goto-char 1)
+      (set-mark (point))
+      (goto-char 4)
+      (activate-mark)
+      (call-interactively #'hui-kill-region)
+      (should (string= "{def}ghi" (buffer-string)))
+
+      (erase-buffer)
+      (insert "abc{def}ghi")
+      (goto-char 1)
       (set-mark (point))
       (goto-char 4)
       (deactivate-mark)
       (call-interactively #'hui-kill-region)
-      (should (string= "{def}ghi" (buffer-string))))))
+      (should (string= "abcghi" (buffer-string)))
+
+      (erase-buffer)
+      (insert "abc{def}ghi")
+      (goto-char 1)
+      (set-mark (point))
+      (goto-char 5)
+      (deactivate-mark)
+      (call-interactively #'hui-kill-region)
+      (should (string= "def}ghi" (buffer-string))))))
 
 ;; This file can't be byte-compiled without `with-simulated-input' which
 ;; is not part of the actual dependencies, so:

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     11-Jan-25 at 01:10:02 by Mats Lidell
+;; Last-Mod:     11-Jan-25 at 23:40:55 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1184,8 +1184,7 @@ With point on label suggest that ibut for rename."
 
       (set-mark (point))
       (goto-char 4)
-      (mocklet ((called-interactively-p => t))
-        (funcall-interactively 'hui-kill-region (region-beginning) (region-end)))
+      (call-interactively #'hui-kill-region)
       (should (string= "{def}ghi" (buffer-string)))
 
       (erase-buffer)
@@ -1194,8 +1193,7 @@ With point on label suggest that ibut for rename."
       (set-mark (point))
       (goto-char 4)
       (deactivate-mark)
-      (mocklet ((called-interactively-p => t))
-        (funcall-interactively 'hui-kill-region (region-beginning) (region-end)))
+      (call-interactively #'hui-kill-region)
       (should (string= "abcghi" (buffer-string)))
 
       (erase-buffer)
@@ -1204,8 +1202,7 @@ With point on label suggest that ibut for rename."
       (set-mark (point))
       (goto-char 5)
       (deactivate-mark)
-      (mocklet ((called-interactively-p => t))
-        (funcall-interactively 'hui-kill-region (region-beginning) (region-end)))
+      (call-interactively #'hui-kill-region)
       (should (string= "def}ghi" (buffer-string))))
 
     (let ((transient-mark-mode nil))
@@ -1215,8 +1212,7 @@ With point on label suggest that ibut for rename."
       (set-mark (point))
       (goto-char 4)
       (deactivate-mark)
-      (mocklet ((called-interactively-p => t))
-        (funcall-interactively 'hui-kill-region (region-beginning) (region-end)))
+      (call-interactively #'hui-kill-region)
       (should (string= "{def}ghi" (buffer-string))))))
 
 ;; This file can't be byte-compiled without `with-simulated-input' which

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     13-Jul-24 at 23:42:26 by Mats Lidell
+;; Last-Mod:      9-Jan-25 at 23:03:37 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1171,6 +1171,120 @@ With point on label suggest that ibut for rename."
           (gbut:ebut-program "global" 'eval-elisp ''(should (string= current-folder default-directory)))
           (gbut:act "global"))
       (hy-delete-file-and-buffer global-but-file))))
+
+(ert-deftest hui--kill-region ()
+  "Verify `hui-kill-region'."
+  (with-temp-buffer
+    (transient-mark-mode 1)
+    (insert "123")
+    (goto-char 1)
+
+    ;; No mark set
+    (should-error (hui-kill-region) :type 'error)
+
+    (set-mark (point))
+    (hui-kill-region)
+    (should (looking-at-p "123"))
+
+    (goto-char (point-max))
+    (should (region-active-p))
+    (hui-kill-region)
+    (beginning-of-buffer)
+    (should (string= "" (buffer-string)))
+
+    (insert "123(456)789")
+    (goto-char 1)
+    (set-mark (point))
+    (goto-char 4)
+    (deactivate-mark)
+    (should-not (region-active-p))
+    (funcall-interactively 'hui-kill-region)
+    (if noninteractive
+        (should (string= "(456)789" (buffer-string)))
+      (should (string= "123789" (buffer-string))))
+
+    (delete-region (point-min) (point-max))
+    (insert "123(456)789")
+    (goto-char 1)
+    (set-mark (point))
+    (goto-char 4)
+    (should (region-active-p))
+    (funcall-interactively 'hui-kill-region)
+    (should (string= "(456)789" (buffer-string)))
+
+    (delete-region (point-min) (point-max))
+    (insert "123(456)789")
+    (goto-char 1)
+    (set-mark (point))
+    (goto-char 4)
+    (deactivate-mark)
+    (should-not (region-active-p))
+    (hui-kill-region)
+    (should (string= "(456)789" (buffer-string)))
+
+    (delete-region (point-min) (point-max))
+    (insert "123(456)789")
+    (goto-char 1)
+    (set-mark (point))
+    (goto-char 4)
+    (should (region-active-p))
+    (hui-kill-region)
+    (should (string= "(456)789" (buffer-string))))
+
+  (with-temp-buffer
+    (transient-mark-mode 0)
+    (insert "123")
+    (goto-char 1)
+
+    ;; No mark set
+    (should-error (hui-kill-region) :type 'error)
+
+    (set-mark (point))
+    (hui-kill-region)
+    (should (looking-at-p "123"))
+
+    (goto-char (point-max))
+    (should-not (region-active-p))
+    (hui-kill-region)
+    (beginning-of-buffer)
+    (should (string= "" (buffer-string)))
+
+    (insert "123(456)789")
+    (goto-char 1)
+    (set-mark (point))
+    (goto-char 4)
+    (deactivate-mark)
+    (should-not (region-active-p))
+    (funcall-interactively 'hui-kill-region)
+    (should (string= "(456)789" (buffer-string)))
+
+    (delete-region (point-min) (point-max))
+    (insert "123(456)789")
+    (goto-char 1)
+    (set-mark (point))
+    (goto-char 4)
+    (should-not (region-active-p))
+    (funcall-interactively 'hui-kill-region)
+    (should (string= "(456)789" (buffer-string)))
+
+    (delete-region (point-min) (point-max))
+    (insert "123(456)789")
+    (goto-char 1)
+    (set-mark (point))
+    (goto-char 4)
+    (deactivate-mark)
+    (should-not (region-active-p))
+    (hui-kill-region)
+    (should (string= "(456)789" (buffer-string)))
+
+    (delete-region (point-min) (point-max))
+    (insert "123(456)789")
+    (goto-char 1)
+    (set-mark (point))
+    (goto-char 4)
+    (should-not (region-active-p))
+    (hui-kill-region)
+    (should (string= "(456)789" (buffer-string)))))
 
 ;; This file can't be byte-compiled without `with-simulated-input' which
 ;; is not part of the actual dependencies, so:


### PR DESCRIPTION
# What

- Add test for hui-kill-region
- Refactored and simplified
- Use prefix arg for interactive call
- Refactor to have base behavior as kill-region
- Fix non-interactive behavior

# Why

Tests.

# Note

The inspiration for using an argument for identification of
interactive call or not comes from the comment in 
```
{C-hf called-interactively-p RET}
```

It says:

    Instead of using this function, it is cleaner and more reliable to
    give your function an extra optional argument whose ‘interactive’ spec
    specifies non-nil unconditionally ("p" is a good way to do this), or
    via (not (or executing-kbd-macro noninteractive)).

