### PR TITLE
refactor make output to be cleaner

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@
 * Makefile (HYPB_GEN, HYPB_ELC, HYPB_ELC_ELN, HYPB_at): Verbosity macros.
     (VERSIONFLAGS, emacs-environment): Extract to own target to reduce
     noise in regular builds.
+    (HYPB_BIN_WARN): Set default to 'all.
 
 2025-01-27  Mats Lidell  <matsl@gnu.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2025-01-29  Mats Lidell  <matsl@gnu.org>
+
+* Makefile (HYPB_GEN, HYPB_ELC, HYPB_ELC_ELN, HYPB_at): Verbosity macros.
+    (VERSIONFLAGS, emacs-environment): Extract to own target to reduce
+    noise in regular builds.
+
 2025-01-27  Mats Lidell  <matsl@gnu.org>
 
 * hywiki.el (hywiki-cache-save): Shorten docstring.

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:     29-Jan-25 at 17:15:04 by Mats Lidell
+# Last-Mod:     29-Jan-25 at 22:02:28 by Mats Lidell
 #
 # Copyright (C) 1994-2023  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -331,16 +331,16 @@ $(data_dir)/hkey-help.txt: $(man_dir)/hkey-help.txt
 src: autoloads tags
 
 # Byte compile files but apply a filter for either including or
-# removing warnings.  See variable {C-hv byte-compile-warnings RET} for
-# list of warnings that can be controlled.  Default is set to suppress
-# warnings for long docstrings.
+# removing warnings.  See variable {C-hv byte-compile-warnings RET}
+# for list of warnings that can be controlled.  Default is set to 'all
+# from emacs versions that define `byte-compile--emacs-build-warning-types'.
 #
 # Example for getting warnings for obsolete functions and variables
 #   HYPB_WARNINGS="free-vars" make bin
 # Example for surpressing the free-vars warnings
 #   HYPB_WARNINGS="not free-vars" make bin
 ifeq ($(origin HYPB_WARNINGS), undefined)
-HYPB_BIN_WARN =
+HYPB_BIN_WARN = --eval "(setq-default byte-compile-warnings (if (boundp 'byte-compile--emacs-build-warning-types) 'all t))"
 else ifeq ($(origin HYPB_WARNINGS), environment)
 HYPB_BIN_WARN = --eval "(setq-default byte-compile-warnings '(${HYPB_WARNINGS}))"
 endif
@@ -350,13 +350,13 @@ ifeq ($(HYPB_NATIVE_COMP),yes)
 %.elc: %.el
 	$(HYPB_ELN_ELC)$(EMACS) --batch --quick \
 	--eval "(progn (add-to-list 'load-path \"$(curr_dir)\") (add-to-list 'load-path \"$(curr_dir)/kotl\"))" \
-	${HYPB_BIN_WARN} \
+	-l bytecomp ${HYPB_BIN_WARN} \
 	-f batch-native-compile $<
 else
 %.elc: %.el
 	$(HYPB_ELC)$(EMACS) --batch --quick \
 	--eval "(progn (add-to-list 'load-path \"$(curr_dir)\") (add-to-list 'load-path \"$(curr_dir)/kotl\"))" \
-	${HYPB_BIN_WARN} \
+	-l bytecomp ${HYPB_BIN_WARN} \
 	-f batch-byte-compile $<
 endif
 

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:     19-Jan-25 at 17:56:38 by Bob Weiner
+;; Last-Mod:     29-Jan-25 at 10:07:49 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -95,19 +95,19 @@
 ;;; Supports jumping to Emacs Regression Test (ert) 'should' source lines
 ;;; ========================================================================
 
-(load "hsys-ert")
+(load "hsys-ert" nil t)
 
 ;;; ========================================================================
 ;;; Displays Org and Org Roam files and sections by name link
 ;;; ========================================================================
 
-(load "hynote")
+(load "hynote" nil t)
 
 ;;; ========================================================================
 ;;; Creates and displays personal wiki pages and sections with auto-wikiword links
 ;;; ========================================================================
 
-(load "hywiki")
+(load "hywiki" nil t)
 
 ;;; ========================================================================
 ;;; Jumps to source line from Python traceback lines
@@ -128,13 +128,13 @@ line and check for a source reference line again."
 ;;; ert-deftest ibtype executes current ert test when on first line of def.
 ;;; ========================================================================
 
-(load "hypb-ert")
+(load "hypb-ert" nil t)
 
 ;;; ========================================================================
 ;;; Handles social media hashtag and username references, e.g. twitter#myhashtag
 ;;; ========================================================================
 
-(load "hib-social")
+(load "hib-social" nil t)
 
 ;;; ========================================================================
 ;;; Displays Org Roam and Org IDs.
@@ -366,7 +366,7 @@ display options."
 ;;; Follows URLs by invoking a web browser.
 ;;; ========================================================================
 
-(load "hsys-www")
+(load "hsys-www" nil t)
 
 ;;; ========================================================================
 ;;; Uses web browser to display links to Hyperbole HTML manual sections;
@@ -755,13 +755,13 @@ spaces and then another non-space, non-parenthesis, non-brace character."
 ;;; Handles Gnu debbugs issue ids, e.g. bug#45678 or just 45678.
 ;;; ========================================================================
 
-(load "hib-debbugs")
+(load "hib-debbugs" nil t)
 
 ;;; ========================================================================
 ;;; Executes or documents command bindings of brace delimited key sequences.
 ;;; ========================================================================
 
-(load "hib-kbd")
+(load "hib-kbd" nil t)
 
 ;;; ========================================================================
 ;;; Makes Internet RFC references retrieve the RFC.
@@ -823,7 +823,7 @@ Requires the Emacs builtin Tramp library for ftp file retrievals."
 ;;; Follows links to Hyperbole Koutliner cells.
 ;;; ========================================================================
 
-(load "klink")
+(load "klink" nil t)
 
 ;;; ========================================================================
 ;;; Links to Hyperbole button types

--- a/hload-path.el
+++ b/hload-path.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    29-Jun-16 at 14:39:33
-;; Last-Mod:     29-Jan-25 at 09:56:50 by Mats Lidell
+;; Last-Mod:     29-Jan-25 at 19:07:46 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -136,7 +136,7 @@ DIR can be either a single directory or a list of
 directories.  (The latter usage is discouraged.)
 
 The autoloads will be written to OUTPUT-FILE.  If any Lisp file
-binds ‘generated-autoload-file’ as a file-local variable, write
+binds `generated-autoload-file' as a file-local variable, write
 its autoloads into the specified file instead.
 
 The function does NOT recursively descend into subdirectories of the

--- a/hload-path.el
+++ b/hload-path.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    29-Jun-16 at 14:39:33
-;; Last-Mod:     21-Mar-24 at 11:35:21 by Bob Weiner
+;; Last-Mod:     29-Jan-25 at 09:56:50 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -187,10 +187,10 @@ This is used only when running from git source and not a package release."
 	 (kotl-autoloads (expand-file-name "kotl/kotl-autoloads.el")))
     (unless (featurep 'hyperbole-autoloads)
       (when (file-readable-p hypb-autoloads)
-        (load-file hypb-autoloads)))
+        (load hypb-autoloads nil t)))
     (unless (featurep 'kotl-autoloads)
       (when (file-readable-p kotl-autoloads)
-        (load-file kotl-autoloads)))))
+        (load kotl-autoloads nil t)))))
 
 ;; Ensure *-autoloads.el files are already generated or generate them.
 ;; Then ensure they are loaded.

--- a/hmouse-tag.el
+++ b/hmouse-tag.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    24-Aug-91
-;; Last-Mod:     26-Jan-25 at 10:33:32 by Bob Weiner
+;; Last-Mod:     29-Jan-25 at 20:12:31 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -25,7 +25,7 @@
     ;; Force use of .elc file here since otherwise the bin/etags
     ;; executable might be found in a user's load-path by the load
     ;; command.
-    (load "etags.elc" t nil t)))
+    (load "etags.elc" t t t)))
 
 (require 'hsys-xref)
 

--- a/hmouse-tag.el
+++ b/hmouse-tag.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    24-Aug-91
-;; Last-Mod:     29-Jan-25 at 20:12:31 by Mats Lidell
+;; Last-Mod:     29-Jan-25 at 20:26:54 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -68,22 +68,22 @@
 
 (defconst find-defact-regexp "^\\s-*(defact\\s-+%s\\s-"
   "The regexp used to search for a Hyperbole action type definition.
-Note it must contain a ‘%s’ at the place where ‘format’
+Note it must contain a '%s' at the place where `format'
 should insert the action type definition name.")
 
 (defconst find-defal-regexp "^\\s-*(defal\\s-+%s\\s-"
   "The regexp used to search for a Hyperbole action link type definition.
-Note it must contain a ‘%s’ at the place where ‘format’
+Note it must contain a '%s' at the place where `format'
 should insert the action link type definition name.")
 
 (defconst find-defib-regexp "^\\s-*(defib\\s-+%s\\s-"
   "The regexp used to search for a Hyperbole implicit button type definition.
-Note it must contain a ‘%s’ at the place where ‘format’
+Note it must contain a '%s' at the place where `format'
 should insert the implicit button type definition name.")
 
 (defconst find-defil-regexp "^\\s-*(defil\\s-+%s\\s-"
   "The regexp used to search for a Hyperbole implicit link type definition.
-Note it must contain a ‘%s’ at the place where ‘format’
+Note it must contain a '%s' at the place where `format’
 should insert the implicit link type definition name.")
 
 ;; Change ert-deftest lookups to use this regexp rather than the
@@ -94,7 +94,7 @@ should insert the implicit link type definition name.")
 ;; entry in `find-function-regexp-alist' is a regexp.
 (defconst find-ert-test-regexp "^\\s-*(ert-deftest\\s-+%s\\s-"
   "The regexp used to search for an ert test definition.
-Note it must contain a ‘%s’ at the place where ‘format’
+Note it must contain a '%s' at the place where `format'
 should insert the implicit link type definition name.")
 
 ;; Add Hyperbole def types to `find-function-regexp-alist'.

--- a/hycontrol.el
+++ b/hycontrol.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Jun-16 at 15:35:36
-;; Last-Mod:      8-Jan-25 at 22:49:42 by Mats Lidell
+;; Last-Mod:     29-Jan-25 at 19:05:16 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -839,7 +839,7 @@ HEIGHT lines but that the idea of the actual height of the frame should
 not be changed.
 
 Optional fourth argument PIXELWISE non-nil means that FRAME should be
-HEIGHT pixels high.  Note: When ‘frame-resize-pixelwise’ is nil, some
+HEIGHT pixels high.  Note: When `frame-resize-pixelwise’ is nil, some
 window managers may refuse to honor a HEIGHT that is not an integer
 multiple of the default frame font height."
   (let ((frame-resize-pixelwise t))
@@ -863,7 +863,7 @@ bottom edge of FRAME’s display."
 Ensure frame fits within the screen size.
 
 Optional argument PIXELWISE non-nil means to measure in pixels.  Note:
-When ‘frame-resize-pixelwise’ is nil, some window managers may refuse to
+When `frame-resize-pixelwise’ is nil, some window managers may refuse to
 honor a WIDTH that is not an integer multiple of the default frame font
 width or a HEIGHT that is not an integer multiple of the default frame
 font height."
@@ -880,7 +880,7 @@ columns but that the idea of the actual width of the frame should not
 be changed.
 
 Optional fourth argument PIXELWISE non-nil means that FRAME should be
-WIDTH pixels wide.  Note: When ‘frame-resize-pixelwise’ is nil, some
+WIDTH pixels wide.  Note: When `frame-resize-pixelwise’ is nil, some
 window managers may refuse to honor a WIDTH that is not an integer
 multiple of the default frame font width."
   (let ((x-origin (hycontrol-frame-x-origin))

--- a/hypb.el
+++ b/hypb.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     6-Oct-91 at 03:42:38
-;; Last-Mod:     19-Jan-25 at 15:01:21 by Bob Weiner
+;; Last-Mod:     29-Jan-25 at 20:27:07 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1029,9 +1029,9 @@ found match."
 (defun hypb:toggle-isearch-invisible (&optional arg)
   "Toggle interactive invisible searching on or off.
 This determines whether to search inside invisible text or not.
-Toggles the variable ‘isearch-invisible’ between values
-nil and a non-nil value of the option ‘search-invisible’
-\(or ‘open’ if ‘search-invisible’ is nil).
+Toggles the variable `isearch-invisible' between values
+nil and a non-nil value of the option `search-invisible’
+\(or `open' if `search-invisible' is nil).
 
 With optional prefix ARG > 0, turn on searching invisible text.
 If ARG <= 0, turn search only visible text."

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Apr-24 at 22:41:13
-;; Last-Mod:     27-Jan-25 at 18:17:45 by Mats Lidell
+;; Last-Mod:     29-Jan-25 at 19:13:12 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1199,7 +1199,7 @@ This replaces any existing referent the WIKIWORD may have.
 
 With either `hywiki-referent-prompt-flag' set or optional prefix ARG,
 prompt for and choose a typed referent, otherwise, create and/or display
-a HyWiki page.  See ‘hywiki-referent-menu’ for valid referent types.
+a HyWiki page.  See `hywiki-referent-menu' for valid referent types.
 
 Use `hywiki-get-referent' to test for and retrieve an existing HyWikiWord
 referent."
@@ -1222,7 +1222,7 @@ referent."
 If there is no existing WIKIWORD referent, add one.
 With either `hywiki-referent-prompt-flag' set or optional prefix ARG,
 prompt for and choose a typed referent, otherwise, create and/or display
-a HyWiki page.  See ‘hywiki-referent-menu’ for valid referent types.
+a HyWiki page.  See `hywiki-referent-menu' for valid referent types.
 
 Use `hywiki-get-referent' to determine whether a HyWikiWord referent
 exists."
@@ -1242,7 +1242,7 @@ exists."
 (defun hywiki-create-referent-and-display (wikiword)
   "Display the HyWiki referent for WIKIWORD and return it.
 If there is no existing WIKIWORD referent, prompt for and choose
-a referent type; see ‘hywiki-referent-menu’ for valid referent
+a referent type; see `hywiki-referent-menu' for valid referent
 types.
 
 Use `hywiki-get-referent' to determine whether a HyWikiWord referent
@@ -1255,7 +1255,7 @@ exists."
   "Display the HyWiki referent for WIKIWORD and return it.
 If there is no existing WIKIWORD referent, add a HyWiki page for
 it unless optional prefix arg, PROMPT-FLAG, is given, then prompt
-for and create another referent type.  See ‘hywiki-referent-menu’
+for and create another referent type.  See `hywiki-referent-menu'
 for valid referent types.
 
 Use `hywiki-get-referent' to determine whether a HyWiki page exists."

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:      5-Jan-25 at 11:15:10 by Bob Weiner
+;; Last-Mod:     29-Jan-25 at 18:57:50 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -3166,7 +3166,7 @@ When called interactively, it displays the value in the minibuffer."
 ;;; ------------------------------------------------------------------------
 
 (defun kotl-mode:org-delete-backward-char (n)
-  "Like ‘delete-backward-char’, insert whitespace at field end in tables.
+  "Like `delete-backward-char', insert whitespace at field end in tables.
 When deleting backwards, in tables this function will insert whitespace in
 front of the next \"|\" separator, to keep the table aligned.  The table will
 still be marked for re-alignment if the field did fill the entire column,
@@ -3176,7 +3176,7 @@ because, in this case the deletion might narrow the column."
    (lambda () (org-delete-backward-char n))))
 
 (defun kotl-mode:org-delete-char (n)
-  "Like ‘delete-char’, but insert whitespace at field end in tables.
+  "Like `delete-char', but insert whitespace at field end in tables.
 When deleting characters, in tables this function will insert whitespace in
 front of the next \"|\" separator, to keep the table aligned.  The table will
 still be marked for re-alignment if the field did fill the entire column,

--- a/kotl/kview.el
+++ b/kotl/kview.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:     27-Jan-24 at 23:43:15 by Bob Weiner
+;; Last-Mod:     29-Jan-25 at 19:07:24 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1011,9 +1011,9 @@ than the bounds of the active region.
 
 FUNC should take no arguments and should operate upon the cell at point.
 
-`lbl-sep-len’ contains the label separator length.
+`lbl-sep-len' contains the label separator length.
 
-See also `kview:map-tree', `kview:map-branch’, and ‘kview:map-siblings’."
+See also `kview:map-tree', `kview:map-branch', and `kview:map-siblings'."
   (with-current-buffer (kview:buffer kview)
     (save-excursion
       (let* ((results)


### PR DESCRIPTION
# What

- Add verbosity macros for a cleaner build experience
- Make loads silent for a cleaner build experience
- Set byte-compile-warnings to 'all
- Remove warnings for docstring uses curved single quotes

_It seems you need to control or shift click for getting to the build step directly on these links below._

[Example of new build compile step - master](https://github.com/rswgnu/hyperbole/actions/runs/13041075895/job/36382851585?pr=657#step:5:1) 

[Example of old build compile step - master](https://github.com/rswgnu/hyperbole/actions/runs/13006602380/job/36274760200#step:5:1)

# Why

A cluttered build output makes it harder to see issues. This PR is
inspired by the Emacs make file for the representation of each build
step using macros for controlling output and verbosity. 

Load messages have been silenced to make it even further clean.

In addition to that the "new" feature of allowing new warnings, still
not in the default set, to be active, has been applied and the
warnings have been fixed.

# Note

There is an issue with `string-replace` for 27.2 that is not part of
this PR. It does not affect the unit tests and has been going under
our radar. It is more visible when the output from the build is
stripped from noise.
