### PR TITLE
remove compiler warnings

### DIFF
--- a/hsys-ert.el
+++ b/hsys-ert.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Jan-25
-;; Last-Mod:     20-Jan-25 at 02:00:12 by Bob Weiner
+;; Last-Mod:     20-Jan-25 at 23:57:21 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -47,6 +47,7 @@
 ;;; ************************************************************************
 
 (require 'hbut)  ;; For defib
+(require 'hmouse-tag)  ;; For smart-lisp
 
 ;;; ************************************************************************
 ;;; Implicit button types

--- a/hui.el
+++ b/hui.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 21:42:03
-;; Last-Mod:     20-Jan-25 at 00:40:40 by Bob Weiner
+;; Last-Mod:     21-Jan-25 at 00:23:41 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -2047,7 +2047,7 @@ Buffer without File      link-to-buffer-tmp"
 	  lst))
 
 (defun hui:validate-region (beg end region)
-  "Trigger a user error unless both BEG and END are whole numbers or REGION is non-nil."
+  "Trigger a user error unless BEG and END are whole numbers or REGION is non-nil."
   (unless (or (and (number-or-marker-p beg) (number-or-marker-p end)) region)
     (user-error "The mark is not set now, so there is no region")))
 

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Apr-24 at 22:41:13
-;; Last-Mod:     18-Jan-25 at 23:45:34 by Bob Weiner
+;; Last-Mod:     21-Jan-25 at 00:20:28 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -166,9 +166,11 @@
 (declare-function bookmark-location "bookmark" (bookmark-name-or-record))
 (declare-function hsys-org-at-tags-p "hsys-org")
 (declare-function org-link-store-props "ol" (&rest plist))
+(declare-function org-publish-property "ox-publish" (property project &optional default))
+(declare-function org-roam-node-from-title-or-alias "org-roam-node" (s &optional nocase))
 (declare-function org-roam-node-open "org-roam" (note &optional cmd force))
 (declare-function org-roam-node-read "org-roam" (&optional initial-input filter-fn sort-fn require-match prompt))
-(declare-function org-publish-property "ox-publish" (property project &optional default))
+(declare-function org-roam-node-title "org-roam-node" (node))
 (declare-function smart-treemacs-edit "hui-treemacs" (&optional dir))
 
 ;;; ************************************************************************


### PR DESCRIPTION
# What

- Shorten doc string
- Declare unknown functions and sort declarations
- Require hmouse.tag for getting smart-lisp

# Why

There are warnings that can be silenced and that is a good thing.
