### PR TITLE
make failing test case succeed on test all

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@
 
 * test/hy-test-helpers.el (hy-make-random-wikiword): Helper for making
     random WikiWords.
+    (hy-test-make-random-wikiword): Add test.
 
 2025-01-20  Bob Weiner  <rsw@gnu.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,8 +1,12 @@
 2025-01-20  Mats Lidell  <matsl@gnu.org>
 
+* test/test-helpers-tests.el (test-helpers-test--make-random-wikiword):
+    Add test.
+
+* test/MANIFEST: Test file for the test helpers.
+
 * test/hy-test-helpers.el (hy-make-random-wikiword): Helper for making
     random WikiWords.
-    (hy-test-make-random-wikiword): Add test.
 
 2025-01-20  Bob Weiner  <rsw@gnu.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2025-01-20  Mats Lidell  <matsl@gnu.org>
+
+* test/hy-test-helpers.el (hy-make-random-wikiword): Helper for making
+    random WikiWords.
+
 2025-01-20  Bob Weiner  <rsw@gnu.org>
 
 * hsys-ert.el (require 'hbut): For 'defib'.

--- a/test/MANIFEST
+++ b/test/MANIFEST
@@ -30,3 +30,4 @@ kotl-mode-tests.el      - kotl-mode-el tests
 kotl-orgtbl-tests.el    - kotl orgtbl tests
 set-tests.el            - mathematical set library tests
 smart-org-tests.el      - smart-org-el tests
+test-helpers-tests.el   - unit test of the test helpers

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -3,11 +3,11 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     20-Jan-25 at 01:39:41 by Bob Weiner
+;; Last-Mod:     21-Jan-25 at 17:05:46 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
-;; Copyright (C) 2021-2024  Free Software Foundation, Inc.
+;; Copyright (C) 2021-2025  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.

--- a/test/hy-test-helpers.el
+++ b/test/hy-test-helpers.el
@@ -3,11 +3,11 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     20-Jan-25 at 20:21:34 by Mats Lidell
+;; Last-Mod:     21-Jan-25 at 17:02:36 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
-;; Copyright (C) 2021-2024  Free Software Foundation, Inc.
+;; Copyright (C) 2021-2025  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.

--- a/test/hy-test-helpers.el
+++ b/test/hy-test-helpers.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     20-Jan-25 at 00:24:32 by Mats Lidell
+;; Last-Mod:     20-Jan-25 at 20:13:23 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -101,8 +101,10 @@ Checks ACTYPE, ARGS, LOC, LBL-KEY and NAME."
     (delete-directory dir)))
 
 (defun hy-make-random-wikiword (&optional length word-length)
-  "Return a random WikiWord of LENGTH and with WORD-LENGTH.
-Default LENGTH is 12 and default WORD-LENGTH is 4."
+  "Create a random WikiWord (string).
+The WikiWord will have a total of LENGTH characters.  Each word part of
+the WikiWord will have WORD-LENGTH characters.  The default LENGTH is 12
+and the default WORD-LENGTH is 4."
   (unless length
     (setq length 12))
   (unless word-length
@@ -114,6 +116,16 @@ Default LENGTH is 12 and default WORD-LENGTH is 4."
         (setq result (concat result " ")))
       (setq result (concat result (char-to-string (elt chars (random (length chars)))))))
     (replace-regexp-in-string "[[:space:]]" "" (capitalize result))))
+
+(ert-deftest hy-test-make-random-wikiword ()
+  "Verify `hy-make-random-wikiword'."
+  (should (= 12 (length (hy-make-random-wikiword))))
+  (dolist (wwl '(3 9 21))
+    (dolist (wl '(2 3 9))
+      (let ((ww (hy-make-random-wikiword wwl wl)))
+        (should (= wwl (length ww)))
+        (should (char-uppercase-p (string-to-char (substring ww 0 1))))
+        (should-not (char-uppercase-p (string-to-char (substring ww 1 2))))))))
 
 (provide 'hy-test-helpers)
 ;;; hy-test-helpers.el ends here

--- a/test/hy-test-helpers.el
+++ b/test/hy-test-helpers.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     15-Dec-24 at 14:24:42 by Bob Weiner
+;; Last-Mod:     20-Jan-25 at 00:24:32 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -99,6 +99,21 @@ Checks ACTYPE, ARGS, LOC, LBL-KEY and NAME."
     (when buf
       (kill-buffer buf))
     (delete-directory dir)))
+
+(defun hy-make-random-wikiword (&optional length word-length)
+  "Return a random WikiWord of LENGTH and with WORD-LENGTH.
+Default LENGTH is 12 and default WORD-LENGTH is 4."
+  (unless length
+    (setq length 12))
+  (unless word-length
+    (setq word-length 4))
+  (let ((chars (vconcat (number-sequence ?a ?z)))
+        (result ""))
+    (dotimes (i length)
+      (when (zerop (mod i word-length))
+        (setq result (concat result " ")))
+      (setq result (concat result (char-to-string (elt chars (random (length chars)))))))
+    (replace-regexp-in-string "[[:space:]]" "" (capitalize result))))
 
 (provide 'hy-test-helpers)
 ;;; hy-test-helpers.el ends here

--- a/test/hy-test-helpers.el
+++ b/test/hy-test-helpers.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     20-Jan-25 at 20:13:23 by Mats Lidell
+;; Last-Mod:     20-Jan-25 at 20:21:34 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -116,16 +116,6 @@ and the default WORD-LENGTH is 4."
         (setq result (concat result " ")))
       (setq result (concat result (char-to-string (elt chars (random (length chars)))))))
     (replace-regexp-in-string "[[:space:]]" "" (capitalize result))))
-
-(ert-deftest hy-test-make-random-wikiword ()
-  "Verify `hy-make-random-wikiword'."
-  (should (= 12 (length (hy-make-random-wikiword))))
-  (dolist (wwl '(3 9 21))
-    (dolist (wl '(2 3 9))
-      (let ((ww (hy-make-random-wikiword wwl wl)))
-        (should (= wwl (length ww)))
-        (should (char-uppercase-p (string-to-char (substring ww 0 1))))
-        (should-not (char-uppercase-p (string-to-char (substring ww 1 2))))))))
 
 (provide 'hy-test-helpers)
 ;;; hy-test-helpers.el ends here

--- a/test/hycontrol-tests.el
+++ b/test/hycontrol-tests.el
@@ -3,11 +3,11 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:     8-Jan-25 at 22:52:00
-;; Last-Mod:      8-Jan-25 at 23:13:27 by Mats Lidell
+;; Last-Mod:     21-Jan-25 at 17:03:54 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
-;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
+;; Copyright (C) 2025  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.

--- a/test/hyrolo-tests.el
+++ b/test/hyrolo-tests.el
@@ -3,11 +3,11 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    19-Jun-21 at 22:42:00
-;; Last-Mod:     18-Jan-25 at 22:46:39 by Bob Weiner
+;; Last-Mod:     21-Jan-25 at 17:04:35 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
-;; Copyright (C) 2021-2024  Free Software Foundation, Inc.
+;; Copyright (C) 2021-2025  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -7,7 +7,7 @@
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
-;; Copyright (C) 2024  Free Software Foundation, Inc.
+;; Copyright (C) 2024-2025  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -893,16 +893,36 @@ Note special meaning of `hywiki-allow-plurals-flag'."
 
 (ert-deftest hywiki-tests--add-org-roam-node ()
   "Verify `hywiki-add-org-roam-node'."
-  (let ((hywiki-directory (make-temp-file "hywiki" t))
-	(wikiword "WikiWord"))
+  (let* ((hywiki-directory (make-temp-file "hywiki" t))
+         (wiki-page (cdr (hywiki-add-page "FirstWord")))
+	 (wikiword (hy-make-random-wikiword)))
     (unwind-protect
         (mocklet (((hypb:require-package 'org-roam) => t)
-		  ((org-roam-node-read) => t)
-		  ((org-roam-node-title t) => "org-roam-node"))
+		  ((org-roam-node-read) => "node")
+		  ((org-roam-node-title "node") => "node-title"))
 	  (hywiki-add-org-roam-node wikiword)
-          (should (equal '(org-roam-node . "org-roam-node")
+          (should (equal '(org-roam-node . "node-title")
 			 (hywiki-get-referent wikiword))))
+      (hy-delete-file-and-buffer wiki-page)
       (hy-delete-dir-and-buffer hywiki-directory))))
+
+;;; FIXME
+;; Without creating an initial page the test case above oddly fails on
+;; first run when executed interactively in a fresh Emacs. Such as
+;; running "make all-tests" in a shell. Why?
+;;
+;; (ert-deftest hywiki-tests--add-org-roam-node ()
+;;   "Verify `hywiki-add-org-roam-node'."
+;;   (let* ((hywiki-directory (make-temp-file "hywiki" t))
+;; 	 (wikiword (hy-make-random-wikiword)))
+;;     (unwind-protect
+;;         (mocklet (((hypb:require-package 'org-roam) => t)
+;; 		  ((org-roam-node-read) => "node")
+;; 		  ((org-roam-node-title "node") => "node-title"))
+;; 	  (hywiki-add-org-roam-node wikiword)
+;;           (should (equal '(org-roam-node . "node-title")
+;; 			 (hywiki-get-referent wikiword))))
+;;       (hy-delete-dir-and-buffer hywiki-directory))))
 
 (provide 'hywiki-tests)
 ;;; hywiki-tests.el ends here

--- a/test/test-helpers-tests.el
+++ b/test/test-helpers-tests.el
@@ -3,11 +3,11 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    20-Jan-25 at 20:22:05
-;; Last-Mod:     20-Jan-25 at 20:56:51 by Mats Lidell
+;; Last-Mod:     21-Jan-25 at 17:02:12 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
-;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
+;; Copyright (C) 2025  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.

--- a/test/test-helpers-tests.el
+++ b/test/test-helpers-tests.el
@@ -1,0 +1,35 @@
+;;; test-helpers-tests.el --- tests of the test helpers -*- lexical-binding: t; -*-
+;;
+;; Author:       Mats Lidell
+;;
+;; Orig-Date:    20-Jan-25 at 20:22:05
+;; Last-Mod:     20-Jan-25 at 20:44:26 by Mats Lidell
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
+;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
+;; See the "HY-COPY" file for license information.
+;;
+;; This file is part of GNU Hyperbole.
+
+;;; Commentary:
+;;
+;; These are tests for the test helpers used in other tests.
+
+;;; Code:
+
+(require 'ert)
+(require 'hy-test-helpers)
+
+(ert-deftest test-helpers-test--make-random-wikiword ()
+  "Verify hy-make-random-wikiword."
+  (should (= 12 (length (hy-make-random-wikiword))))
+  (dolist (wwl '(3 9 21))
+    (dolist (wl '(2 3 9))
+      (let ((ww (hy-make-random-wikiword wwl wl)))
+        (should (= wwl (length ww)))
+        (should (char-uppercase-p (string-to-char (substring ww 0 1))))
+        (should-not (char-uppercase-p (string-to-char (substring ww 1 2))))))))
+
+(provide 'test-helpers-tests)
+;;; test-helpers-tests.el ends here

--- a/test/test-helpers-tests.el
+++ b/test/test-helpers-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    20-Jan-25 at 20:22:05
-;; Last-Mod:     20-Jan-25 at 20:44:26 by Mats Lidell
+;; Last-Mod:     20-Jan-25 at 20:56:51 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -20,6 +20,15 @@
 
 (require 'ert)
 (require 'hy-test-helpers)
+
+(unless (fboundp #'char-uppercase-p)
+  (defun char-uppercase-p (char)
+    "Return non-nil if CHAR is an upper-case character.
+If the Unicode tables are not yet available, e.g. during bootstrap,
+then gives correct answers only for ASCII characters."
+    (cond ((unicode-property-table-internal 'lowercase)
+           (characterp (get-char-code-property char 'lowercase)))
+          ((<= ?A char ?Z)))))
 
 (ert-deftest test-helpers-test--make-random-wikiword ()
   "Verify hy-make-random-wikiword."


### PR DESCRIPTION
# What

- Add helper for making random WikiWord suitable for tests
- Modify test to succeed on test-all

# Why

Test fails on make test-all and this PR installs a work-around by
creating an unused initial WikiPage which seems to fix the issue. The
failing test case is left commented out in the code for later
investigation and ideas what can cause this.
