### PR TITLE
Verify that an empty region can be killed twice

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2025-02-01  Mats Lidell  <matsl@gnu.org>
+
+* test/hui-tests.el (hui--kill-empty-region-twice): Unit test.
+
 2025-01-30  Mats Lidell  <matsl@gnu.org>
 
 * test/hui-mini-tests.el (hui--menu-read-from-minibuffer): Unit test.

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     21-Jan-25 at 17:05:46 by Mats Lidell
+;; Last-Mod:      2-Feb-25 at 00:15:17 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1299,6 +1299,24 @@ enabled."
 
       (hui-kill-region (mark t) (point))
       (should (string= "def}hig" (buffer-string))))))
+
+(ert-deftest hui--kill-empty-region-twice ()
+  "Verify that an empty region can be killed twice.
+Mimics the test case of setting a mark and hitting `C-w' twice."
+  :expected-result :failed
+  (with-temp-buffer
+    (let ((transient-mark-mode t)
+	  (mark-even-if-inactive t)
+          last-command)
+      (insert "foo bar")
+      (goto-char 4)
+      (set-mark (point))
+      (call-interactively #'hui-kill-region)
+      ;; Prepare second call to be setup as kill-region would leave
+      ;; the state when calling it using C-w.
+      (setq mark-active nil)
+      (setq last-command #'kill-region)
+      (call-interactively #'hui-kill-region))))
 
 (ert-deftest hui--kill-region-multiple-kill ()
   "Verify `hui-kill-region' saves to the yank ring on multiple kills.


### PR DESCRIPTION
# What

Verify that an empty region can be killed twice.

# Why

Mimics calling C-w (hui-kill-region) on an empty region which causes
an error in kill-region. The test is prepared so that the second call
to hui-kill-region sees the same state as it does when calling it
using C-w. (kill-region does things like sets deactivate-mark and
depends on what the last-command was which need to be setup to
happen.)

