### PR TITLE
ert-should ibtype; hypb:with-macro; rewrite of Hyperbole {C-w} and {M-w} commands and updates to tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 2025-01-20  Bob Weiner  <rsw@gnu.org>
 
+* hsys-ert.el (require 'hbut): For 'defib'.
+
 * test/hui-tests.el (hui--kill-highlighted-region,
                      hui--kill-non-highlighted-region): Separate and rename
     these tests.  Rearrange letters in each subtest so can find which should

--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,9 @@
     Hyperbole manual.  Also add `ert-should' ibtype.
   MANIFEST, Makefile (EL_COMPILE): Add "hsys-ert.el".
 
+* hypb.el (hypb:with-marker): Add context macro for setting a buffer marker
+    and automatically setting it to nil at the end of the context.
+
 * hui.el (hui:kill-region): Update to only apply completion behavior when
     'dynamic-completion-mode' is enabled and call subfunctions interactively
     in interactive flag is set.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,15 @@
 2025-01-19  Bob Weiner  <rsw@gnu.org>
 
+* hsys-ert.el (ert-should): Add this new file and implicit button type.
+    See the Commentary therein for details.
+  hibtypes.el (load "hsys-ert"): Load above ibtype at near lowest priority.
+  hui-mouse.el (hkey-alist): Move priority of ert-results-mode to after
+    (hbut:at-p) so can define implicit buttons in this mode that override
+    the standard behavior.
+  man/hyperbole.texi (Smart Key - ERT Results Mode): Update order in the
+    Hyperbole manual.  Also add `ert-should' ibtype.
+  MANIFEST, Makefile (EL_COMPILE): Add "hsys-ert.el".
+
 * hui.el (hui:kill-region): Update to only apply completion behavior when
     'dynamic-completion-mode' is enabled and call subfunctions interactively
     in interactive flag is set.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,29 @@
+2025-01-20  Bob Weiner  <rsw@gnu.org>
+
+* test/hui-tests.el (hui--kill-highlighted-region,
+                     hui--kill-non-highlighted-region): Separate and rename
+    these tests.  Rearrange letters in each subtest so can find which should
+    is being called.
+
+* hui.el (hui:validate-region): Add to check for valid region args.
+         (hui-kill-ring-save): Call above function.
+
+* test/hui-tests.el (hui--kill-region,
+                     hui--kill-region-multiple-kill): Add let of
+    'mark-even-if-inactive'.  Also, interactively, set beg and end only
+    if 'mark-active' is non-nil.
+
 2025-01-19  Bob Weiner  <rsw@gnu.org>
+
+* hui.el (hui:kill-region): Complete doc string.  Set 'region' arg to nil when
+    killing a delimited region at point.  Also use 'hui-select-at-delimited-thing-p'
+    instead of 'hui-select-delimited-thing'.
+         (hui:delimited-selectable-thing)
+          hui:delimited-selectable-thing-and-bounds): Fix so doesn't create an
+    in-memory Hyperbole button at point if already doing so in a prior stack frame.
+    The latter is used in 'hui-kill-ring-save' bound to {M-w} in 'hyperbole-mode'.
+         (require 'hversion): Since 'hyperb:stack-frame' is defined there and
+    used herein.
 
 * hsys-ert.el (ert-should): Add this new file and implicit button type.
     See the Commentary therein for details.
@@ -17,7 +42,6 @@
     'dynamic-completion-mode' is enabled and call subfunctions interactively
     in interactive flag is set.
          (hui-kill-region): Simplify 'hui-select-delimited-thing'.
-	 (hui:kill-region): 
 
 2025-01-19  Mats Lidell  <matsl@gnu.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,15 @@
+2025-01-19  Bob Weiner  <rsw@gnu.org>
+
+* hui.el (hui:kill-region): Update to only apply completion behavior when
+    'dynamic-completion-mode' is enabled and call subfunctions interactively
+    in interactive flag is set.
+         (hui-kill-region): Simplify 'hui-select-delimited-thing'.
+	 (hui:kill-region): 
+
 2025-01-19  Mats Lidell  <matsl@gnu.org>
 
 * test/hui-tests.el (hui--kill-region-multiple-kill, hui--kill-region):
-    Test hui-kill-region. 
+    Test hui-kill-region.
 
 2025-01-18  Bob Weiner  <rsw@gnu.org>
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -107,6 +107,7 @@ topwin.py            - Python script to find the topmost macOS app window at a s
 
 * --- EXTERNAL SYSTEM ENCAPSULATIONS ---
 hsys-consult.el      - Hyperbole interactive consult-grep convenience functions
+hsys-ert.el          - Hyperbole support for jumping to ert 'should' source lines
 hsys-flymake.el      - Add missing source buffer keymap to flymake linter
 hsys-org.el          - GNU Hyperbole support functions for Org mode
 hsys-org-roam.el     - GNU Hyperbole support functions for Org Roam

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:     16-Dec-24 at 23:36:16 by Mats Lidell
+# Last-Mod:     19-Jan-25 at 17:53:51 by Bob Weiner
 #
 # Copyright (C) 1994-2023  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -209,7 +209,7 @@ EL_COMPILE = hact.el hactypes.el hargs.el hbdata.el hbmap.el hbut.el \
 	     hinit.el hload-path.el hmail.el hmh.el hmoccur.el hmouse-info.el \
 	     hmouse-drv.el hmouse-key.el hmouse-mod.el hmouse-sh.el hmouse-tag.el \
 	     hpath.el hproperty.el hrmail.el hsettings.el hsmail.el hsys-consult.el \
-             hsys-flymake.el \
+             hsys-ert.el hsys-flymake.el \
              hsys-org.el hsys-org-roam.el hsys-www.el hsys-xref.el hsys-youtube.el htz.el \
 	     hycontrol.el hui-jmenu.el hui-menu.el hui-mini.el hui-mouse.el hui-select.el \
 	     hui-treemacs.el hui-window.el hui.el hvar.el hversion.el hynote.el hypb.el hyperbole.el \

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:      5-Jan-25 at 11:15:09 by Bob Weiner
+;; Last-Mod:     19-Jan-25 at 17:56:38 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -90,6 +90,12 @@
 ;; Don't use require below here for any libraries with ibtypes in
 ;; them.  Use load instead to ensure are reloaded when resetting
 ;; ibtype priorities.
+
+;;; ========================================================================
+;;; Supports jumping to Emacs Regression Test (ert) 'should' source lines
+;;; ========================================================================
+
+(load "hsys-ert")
 
 ;;; ========================================================================
 ;;; Displays Org and Org Roam files and sections by name link

--- a/hsys-ert.el
+++ b/hsys-ert.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Jan-25
-;; Last-Mod:     19-Jan-25 at 21:42:20 by Bob Weiner
+;; Last-Mod:     20-Jan-25 at 02:00:12 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -41,6 +41,12 @@
 ;;      Action Key.
 
 ;;; Code:
+
+;;; ************************************************************************
+;;; Other required Elisp libraries
+;;; ************************************************************************
+
+(require 'hbut)  ;; For defib
 
 ;;; ************************************************************************
 ;;; Implicit button types

--- a/hsys-ert.el
+++ b/hsys-ert.el
@@ -1,0 +1,111 @@
+;;; hsys-ert.el --- Hyperbole support for jumping to ert 'should' source lines  -*- lexical-binding: t -*-
+;;
+;; Author:       Bob Weiner
+;;
+;; Orig-Date:    19-Jan-25
+;; Last-Mod:     19-Jan-25 at 21:42:20 by Bob Weiner
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
+;; Copyright (C) 2025  Free Software Foundation, Inc.
+;; See the "HY-COPY" file for license information.
+;;
+;; This file is part of GNU Hyperbole.
+
+;;; Commentary:
+;;
+;;  ERT is the Emacs Regression Test framework in "ert.el".  Hyperbole uses
+;;  it for all of its regression testing as well.
+;;
+;;  Sometimes when building Emacs Lisp tests with the ERT package, multiple
+;;  tests are added to a single test fixture/function.  Each subtest
+;;  has its own `should'-type clause.  But if one of these subtests fails,
+;;  ERT shows you the test name and the should clause in its results buffer
+;;  but if there are 12 subtests, it is difficult to match the displayed
+;;  should clause to the source line that ran it.
+;;
+;;  The `ert-should' implicit button type defined herein solves this problem.
+;;  Hyperbole loads this and then a press of the Action Key within an ert
+;;  results buffer (or another buffer to which the results have been copied)
+;;  produces the following:
+;;
+;;    - If on the first line of the result with the test name, jump to the
+;;      test definition.
+;;
+;;    - If on a highlighted button, activate the button.
+;;
+;;    - Otherwise if not at the end of a line and within a failed test result,
+;;      find the `should' clause and go to the matching line within the test
+;;      source code.  An easy way to use it is to put point at the beginning
+;;      of a line other than the first within an ert result and press the
+;;      Action Key.
+
+;;; Code:
+
+;;; ************************************************************************
+;;; Implicit button types
+;;; ************************************************************************
+
+(defib ert-should ()
+  "Jump to the source code definition of a should expr from an ert test failure.
+If on the first line of a failure, jump to the source definition of the
+associated test."
+  (when (or (derived-mode-p 'ert-results-mode)
+            (save-excursion
+              (forward-line 0)
+              (or (search-backward "(ert-test-failed\n" nil t)
+                  (search-forward "(ert-test-failed\n" nil t))))
+    (catch 'exit
+    (save-excursion
+      (save-restriction
+        (forward-line 0)
+        (cond ((looking-at "\\`\\|^[AFPS] ")
+	       ;; On a result line with a test name, jump to the test
+               (goto-char (match-end 0))
+	       ;; Use the test definition name as the ibut label
+               (ibut:label-set (buffer-substring-no-properties
+				(+ 2 (line-beginning-position))
+				(line-end-position))
+			       (+ 2 (line-beginning-position))
+			       (line-end-position))
+               (let ((major-mode 'emacs-lisp-mode))
+                 (if (button-at (point))
+                     ;; jump to source buffer
+                     (push-button)
+                   (throw 'exit (hact 'smart-lisp)))))
+               ((looking-at "\\s-*(ert-test-failed\\s-")
+		(when (re-search-forward "^\\s-+(\\((should\\)\\(-\\|\\s-\\)" nil t)
+                  (goto-char (match-beginning 1))))
+               ((looking-at "\\s-*(\\((should\\)\\(-\\|\\s-\\)")
+		(goto-char (match-beginning 1)))
+               ((re-search-backward "\\`\\|^[AFPS] " nil t)
+		(let ((start (point)))
+                  (goto-char (1+ (point)))
+                  (when (re-search-forward "^[AFPS] \\|\\'" nil t)
+                    (goto-char (1- (match-beginning 0)))
+                    (narrow-to-region start (point))
+                    (goto-char start)
+                    (when (re-search-forward "^\\s-+(\\((should\\)\\(-\\|\\s-\\)" nil t)
+                      (goto-char (match-beginning 1)))))))
+              (when (looking-at "(should\\(-\\|\\s-\\)")
+		(let ((should-regexp (regexp-quote (thing-at-point 'sexp))))
+		  (setq should-regexp (replace-regexp-in-string
+                                       "[ \t\n\r\f]+" "\\s-+" (string-trim should-regexp)
+                                       t t))
+		  ;; follow the function link to the source file of the function
+		  (when (re-search-backward "^[AFPS] " nil t)
+		    (goto-char (match-end 0))
+		    (let ((major-mode 'emacs-lisp-mode))
+                      (if (button-at (point))
+			  ;; jump to source buffer
+			  (push-button)
+			(smart-lisp))
+                      ;; re-search-forward for should-regexp
+                      (when (re-search-forward should-regexp nil t)
+			(goto-char (match-beginning 0))
+			(ibut:label-set "(should" (point) (+ (point) 7))
+			(hact 'identity t)))))))))))
+
+(provide 'hsys-ert)
+
+;;; hsys-ert.el ends here

--- a/hui-mouse.el
+++ b/hui-mouse.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-89
-;; Last-Mod:     29-Dec-24 at 12:29:33 by Mats Lidell
+;; Last-Mod:     19-Jan-25 at 16:40:13 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -248,11 +248,6 @@ Its default value is `smart-scroll-down'.  To disable it, set it to
     ((eq major-mode 'dired-sidebar-mode)
      . ((smart-dired-sidebar) . (smart-dired-sidebar)))
     ;;
-    ((and (eq major-mode 'ert-results-mode)
-	  (featurep 'ert-results)
-	  (setq hkey-value (ert-results-filter-status-p)))
-     . ((smart-ert-results hkey-value) . (smart-ert-results-assist hkey-value)))
-    ;;
     ;; Handle Emacs push buttons in buffers
     ((and (fboundp 'button-at) (button-at (point)))
      . ((smart-push-button nil (mouse-event-p last-command-event))
@@ -368,6 +363,11 @@ Its default value is `smart-scroll-down'.  To disable it, set it to
 			       (smart-helm-at-header)
 			       (smart-helm-line-has-action))))
      . ((smart-helm) . (smart-helm-assist)))
+    ;;
+    ((and (eq major-mode 'ert-results-mode)
+	  (featurep 'ert-results)
+	  (setq hkey-value (ert-results-filter-status-p)))
+     . ((smart-ert-results hkey-value) . (smart-ert-results-assist hkey-value)))
     ;;
     ;; Support the OO-Browser when available.  It is a separate Emacs
     ;; package not included with Hyperbole.  Within an OO-Browser

--- a/hui-select.el
+++ b/hui-select.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Oct-96 at 02:25:27
-;; Last-Mod:      9-Sep-24 at 22:25:55 by Bob Weiner
+;; Last-Mod:     19-Jan-25 at 10:04:03 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -67,12 +67,12 @@
 ;;      kill ring
 ;;    `hui-select-and-kill-thing' - kill the syntactical unit at point
 ;;    `hui-select-goto-matching-tag' - In modes listed in the variable,
-;;    `hui-select-markup-modes'), move point to the
-;;      start of the tag paired with the closest tag that point is within or
-;;      which it precedes, so you can quickly jump back and forth between
-;;      open and close tags.  In these modes, this is bound to {C-c .}
-;;    `hui-select-at-p' - predicate to test if a buffer position (or point) starts
-;;      or ends a matching syntactical region (excluding a single character).
+;;    `hui-select-markup-modes', move point to the  start of the tag paired
+;;      with the closest tag that point is within or which it precedes, so
+;;      you can quickly jump back and forth between open and close tags.  In
+;;      these modes, this is bound to {C-c .}
+;;    `hui-select-at-p' - predicate to test if a buffer position (or point)
+;;     starts or ends a matching syntactical region (excluding a single character).
 ;;
 ;;   ---------------
 ;;   SETUP IF USED SEPARATELY FROM HYPERBOLE (otherwise ignore):

--- a/hypb.el
+++ b/hypb.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     6-Oct-91 at 03:42:38
-;; Last-Mod:      5-Jan-25 at 11:16:50 by Bob Weiner
+;; Last-Mod:     19-Jan-25 at 15:01:21 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1082,6 +1082,21 @@ Optional first arg MINIBUFFER-FLAG t means include the minibuffer window
 in the list, even if it is not active.  If MINIBUFFER-FLAG is neither t
 nor nil it means to not count the minibuffer window even if it is active."
   (window-list nil minibuffer-flag))
+
+;;;###autoload
+(defmacro hypb:with-marker (marker &rest body)
+  "Set MARKER while executing BODY, then set MARKER to nil.
+Return result of last BODY expression."
+  (declare (indent 1) (debug t))
+  `(prog1 (progn
+	    (unless (symbolp ',marker)
+	      (error "(with-marker): `marker' must be a symbol, not: '%s'" marker))
+	    (unless (boundp ',marker)
+	      (setq ,marker nil))
+	    (unless (markerp ,marker)
+	      (setq ,marker (make-marker)))
+	    ,@body)
+     (set-marker ,marker nil)))
 
 ;;; ************************************************************************
 ;;; About Hyperbole Setup

--- a/man/hyperbole.texi
+++ b/man/hyperbole.texi
@@ -7,7 +7,7 @@
 @c Author:       Bob Weiner
 @c
 @c Orig-Date:     6-Nov-91 at 11:18:03
-@c Last-Mod:     30-Dec-24 at 23:34:55 by Mats Lidell
+@c Last-Mod:     19-Jan-25 at 18:06:31 by Bob Weiner
 
 @c %**start of header (This is for running Texinfo on a region.)
 @setfilename hyperbole.info
@@ -30,8 +30,8 @@
 @set txicodequoteundirected
 @set txicodequotebacktick
 
-@set UPDATED October, 2024
-@set UPDATED-MONTH October 2024
+@set UPDATED January, 2025
+@set UPDATED-MONTH January 2025
 @set EDITION 9.0.2pre
 @set VERSION 9.0.2pre
 
@@ -67,7 +67,7 @@
 This manual is for GNU Hyperbole
 (Edition @value{EDITION}, Published @value{UPDATED}).
 
-Copyright @copyright{} 1989-2024  Free Software Foundation, Inc.
+Copyright @copyright{} 1989-2025  Free Software Foundation, Inc.
 
 @quotation
 Permission is granted to copy, distribute and/or modify this document
@@ -158,7 +158,7 @@ Texinfo markup language.
 <CENTER><H3><A HREF="mailto:rsw@@gnu.org">Say thanks or send a testimonial if you like Hyperbole.</A></H3></CENTER>
 
 
-<P>Copyright &copy; 1989-2024  Free Software Foundation, Inc.</P>
+<P>Copyright &copy; 1989-2025  Free Software Foundation, Inc.</P>
 
 <P>GNU Hyperbole is available for use, modification, and distribution under
 the terms of the GNU General Public License (GPL) Version 3 or later,
@@ -171,7 +171,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.</P>
 
 <PRE>
 Edition 9.0.2pre
-Printed October 22, 2024.
+Printed January 19, 2025.
 
   Published by the Free Software Foundation, Inc.
   Author:    Bob Weiner
@@ -199,7 +199,7 @@ Printed October 22, 2024.
 
 @sp 2
 @noindent
-Copyright @copyright{} 1989-2024  Free Software Foundation, Inc.
+Copyright @copyright{} 1989-2025  Free Software Foundation, Inc.
 
 GNU Hyperbole is available for use, modification, and distribution
 under the terms of the GNU General Public License (GPL) Version 3 or
@@ -213,7 +213,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
 @example
 Edition 9.0.2pre
-October 22, 2024
+January 19, 2025
 
   Published by the Free Software Foundation, Inc.
   Author:    Bob Weiner
@@ -483,7 +483,6 @@ Smart Keyboard Keys
 * Smart Key - Ivy::
 * Smart Key - Treemacs::
 * Smart Key - Dired Sidebar Mode::
-* Smart Key - ERT Results Mode::
 * Smart Key - Emacs Pushbuttons::
 * Smart Key - Argument Completion::
 * Smart Key - ID Edit Mode::
@@ -494,6 +493,7 @@ Smart Keyboard Keys
 * Smart Key - Hyperbole Buttons::
 * Smart Key - View Mode::
 * Smart Key - Helm Mode::
+* Smart Key - ERT Results Mode::
 * Smart Key - Delimited Things::
 * Smart Key - Occurrence Matches::
 * Smart Key - The Koutliner::
@@ -3056,6 +3056,20 @@ When on a HyNote file name stem, display the file and its optional
 section.  This type is active only in buffers where
 @code{hywiki-active-in-current-buffer-p} is true.  This may require
 that the global minor mode @code{hywiki-mode} has been enabled.
+
+@findex ibtypes ert-should
+@findex ert-results-mode
+@cindex ert
+@cindex tests
+@cindex ert results
+@cindex test results
+@item ert-should
+When on an Emacs Regression Test (ERT) result and not on the first
+line of a result (its name), on a button or at the end of line, search
+for a matching @code{should} clause in the source buffer where the
+associated test is defined.  This speeds debugging when a single test
+name contains many subtests, each with their own unique @code{should}
+clauses.
 @end table
 
 @node Action Buttons,  , Implicit Button Types, Implicit Buttons
@@ -10424,7 +10438,6 @@ If dragged from an Emacs window to outside of Emacs:
 * Smart Key - Ivy::
 * Smart Key - Treemacs::
 * Smart Key - Dired Sidebar Mode::
-* Smart Key - ERT Results Mode::
 * Smart Key - Emacs Pushbuttons::
 * Smart Key - Argument Completion::
 * Smart Key - ID Edit Mode::
@@ -10435,6 +10448,7 @@ If dragged from an Emacs window to outside of Emacs:
 * Smart Key - Hyperbole Buttons::
 * Smart Key - View Mode::
 * Smart Key - Helm Mode::
+* Smart Key - ERT Results Mode::
 * Smart Key - Delimited Things::
 * Smart Key - Occurrence Matches::
 * Smart Key - The Koutliner::
@@ -10601,7 +10615,7 @@ When in a Treemacs file browser buffer:
 @end group
 @end format
 
-@node Smart Key - Dired Sidebar Mode, Smart Key - ERT Results Mode, Smart Key - Treemacs, Smart Keyboard Keys
+@node Smart Key - Dired Sidebar Mode, Smart Key - Emacs Pushbuttons, Smart Key - Treemacs, Smart Keyboard Keys
 @subsection Smart Key - Dired Sidebar Mode
 
 @cindex dired-sidebar-mode
@@ -10629,35 +10643,7 @@ When in a dired-sidebar buffer:
 @end group
 @end format
 
-@node Smart Key - ERT Results Mode, Smart Key - Emacs Pushbuttons, Smart Key - Dired Sidebar Mode, Smart Keyboard Keys
-@subsection Smart Key - ERT Results Mode
-
-@cindex ert-results-mode
-@cindex elisp testing
-@cindex ert
-@cindex regression testing
-@format
-@group
-When in an Emacs Regression Test (ERT) results buffer:
-  ACTION KEY
-     Filters @code{ert-results-mode} test results entries to those
-     matching the result status of the entry at point.  Does nothing
-     if there is no entry at point.
-
-     With point on any of the statistics lines in the top section of the
-     results buffer, does the following:
-       Selector: - toggles showing/hiding all test results
-       Passed:   - shows passed tests only
-       Failed:   - shows failed tests only
-       Skipped:  - shows skipped tests only
-       Total:    - shows all tests
-  ASSIST KEY
-     Displays help documentation for the @code{ert-results-mode} test at point,
-     if any.  Triggers an error if there is no test result at or before point."
-@end group
-@end format
-
-@node Smart Key - Emacs Pushbuttons, Smart Key - Argument Completion, Smart Key - ERT Results Mode, Smart Keyboard Keys
+@node Smart Key - Emacs Pushbuttons, Smart Key - Argument Completion, Smart Key - Dired Sidebar Mode, Smart Keyboard Keys
 @subsection Smart Key - Emacs Pushbuttons
 
 @format
@@ -10865,7 +10851,7 @@ If pressed within a buffer in View major or minor mode:
 @end group
 @end format
 
-@node Smart Key - Helm Mode, Smart Key - Delimited Things, Smart Key - View Mode, Smart Keyboard Keys
+@node Smart Key - Helm Mode, Smart Key - ERT Results Mode, Smart Key - View Mode, Smart Keyboard Keys
 @subsection Smart Key - Helm Mode
 
 Because of the way helm is written, you may need a modified version of
@@ -10907,7 +10893,35 @@ If pressed within a buffer in helm major mode:
 @end group
 @end format
 
-@node Smart Key - Delimited Things, Smart Key - Occurrence Matches, Smart Key - Helm Mode, Smart Keyboard Keys
+@node Smart Key - ERT Results Mode, Smart Key - Delimited Things, Smart Key - Helm Mode, Smart Keyboard Keys
+@subsection Smart Key - ERT Results Mode
+
+@cindex ert-results-mode
+@cindex elisp testing
+@cindex ert
+@cindex regression testing
+@format
+@group
+When in an Emacs Regression Test (ERT) results buffer:
+  ACTION KEY
+     Filters @code{ert-results-mode} test results entries to those
+     matching the result status of the entry at point.  Does nothing
+     if there is no entry at point.
+
+     With point on any of the statistics lines in the top section of the
+     results buffer, does the following:
+       Selector: - toggles showing/hiding all test results
+       Passed:   - shows passed tests only
+       Failed:   - shows failed tests only
+       Skipped:  - shows skipped tests only
+       Total:    - shows all tests
+  ASSIST KEY
+     Displays help documentation for the @code{ert-results-mode} test at point,
+     if any.  Triggers an error if there is no test result at or before point."
+@end group
+@end format
+
+@node Smart Key - Delimited Things, Smart Key - Occurrence Matches, Smart Key - ERT Results Mode, Smart Keyboard Keys
 @subsection Smart Key - Delimited Things
 
 @cindex thing

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     19-Jan-25 at 00:46:05 by Mats Lidell
+;; Last-Mod:     19-Jan-25 at 11:07:35 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1213,7 +1213,7 @@ With point on label suggest that ibut for rename."
       (goto-char 1)
       (set-mark (point))
       (goto-char 4)
-      (hui-kill-region)
+      (hui-kill-region (mark t) (point) 'region)
       (should (string= "{def}ghi" (buffer-string)))
 
       (erase-buffer)
@@ -1222,7 +1222,7 @@ With point on label suggest that ibut for rename."
       (set-mark (point))
       (goto-char 4)
       (deactivate-mark)
-      (hui-kill-region)
+      (hui-kill-region (mark t) (point) 'region)
       (should (string= "{def}ghi" (buffer-string))))
 
     (let ((transient-mark-mode nil))
@@ -1262,7 +1262,7 @@ With point on label suggest that ibut for rename."
       (goto-char 1)
       (set-mark (point))
       (goto-char 4)
-      (hui-kill-region)
+      (hui-kill-region (mark t) (point) 'region)
       (should (string= "abcghi" (buffer-string)))
 
       (erase-buffer)
@@ -1270,7 +1270,7 @@ With point on label suggest that ibut for rename."
       (goto-char 1)
       (set-mark (point))
       (goto-char 4)
-      (hui-kill-region (region-beginning) (region-end))
+      (hui-kill-region (mark t) (point) 'region)
       (should (string= "{def}ghi" (buffer-string)))
 
       (erase-buffer)
@@ -1278,10 +1278,10 @@ With point on label suggest that ibut for rename."
       (goto-char 1)
       (set-mark (point))
       (goto-char 5)
-      (hui-kill-region)
+      (hui-kill-region (mark t) (point) 'region)
       (should (string= "abc{def}ghi" (buffer-string))) ;; Nothing
 
-      (hui-kill-region (region-beginning) (region-end))
+      (hui-kill-region (mark t) (point) 'region)
       (should (string= "def}ghi" (buffer-string))))))
 
 (ert-deftest hui--kill-region-multiple-kill ()

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     19-Jan-25 at 11:07:35 by Bob Weiner
+;; Last-Mod:     20-Jan-25 at 01:39:41 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1173,10 +1173,13 @@ With point on label suggest that ibut for rename."
           (gbut:act "global"))
       (hy-delete-file-and-buffer global-but-file))))
 
-(ert-deftest hui--kill-region ()
-  "Verify `hui-kill-region'."
+(ert-deftest hui--kill-highlighted-region ()
+  "Verify `hui-kill-region'.
+`transient-mark-mode' is enabled and `mark-even-if-inactive' is
+disabled."
   (with-temp-buffer
-    (let ((transient-mark-mode t))
+    (let ((transient-mark-mode t)
+	  (mark-even-if-inactive nil))
       (insert "abc{def}ghi")
       (goto-char 1)
       (set-mark nil)
@@ -1190,42 +1193,56 @@ With point on label suggest that ibut for rename."
       (should (string= "{def}ghi" (buffer-string)))
 
       (erase-buffer)
-      (insert "abc{def}ghi")
+      (insert "abc{def}hig")
       (goto-char 1)
       (set-mark (point))
       (goto-char 4)
       (deactivate-mark)
       (call-interactively #'hui-kill-region)
-      (should (string= "abcghi" (buffer-string)))
+      (should (string= "abchig" (buffer-string)))
 
       (erase-buffer)
-      (insert "abc{def}ghi")
+      (insert "abc{def}igh")
+      (goto-char 1)
+      (set-mark (point))
+      (goto-char 4)
+      (activate-mark)
+      (call-interactively #'hui-kill-region)
+      (should (string= "{def}igh" (buffer-string)))
+
+      (erase-buffer)
+      (insert "bca{def}ghi")
       (goto-char 1)
       (set-mark (point))
       (goto-char 5)
       (deactivate-mark)
-      (call-interactively #'hui-kill-region)
-      (should (string= "def}ghi" (buffer-string)))
+      (should-error (call-interactively #'hui-kill-region) :type 'error)
 
       ;; Not interactive
       (erase-buffer)
-      (insert "abc{def}ghi")
+      (insert "cab{efd}ghi")
       (goto-char 1)
       (set-mark (point))
       (goto-char 4)
-      (hui-kill-region (mark t) (point) 'region)
-      (should (string= "{def}ghi" (buffer-string)))
+      (activate-mark)
+      (hui-kill-region (mark t) (point))
+      (should (string= "{efd}ghi" (buffer-string)))
 
       (erase-buffer)
-      (insert "abc{def}ghi")
+      (insert "bac{def}ghi")
       (goto-char 1)
       (set-mark (point))
       (goto-char 4)
       (deactivate-mark)
-      (hui-kill-region (mark t) (point) 'region)
-      (should (string= "{def}ghi" (buffer-string))))
+      (should-error (hui-kill-region nil (point)) :type 'error))))
 
-    (let ((transient-mark-mode nil))
+(ert-deftest hui--kill-non-highlighted-region ()
+  "Verify `hui-kill-region'.
+`transient-mark-mode' is disabled and `mark-even-if-inactive' is
+enabled."
+  (with-temp-buffer
+    (let ((transient-mark-mode nil)
+	  (mark-even-if-inactive t))
       (erase-buffer)
       (insert "abc{def}ghi")
       (goto-char 1)
@@ -1237,52 +1254,51 @@ With point on label suggest that ibut for rename."
       (set-mark (point))
       (goto-char 4)
       (call-interactively #'hui-kill-region)
-      (should (string= "abcghi" (buffer-string)))
+      (should (string= "{def}ghi" (buffer-string)))
 
       (erase-buffer)
-      (insert "abc{def}ghi")
+      (insert "bca{def}hig")
       (goto-char 1)
       (set-mark (point))
       (goto-char 4)
       (call-interactively #'hui-kill-region)
-      (should (string= "abcghi" (buffer-string)))
+      (should (string= "{def}hig" (buffer-string)))
 
       (erase-buffer)
-      (insert "abc{def}ghi")
+      (insert "cab{def}igh")
       (goto-char 1)
       (set-mark (point))
       (goto-char 5)
       (call-interactively #'hui-kill-region)
-      (should (string= "def}ghi" (buffer-string)))
+      (should (string= "def}igh" (buffer-string)))
 
       ;; Not interactive
 
       (erase-buffer)
-      (insert "abc{def}ghi")
+      (insert "acb{def}gih")
       (goto-char 1)
       (set-mark (point))
       (goto-char 4)
-      (hui-kill-region (mark t) (point) 'region)
-      (should (string= "abcghi" (buffer-string)))
+      (hui-kill-region (mark t) (point))
+      (should (string= "{def}gih" (buffer-string)))
 
       (erase-buffer)
       (insert "abc{def}ghi")
       (goto-char 1)
-      (set-mark (point))
+      (set-mark nil)
       (goto-char 4)
-      (hui-kill-region (mark t) (point) 'region)
-      (should (string= "{def}ghi" (buffer-string)))
+      (should-error (hui-kill-region nil (point)) :type 'error)
 
       (erase-buffer)
-      (insert "abc{def}ghi")
+      (insert "bca{def}hig")
       (goto-char 1)
       (set-mark (point))
       (goto-char 5)
-      (hui-kill-region (mark t) (point) 'region)
-      (should (string= "abc{def}ghi" (buffer-string))) ;; Nothing
+      (hui-kill-region (mark t) (point))
+      (should (string= "def}hig" (buffer-string)))
 
-      (hui-kill-region (mark t) (point) 'region)
-      (should (string= "def}ghi" (buffer-string))))))
+      (hui-kill-region (mark t) (point))
+      (should (string= "def}hig" (buffer-string))))))
 
 (ert-deftest hui--kill-region-multiple-kill ()
   "Verify `hui-kill-region' saves to the yank ring on multiple kills.
@@ -1290,7 +1306,8 @@ See test case `kill-whole-line-after-other-kill' and others in
 simple-tests.el for prior art of forcing values on `last-command'."
   ;; Two regions
   (with-temp-buffer
-    (let ((transient-mark-mode t))
+    (let ((transient-mark-mode t)
+	  (mark-even-if-inactive nil))
       (insert "123456")
       (goto-char 2)
       (set-mark (point))
@@ -1306,7 +1323,8 @@ simple-tests.el for prior art of forcing values on `last-command'."
 
   ;; Kill line followed by kill of a region
   (with-temp-buffer
-    (let ((transient-mark-mode t))
+    (let ((transient-mark-mode t)
+	  (mark-even-if-inactive nil))
       (insert "\
 line 1
 1234")
@@ -1324,7 +1342,8 @@ line 1
 
   ;; Two consecutive kill thing
   (with-temp-buffer
-    (let ((transient-mark-mode t))
+    (let ((transient-mark-mode t)
+	  (mark-even-if-inactive nil))
       (insert "abc{def}{ghi}jkl")
       (goto-char 1)
       (set-mark (point))


### PR DESCRIPTION
- [hsys-ert.el - Add `ert-should' ibtype to jump to should clauses](https://github.com/rswgnu/hyperbole/commit/1b09a8cb1818baf2771cb1532809877820f05260)

- [hypb:with-marker - Add this context macro that sets markers to nil](https://github.com/rswgnu/hyperbole/commit/3d1bb9325e14410039ca0ca70705a9358c280bad)

- [hui.el, hui-tests.el - Rewrite Hyperbole {C-w} and {M-w} commands](https://github.com/rswgnu/hyperbole/commit/ee9d530dd5c633a65640296ca919bbdc4e9716d2)