### PR TITLE
Fix hywiki publishing

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2025-02-08  Mats Lidell  <matsl@gnu.org>
+
+* hywiki.el (hywiki--sitemap-file): Helper function for getting the sitemap
+    file-name.
+    (hywiki-org-export-function): Only use org publishing for the sitemap file.
+    (hywiki-convert-words-to-org-links): Highlight wiki page names so overlays
+    are defined before looking for them.
+
 2025-02-07  Mats Lidell  <matsl@gnu.org>
 
 * test/hywiki-tests.el (hywiki-tests--save-referent)

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Acpr-24 at 22:41:13
-;; Last-Mod:      6-Feb-25 at 23:35:41 by Mats Lidell
+;; Last-Mod:      8-Feb-25 at 22:56:32 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1409,6 +1409,7 @@ per file to the absolute value of MAX-MATCHES, if given and not 0.  If
 (defun hywiki-convert-words-to-org-links ()
   "Convert all highlighted HyWiki words in current buffer to Org links."
   (barf-if-buffer-read-only)
+  (hywiki-maybe-highlight-page-names)
   (let ((make-index (hywiki-org-get-publish-property :makeindex))
 	wiki-word)
     (hywiki-map-words (lambda (overlay)
@@ -2482,11 +2483,18 @@ save and potentially set `hywiki--directory-mod-time' and
 (defun hywiki-non-page-elt (val-key)
   (unless (eq (caar val-key) 'page) val-key))
 
+(defun hywiki--sitemap-file ()
+  "Return file name for the sitemap file."
+  (expand-file-name
+   (org-publish-property :sitemap-filename (hywiki-org-get-publish-project))
+   (org-publish-property :base-directory (hywiki-org-get-publish-project))))
+
 (defun hywiki-org-export-function (&rest _)
   "Add to `write-contents-functions' to convert HyWikiWord links to Org links.
 This is done automatically by loading HyWiki."
   (require 'org-element)
   (when (and (derived-mode-p 'org-mode)
+             (not (string= (hywiki--sitemap-file) (buffer-file-name)))
 	     (hyperb:stack-frame '(org-export-copy-buffer)))
     (hywiki-convert-words-to-org-links)
     (hywiki-org-maybe-add-title)))


### PR DESCRIPTION
# What

Highlight wiki page names before looking for overlays to turn into
org-links. Let org handle the sitemap file.

# Why

The wiki pages are copied during export so the overlays are not
immediately available so we need to force the highlighting. 

The sitemap is already handled by org export so we do not need to
touch that. This is no optimisation but rather that adding the
hy-prefix trips org export and outputs link with `hy:` verbatim in the
link text which is not what we want.

# Note

No tests are added yet. Working on that.

What do you think of not using the overlays for the finding the wiki
words to convert? Maybe a more direct way to find the page names and
convert them would be preferred? Instead of going pass inserting
overlays and then find them!? (But this seems to work so for now I'm
happy with it.)

