### PR TITLE
Shorten docstring and fix quotes for variable

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2025-01-27  Mats Lidell  <matsl@gnu.org>
+
+* hywiki.el (hywiki-cache-save): Shorten docstring.
+
 2025-01-26  Mats Lidell  <matsl@gnu.org>
 
 * .github/workflows/static.yaml: Remove deploy static content to pages

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Apr-24 at 22:41:13
-;; Last-Mod:     26-Jan-25 at 18:01:00 by Bob Weiner
+;; Last-Mod:     27-Jan-25 at 18:17:45 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -2369,9 +2369,10 @@ absolute path."
 	  buffer-read-only nil)))
 
 (defun hywiki-cache-save (&optional save-file)
-  "Save the modified Environment to a file given by optional SAVE-FILE or `hywiki-cache-file'.
-Also saves and potentially sets `hywiki--directory-mod-time' and
- hywiki--directory-checksum'."
+  "Save the modified Environment to a file.
+The file is given by optional SAVE-FILE or `hywiki-cache-file'.  Also
+save and potentially set `hywiki--directory-mod-time' and
+`hywiki--directory-checksum'."
   (when (or (not (stringp save-file)) (equal save-file ""))
     (setq save-file (hywiki-cache-default-file)))
   (setq save-file (expand-file-name save-file hywiki-directory))


### PR DESCRIPTION
# What

Fix docstring length and missing quote from variable.

# Why

Lines of a docstring should be shorter than 80 chars.

# Note

There was a small docstring issue with the latest merge. I made my suggested fix as a patch against master after pushing. It was so small change so I thought it could be done separately from pushing to savannah.
