### PR TITLE
Suppress byte compile warnings calling org-id-get

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2025-02-05  Mats Lidell  <matsl@gnu.org>
+
+* hywiki.el (hywiki-add-org-id): Suppress byte compile warnings for calling org-id-get with
+    different number of args. Later versions have a fourth optional arg that we use.
+
 2025-02-02  Mats Lidell  <matsl@gnu.org>
 
 * test/hui-tests.el (hui--kill-highlighted-region-default-settings): Add test for hui-kill-region

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Acpr-24 at 22:41:13
-;; Last-Mod:      2-Feb-25 at 14:45:23 by Bob Weiner
+;; Last-Mod:      5-Feb-25 at 22:21:38 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1113,9 +1113,10 @@ calling this function."
 	(user-error "(hywiki-add-org-id): Referent buffer <%s> must be in org-mode, not %s"
 		    (buffer-name)
 		    major-mode))
-      (let ((org-id (if (>= (action:param-count #'org-id-get) 4)
+      (let ((org-id (hyperb:with-suppressed-warnings ((callargs org-id-get))
+                      (if (>= (action:param-count #'org-id-get) 4)
 			(org-id-get nil nil nil t)
-		      (org-id-get))))
+		      (org-id-get)))))
 	(when (and (null org-id) buffer-read-only)
 	  (user-error "(hywiki-add-org-id): Referent buffer <%s> point has no Org ID and buffer is read-only"
 		      (buffer-name)))


### PR DESCRIPTION
# What

Suppress byte compile warnings for calling org-id-get with different
number of args

# Why

Later version of org added a fourth argument that we want to use if
available.

# Note

Warning has been removed [from 29.4 build](https://github.com/rswgnu/hyperbole/actions/runs/13166931507)

Uses hypb:with-suppressed-warnings as we are using that in another
place. The comment in the functions hints that it is a requirement due
to Emacs 26 being used in ELPA or for ELPA compatibility. The change
comes from 2022 so I would think that it is not required
anymore. Especially since Hyperbole can't be byte compiled nor used
without byte compilation using Emacsen earlier than Emacs 27!?
