### PR TITLE
Use replace-regexp-in-string for compatibility with Emacs 27.2

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2025-01-30  Mats Lidell  <matsl@gnu.org>
+
+* hui-mini.el (hui:menu-read-from-minibuffer): Use
+    replace-regexp-in-string for compatibility with Emacs 27.2.
+
 2025-01-29  Mats Lidell  <matsl@gnu.org>
 
 * Makefile (HYPB_GEN, HYPB_ELC, HYPB_ELC_ELN, HYPB_at): Verbosity macros.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 2025-01-30  Mats Lidell  <matsl@gnu.org>
 
+* test/hui-mini-tests.el (hui--menu-read-from-minibuffer): Unit test.
+
+* test/MANIFEST: Added hui-mini-tests.el.
+
+* test/hui-mini-tests.el: New file. Test for hui-mini.
+
 * hui-mini.el (hui:menu-read-from-minibuffer): Use
     replace-regexp-in-string for compatibility with Emacs 27.2.
 

--- a/hui-mini.el
+++ b/hui-mini.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Oct-91 at 20:13:17
-;; Last-Mod:     18-Jan-25 at 13:57:49 by Bob Weiner
+;; Last-Mod:     30-Jan-25 at 19:44:11 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -22,8 +22,6 @@
 (require 'browse-url)
 (require 'hsettings)                    ; For hyperbole-web-search-alist
 (require 'hypb)
-(unless (fboundp 'string-replace)
-  (load "subr")) ;; for `string-replace'
 
 ;;; ************************************************************************
 ;;; Public declarations
@@ -424,9 +422,9 @@ Allows custom handling of menu lines before selecting an item."
 				   org-m-ret-options))
 	   (current-name (cdr (assq hsys-org-enable-smart-keys option-lookups))))
       (when (and (stringp current-name) (stringp initial-contents))
-	(setq initial-contents (string-replace current-name
-					       (concat "==" current-name "==")
-					       initial-contents)))))
+	(setq initial-contents (replace-regexp-in-string (regexp-quote current-name)
+					                 (concat "==" current-name "==")
+					                 initial-contents)))))
   (setq initial-contents (hui:menu-maybe-highlight-item-keys initial-contents))
   (read-from-minibuffer prompt initial-contents keymap read
 			hist default-value inherit-input-method))

--- a/test/MANIFEST
+++ b/test/MANIFEST
@@ -12,6 +12,7 @@ hmouse-info-tests.el    - hmouse-info unit tests
 hpath-tests.el          - unit tests for hpath
 hsettings-test.el       - unit tests for hsettings
 hsys-org-tests.el       - hsys-org tests
+hui-mini-tests.el       - hui-mini tests
 hui-register-tests.el   - test for hui-register
 hui-select-tests.el     - hui-select tests
 hui-tests.el            - tests for hui.el Hyperbole UI

--- a/test/hui-mini-tests.el
+++ b/test/hui-mini-tests.el
@@ -1,0 +1,36 @@
+;;; hui-mini-tests.el --- Unit test for hui-mini -*- lexical-binding: t; -*-
+;;
+;; Author:       Mats Lidell
+;;
+;; Orig-Date:    30-Jan-25 at 22:39:37
+;; Last-Mod:     30-Jan-25 at 23:28:18 by Mats Lidell
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
+;; Copyright (C) 2025  Free Software Foundation, Inc.
+;; See the "HY-COPY" file for license information.
+;;
+;; This file is part of GNU Hyperbole.
+
+;;; Commentary:
+;;
+
+;;; Code:
+
+(require 'hui-mini)
+(require 'ert)
+(require 'el-mock)
+
+(ert-deftest hui--menu-read-from-minibuffer ()
+  "Verify prompt shows proper active selection."
+  (defvar menu-string)
+  (dolist (v '((nil "None")
+               (:buttons "Hyperbole-Buttons-Only")
+               (t "All-Hyperbole-Contexts")))
+    (let ((hsys-org-enable-smart-keys (car v))
+          (menu-string (cadr v)))
+      (mocklet (((read-from-minibuffer "" (format "Org M-RET ==%s==" menu-string) hui:menu-mode-map nil t nil nil) => t))
+        (should (hui:menu-read-from-minibuffer "" (format "Org M-RET %s" menu-string) hui:menu-mode-map nil t))))))
+
+(provide 'hui-mini-tests)
+;;; hui-mini-tests.el ends here


### PR DESCRIPTION
# What

Use replace-regexp-in-string since string-replace is not available in
Emacs 27.2.

# Why

We have just one call using string-replace so instead using the older
replace-regexp-in-string seems like a good candidate.

# Note

~We have no tests for this so it is just a textual substitution with
no extensive verification.~ A test has been added.

We could consider using compat for using string-replace. We have done
this change before so it seem the simpler string-replace meets our
needs. Or we could take a middle step and reintroduce the code we had
from compat and use that in a hypb-compat file to be required when we
use functions that we need forward compatibility for!?
