### PR TITLE
Return hasht when rebuilding from load data

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2025-02-07  Mats Lidell  <matsl@gnu.org>
+
+* test/hywiki-tests.el (hywiki-tests--save-referent)
+    (hywiki-tests--save-referent-use-hyperbole-menu): Tests for using the
+    cached page and referent data.
+
+* hywiki.el (hywiki-make-referent-hasht): Return hasht when rebuilding from
+    load data.
+
 2025-02-05  Mats Lidell  <matsl@gnu.org>
 
 * hywiki.el (hywiki-add-org-id): Suppress byte compile warnings for calling org-id-get with

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Acpr-24 at 22:41:13
-;; Last-Mod:      5-Feb-25 at 22:21:38 by Mats Lidell
+;; Last-Mod:      6-Feb-25 at 23:35:41 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -2455,10 +2455,10 @@ save and potentially set `hywiki--directory-mod-time' and
 				       (progn (eval (read (buffer-string)))
 					      t)
 				     (error nil)))))))
-  (if (and hywiki-loaded-flag (not (hywiki-directory-modified-p)))
+    (if (and hywiki-loaded-flag (not (hywiki-directory-modified-p)))
 	;; Rebuild from loaded data
-	(setq hywiki--referent-hasht (hash-make hywiki--referent-alist t)
-	      hywiki--referent-alist nil)
+        (prog1 (setq hywiki--referent-hasht (hash-make hywiki--referent-alist t))
+	  (setq hywiki--referent-alist nil))
       ;; Read `hywiki-directory' for current page files and merge with
       ;; non-page referents
       (let* ((page-files (hywiki-get-page-files))

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    18-May-24 at 23:59:48
-;; Last-Mod:     26-Jan-25 at 18:22:58 by Bob Weiner
+;; Last-Mod:      7-Feb-25 at 00:46:50 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -921,6 +921,57 @@ Note special meaning of `hywiki-allow-plurals-flag'."
 ;;           (should (equal '(org-roam-node . "node-title")
 ;; 			 (hywiki-get-referent wikiword))))
 ;;       (hy-delete-dir-and-buffer hywiki-directory))))
+
+(ert-deftest hywiki-tests--save-referent ()
+  "Verify saving and loading a referent works."
+  (let* ((hywiki-directory (make-temp-file "hywiki" t))
+         (wiki-page (cdr (hywiki-add-page "WikiPage" )))
+	 (wiki-referent "WikiReferent"))
+    (unwind-protect
+        (progn
+          (find-file wiki-page)
+          (insert wiki-referent)
+          (goto-char 4)
+          (with-simulated-input "ABC RET"
+	    (hywiki-add-key-series wiki-referent))
+	  (should (equal '(key-series . "{ABC}") (hywiki-get-referent wiki-referent)))
+          (should (string= wiki-referent (buffer-string)))
+          (should (file-exists-p (hywiki-cache-default-file)))
+
+          ;; Simulate reload from cache
+          (setq hywiki--referent-hasht nil)
+          (hywiki-make-referent-hasht)
+          (should (equal '(key-series . "{ABC}") (hywiki-get-referent wiki-referent))))
+      (hy-delete-files-and-buffers (list wiki-page (hywiki-cache-default-file)))
+      (hy-delete-dir-and-buffer hywiki-directory))))
+
+(ert-deftest hywiki-tests--save-referent-use-hyperbole-menu ()
+  "Verify saving and loading a referent works when using Hyperboles menu."
+  :expected-result :failed
+  ;; The entered key series is inserted into the WikiWord file.
+  (skip-unless (not noninteractive))
+  (let* ((hywiki-directory (make-temp-file "hywiki" t))
+         (wiki-page (cdr (hywiki-add-page "WikiPage" )))
+	 (wiki-referent "WikiReferent"))
+    (unwind-protect
+        (progn
+          (find-file wiki-page)
+          (insert wiki-referent)
+          (goto-char 4)
+
+          (should (hact 'kbd-key "C-u C-h hhck{ABC} RET"))
+          (hy-test-helpers:consume-input-events)
+          
+          (should (string= wiki-referent (buffer-substring-no-properties (point-min) (point-max))))
+          (should (file-exists-p (hywiki-cache-default-file)))
+	  (should (equal '(key-series . "{ABC}") (hywiki-get-referent wiki-referent)))
+
+          ;; Simulate reload from cache
+          (setq hywiki--referent-hasht nil)
+          (hywiki-make-referent-hasht)
+          (should (equal '(key-series . "{ABC}") (hywiki-get-referent wiki-referent))))
+      (hy-delete-files-and-buffers (list wiki-page (hywiki-cache-default-file)))
+      (hy-delete-dir-and-buffer hywiki-directory))))
 
 (provide 'hywiki-tests)
 ;;; hywiki-tests.el ends here

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    18-May-24 at 23:59:48
-;; Last-Mod:      7-Feb-25 at 00:46:50 by Mats Lidell
+;; Last-Mod:      7-Feb-25 at 10:01:25 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -946,9 +946,10 @@ Note special meaning of `hywiki-allow-plurals-flag'."
       (hy-delete-dir-and-buffer hywiki-directory))))
 
 (ert-deftest hywiki-tests--save-referent-use-hyperbole-menu ()
-  "Verify saving and loading a referent works when using Hyperboles menu."
+  "Verify saving and loading a referent works when using Hyperbole's menu."
   :expected-result :failed
-  ;; The entered key series is inserted into the WikiWord file.
+  ;; The entered key series is inserted into the WikiWord file. See
+  ;; comment below.
   (skip-unless (not noninteractive))
   (let* ((hywiki-directory (make-temp-file "hywiki" t))
          (wiki-page (cdr (hywiki-add-page "WikiPage" )))
@@ -961,8 +962,14 @@ Note special meaning of `hywiki-allow-plurals-flag'."
 
           (should (hact 'kbd-key "C-u C-h hhck{ABC} RET"))
           (hy-test-helpers:consume-input-events)
-          
+
+          ;; The buffer contents is changed and now reads
+          ;; "Wik{ABC}iReferent" as the next should verifies. The
+          ;; second should is the expected behavior. No change in the
+          ;; WikiPage buffer.
+          (should (string= "Wik{ABC}iReferent" (buffer-substring-no-properties (point-min) (point-max))))
           (should (string= wiki-referent (buffer-substring-no-properties (point-min) (point-max))))
+
           (should (file-exists-p (hywiki-cache-default-file)))
 	  (should (equal '(key-series . "{ABC}") (hywiki-get-referent wiki-referent)))
 


### PR DESCRIPTION
# What

Return hasht when rebuilding from load data and add test cases that
depends on the fix.

# Why

The result of hywiki-make-referent-hasht is used as a hash table in
some case so it is important that the new value is returned.

The successful test case depends on this change.

The expected failed test case illustrates that the key series is
inserted in the buffer as well as in the definition of the
referent. This can be shown manually too so it does not only happen in
the test case. This test case is only activated when run interactively
like test-all.
