### PR TITLE
hywiki Org export to html - use modified section titles as href ids; hkey-help display actype info at the top

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,18 @@
+2025-02-23  Bob Weiner  <rsw@gnu.org>
+
+* hywiki.el (hywiki-get-referent): Fix suffix match to use group 3 and add
+    suffix to referent-value here.
+            (hywiki-display-referent): Remove adding suffix to referent-value here.
+
+2025-02-22  Bob Weiner  <rsw@gnu.org>
+
+* hywiki.el (hywiki-publish-to-html): Advise 'org-export-get-reference' to use
+    modified Org headings as html ids.
+            (hywiki--org-export-get-reference,
+             hywiki--org-export-new-title-reference,
+             hywiki--org-format-reference): Add to implement the above new html
+    id generation scheme.
+
 * hui-select.el (hui-select-punctuation): Add 'hui-select-markup-pair' so if
     on the opening char of an HTML tag for example with punctuation syntax,
     it is treated as a markup pair from `hui-select-thing'.
@@ -9,6 +24,16 @@
     condition to call 'hui-select-thing' instead of 'hui-select-delimited-thing'
     so does not include extra whitespace and matches the result when
     'hui-select-thing' is called interactively.
+
+* hywiki.el (hywiki-referent-exists-p):
+    Fix bug where 'word' was given as the symbol :range to use as a flag
+    but then the call to 'hywiki-strip-org-link' mistakenly set it to nil.
+            (hywiki-word-set-auto-highlighting): Add so can call interactively
+    to restore HyWikiWord auto-highlighting after a command hook error.  Call
+    when enabling 'hywiki-mode'.
+
+    Fix bug where :range flag was not passed to 'hywiki-word-at' call;
+    manifested as selecting an entire string rather than the wikiword at point.
 
 * hsys-ert.el (ert-should): Constrain matches for this ibtype to the current
     line when not in 'ert-results-mode'.  This fixes a problem of having this
@@ -31,11 +56,32 @@
     When displaying Assist Key help, remove actype and action attributes
     from button or actype display.
 
+* hywiki.el (hywiki-directory-dired-edit): Remove bash-specific file
+    filtering since names the dir after the filter regex and this is
+    unattractive.  Using directory-files to filter instead works fine.
+    Also, use 'hywiki-word-regexp' to match to page names rather than
+    a hardcoded regexp.
+
 * hycontrol.el (require 'zoom-frm): Wrap in an 'ignore-errors' so if its
     required library, 'frame-cmds' is not installed, no error occurs and
     HyControl behaves works without the library.
 
+* test/hact-tests.el (hact-tests--action-params-with-lambdas): Eliminate
+    byte compiler 'unused args' errors by starting args with underscore.
+
 2025-02-19  Bob Weiner  <rsw@gnu.org>
+
+* hywiki.el (hywiki-maybe-dehighlight-page-name,
+             hywiki-maybe-highlight-page-name,
+             hywiki-maybe-highlight-page-names): In
+    non-'hywiki-highlight-all-in-prog-modes', highlight only in strings
+    as well as comments.
+            (hywiki-buttonize-non-character-commands,
+            hywiki-debuttonize-non-character-commands): Don't trigger these
+    pre- and post-command hooks in non-'hywiki-highlight-all-in-prog-modes' when
+    outside of strings and comments.
+            (hywiki-word-at): Whe match to wikiword via face highlight, ensure
+    it matches to the wikiword format regexp.
 
 * hyrolo.el (hyrolo-expand-path-list): Fix to include a default file name
     even when the file does not yet exist.
@@ -57,6 +103,24 @@
     backwards with point after an ending double quote.
     When compile, add (require 'hbut) for 'hbut:syntax-table'.  Fix string
     selection in 'text-mode' by using 'hbut:syntax-table'.
+
+* hywiki.el (hywiki-org-link-export): In html and markdown conversion, call
+    'hpath:spaces-to-dashes-markup-anchor'.
+            (hywiki-referent-menu): Fix missing s typo in 'hywiki-add-sexpression'.
+	    (hywiki-convert-words-to-org-links, hywiki-org-link-export):
+    Update doc string with specific formatting.
+            (hywiki-org-link-resolve): Rewrite to return full referent when not
+    a pathname.
+            (hywiki-referent-menu): Rename 'LinkPath' to 'pathLink' and properly
+    alphabetize entries by invocation character (first capital letter).
+            (hywiki-word-to-org-link): Add to convert a single HyWikiWord reference
+    to an Org link for use during publishing.  Use in `hywiki-convert-words-to-org-links'.
+
+2025-02-09  Bob Weiner  <rsw@gnu.org>
+
+* hpath.el hpath:spaces-to-dashes-markup-anchor): Add.
+           (hpath:normalize-markup-anchor): Rename to
+    'hpath:dashes-to-spaces-markup-anchor'.
 
 2025-02-08  Mats Lidell  <matsl@gnu.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 2025-02-23  Bob Weiner  <rsw@gnu.org>
 
+* test/hywiki-tests.el (hywiki-tests--convert-words-to-org-link): Fix to not
+    expect 'hy:' prefix in HyWiki Org links.
+                       (hywiki-tests--add-org-roam-node): Handle all calls to
+    'org-roam-node-title'.
+
 * hywiki.el (hywiki-get-referent): Fix suffix match to use group 3 and add
     suffix to referent-value here.
             (hywiki-display-referent): Remove adding suffix to referent-value here.

--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,21 @@
     'ert-test-failed match is found but it is far way and unconnected to the
     current point.
 
+* hmouse-drv.el (hkey-help):
+    Update {C-h A} Hyperbole help so button information is displayed at
+    the top before long Action/Assist Key behavior description.
+
+    In cases like the multi-context 'smart-org' handler where a specific
+    action type is triggered without defining an implicit button, display
+    the action type information at the top as well, so it is clear the
+    specific action that will be taken at point.
+
+    Fix bug where 'categ' is nil and 'htype:names' returns a list of all
+    type names to 'concat' since expecting only a single name.
+
+    When displaying Assist Key help, remove actype and action attributes
+    from button or actype display.
+
 * hycontrol.el (require 'zoom-frm): Wrap in an 'ignore-errors' so if its
     required library, 'frame-cmds' is not installed, no error occurs and
     HyControl behaves works without the library.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+* hui-select.el (hui-select-punctuation): Add 'hui-select-markup-pair' so if
+    on the opening char of an HTML tag for example with punctuation syntax,
+    it is treated as a markup pair from `hui-select-thing'.
+                (hui-select-thing): Change return value to be the region selected
+    so can be used as a delimited regional selection predicate like so:
+    (hui-select-delimited-thing-call #'hui-select-thing).
+
+* hui-mouse.el (hkey-alist): Change action for 'hui-select-at-delimited-thing-p'
+    condition to call 'hui-select-thing' instead of 'hui-select-delimited-thing'
+    so does not include extra whitespace and matches the result when
+    'hui-select-thing' is called interactively.
+
 2025-02-19  Bob Weiner  <rsw@gnu.org>
 
 * hyrolo.el (hyrolo-expand-path-list): Fix to include a default file name
@@ -10,6 +22,16 @@
     exists and is readable.  Fixes gh#rswgnu/hyperbole/672 and bug#76424.
             (hyrolo-get-file-list): Return a default rolo file when `hyrolo-
     file-list' is nil.
+
+2025-02-16  Bob Weiner  <rsw@gnu.org>
+
+* hui-select.el (hui-select-punctuation): Add (hui-select-string pos) call
+    when on a double quote since sometimes double quotes have punctuation syntax,
+    e.g. text-mode.
+                (hui-select-string-p): Fix off-by-one error when scan-sexps
+    backwards with point after an ending double quote.
+    When compile, add (require 'hbut) for 'hbut:syntax-table'.  Fix string
+    selection in 'text-mode' by using 'hbut:syntax-table'.
 
 2025-02-08  Mats Lidell  <matsl@gnu.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,12 @@
     so does not include extra whitespace and matches the result when
     'hui-select-thing' is called interactively.
 
+* hsys-ert.el (ert-should): Constrain matches for this ibtype to the current
+    line when not in 'ert-results-mode'.  This fixes a problem of having this
+    ibtype trigger in the "*scratch*" buffer for example where an
+    'ert-test-failed match is found but it is far way and unconnected to the
+    current point.
+
 * hycontrol.el (require 'zoom-frm): Wrap in an 'ignore-errors' so if its
     required library, 'frame-cmds' is not installed, no error occurs and
     HyControl behaves works without the library.

--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,10 @@
     so does not include extra whitespace and matches the result when
     'hui-select-thing' is called interactively.
 
+* hycontrol.el (require 'zoom-frm): Wrap in an 'ignore-errors' so if its
+    required library, 'frame-cmds' is not installed, no error occurs and
+    HyControl behaves works without the library.
+
 2025-02-19  Bob Weiner  <rsw@gnu.org>
 
 * hyrolo.el (hyrolo-expand-path-list): Fix to include a default file name

--- a/hpath.el
+++ b/hpath.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Nov-91 at 00:44:23
-;; Last-Mod:      2-Feb-25 at 07:38:26 by Bob Weiner
+;; Last-Mod:     16-Feb-25 at 10:04:57 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1612,8 +1612,18 @@ but locational suffixes within the file are utilized."
 				(kotl-mode:to-valid-position))
 			      (current-buffer)))))))))))
 
-(defun hpath:normalize-markup-anchor (anchor)
-  "Convert ANCHOR from current buffer into a a string matching its referent."
+(defun hpath:spaces-to-dashes-markup-anchor (anchor)
+  "Replace dashes with spaces in ANCHOR if not a prog mode and no existing dashes."
+  (if (or (derived-mode-p 'prog-mode)
+	  (string-match-p "-.* \\| .*-" anchor))
+      anchor
+    ;; In Markdown or outline modes '-' characters in `anchor' are
+    ;; converted to dashes in references unless anchor contains both
+    ;; '-' and space characters, in which case no conversion occurs.
+    (subst-char-in-string ?\  ?- anchor)))
+
+(defun hpath:dashes-to-spaces-markup-anchor (anchor)
+  "Replace spaces with dashes with spaces in ANCHOR if not a prog mode and no existing dashes."
   (if (or (derived-mode-p 'prog-mode)
 	  (string-match-p "-.* \\| .*-" anchor))
       anchor
@@ -1652,7 +1662,7 @@ of the buffer."
 				    ;; Markdown or outline link ids are case
 				    ;; insensitive.
 				    (case-fold-search (not prog-mode))
-				    (anchor-name (hpath:normalize-markup-anchor anchor))
+				    (anchor-name (hpath:dashes-to-spaces-markup-anchor anchor))
 				    (referent-regexp (format
 						      (cond ((or (derived-mode-p 'outline-mode) ;; Includes Org mode
 								 ;; Treat all caps filenames without suffix like outlines, e.g. README, INSTALL.

--- a/hsys-ert.el
+++ b/hsys-ert.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Jan-25
-;; Last-Mod:     20-Jan-25 at 23:57:21 by Mats Lidell
+;; Last-Mod:     22-Feb-25 at 12:20:29 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -57,11 +57,15 @@
   "Jump to the source code definition of a should expr from an ert test failure.
 If on the first line of a failure, jump to the source definition of the
 associated test."
-  (when (or (derived-mode-p 'ert-results-mode)
-            (save-excursion
-              (forward-line 0)
-              (or (search-backward "(ert-test-failed\n" nil t)
-                  (search-forward "(ert-test-failed\n" nil t))))
+  (when (or (and (derived-mode-p 'ert-results-mode)
+		 (save-excursion
+		   (forward-line 0)
+		   (or (search-backward "(ert-test-failed\n" nil t)
+                       (search-forward "(ert-test-failed\n" nil t))))
+	    ;; In any other mode, consider only the current line
+	    (save-excursion
+	      (forward-line 0)
+              (search-forward "(ert-test-failed" (line-end-position) t)))
     (catch 'exit
     (save-excursion
       (save-restriction

--- a/hui-mini.el
+++ b/hui-mini.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Oct-91 at 20:13:17
-;; Last-Mod:     30-Jan-25 at 19:44:11 by Mats Lidell
+;; Last-Mod:     22-Feb-25 at 22:15:38 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1035,13 +1035,13 @@ support underlined faces as well."
 	(list
 	 '("HyWiki>")
 	 '("Act"            hywiki-word-activate
-	   "Activate HyWikiWord link at point or emulate a press of a Smart Key.")
+	   "Create and display page for HyWikiWord at point or when none, emulate a press of a Smart Key.")
 	 '("Create"         hywiki-word-create-and-display
-	    "Create and display a new HyWiki referent, prompting with any existing referent names.")
+	    "Create and display a new or existing HyWikiWord referent, prompting with any existing referent names.")
 	 '("EditPages"      hywiki-directory-edit
 	   "Display and edit HyWiki directory.")
 	 '("FindReferent"   hywiki-find-referent
-	   "Prompt with completion for and display a HyWiki page ready for editing.")
+	   "Prompt with completion for and display a HyWikiWord referent.")
 	 (when (fboundp 'consult-grep) ;; allow for autoloading
 	   '("GrepConsult"    hywiki-consult-grep
 	     "Grep over HyWiki pages with interactive consult-grep."))

--- a/hui-mouse.el
+++ b/hui-mouse.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-89
-;; Last-Mod:     19-Jan-25 at 16:40:13 by Bob Weiner
+;; Last-Mod:     22-Feb-25 at 16:18:02 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -292,7 +292,8 @@ Its default value is `smart-scroll-down'.  To disable it, set it to
 	      (smart-helm-alive-p)))
      . ((funcall (key-binding (kbd "RET"))) . (funcall (key-binding (kbd "RET")))))
     ;;
-    ;; If at the end of a line (eol), invoke the associated Smart Key handler EOL handler.
+    ;; If at the end of a line (eol), invoke the associated Smart Key
+    ;; handler EOL handler.
     ((and (smart-eolp)
           (not (and (funcall hsys-org-mode-function)
                     (not (equal hsys-org-enable-smart-keys t)))))
@@ -390,8 +391,8 @@ Its default value is `smart-scroll-down'.  To disable it, set it to
     ;; ends at point.  For markup pairs, point must be at the first
     ;; character of the opening or closing tag.
     ((hui-select-at-delimited-thing-p)
-     . ((hui-select-delimited-thing) . (progn (hui-select-delimited-thing)
-					      (hmouse-kill-region))))
+     . ((hui-select-thing) . (progn (hui-select-thing)
+				    (hmouse-kill-region))))
     ;;
     ;; If the prior test failed and point is at the start or end of an
     ;; sexpression, mark it for editing or kill it (assist key).  This
@@ -413,7 +414,8 @@ Its default value is `smart-scroll-down'.  To disable it, set it to
     ((eq major-mode 'kotl-mode)
      . ((kotl-mode:action-key) . (kotl-mode:assist-key)))
     ;;
-    ;; If in the flymake linter list of issues buffer, jump to or show issue at point
+    ;; If in the flymake linter list of issues buffer, jump to or show
+    ;; issue at point.
     ((eq major-mode 'flymake-diagnostics-buffer-mode)
      . ((flymake-goto-diagnostic (point)) . (flymake-show-diagnostic (point) t)))
     ;;

--- a/hycontrol.el
+++ b/hycontrol.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Jun-16 at 15:35:36
-;; Last-Mod:     29-Jan-25 at 19:05:16 by Mats Lidell
+;; Last-Mod:     22-Feb-25 at 09:41:32 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -135,7 +135,10 @@
   (require 'windmove))
 ;; Frame face enlarging/shrinking (zooming) requires this separately available library.
 ;; Everything else works fine without it, so don't make it a required dependency.
-(require 'zoom-frm nil t)
+;; It also requires the separate library, 'frame-cmds', so ignore any
+;; errors if that library is not found as well.
+(ignore-errors
+  (require 'zoom-frm nil t))
 
 ;;; ************************************************************************
 ;;; Public declarations

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Acpr-24 at 22:41:13
-;; Last-Mod:     23-Feb-25 at 02:21:03 by Bob Weiner
+;; Last-Mod:     23-Feb-25 at 11:05:28 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1457,7 +1457,7 @@ publish process."
 			(delete-region (overlay-start overlay)
 				       (overlay-end overlay))
 			(delete-overlay overlay)
-			(if (setq org-link (hywiki-word-to-org-link wikiword nil))
+			(if (setq org-link (hywiki-word-to-org-link wikiword-and-section nil))
 			    (insert org-link)
 			  (message
 			   "(hywiki-convert-words-to-org-links): \"%s\" in \"%s\" produced nil org link output"
@@ -1486,7 +1486,8 @@ publish process."
 	(unless (and suffix (not (string-empty-p suffix)))
 	  (setq suffix nil))
 	(setq suffix-no-hashmark (when suffix (substring suffix 1)))
-	(when (string-equal path (file-name-nondirectory buffer-file-name))
+	(when (or (not buffer-file-name)
+		  (string-equal path (file-name-nondirectory buffer-file-name)))
 	  (setq path nil))
 	(cond (desc
 	       (if path
@@ -2625,11 +2626,11 @@ backend."
 			 (hpath:spaces-to-dashes-markup-anchor
 			  (or suffix ""))
 			 desc))
-	  (`latex (format "\\href{%s}{%s}" (replace-regexp-in-string "[\\{}$%&_#~^]" "\\\\\\&" path) desc))
+	  (`latex (format "\\href{%s.latex}{%s}" (replace-regexp-in-string "[\\{}$%&_#~^]" "\\\\\\&" path-stem) desc))
 	  (`md (format "[%s](%s.md%s)" desc path-stem
 		       (hpath:spaces-to-dashes-markup-anchor
 			(or suffix ""))))
-	  (`texinfo (format "@uref{%s,%s}" path desc))
+	  (`texinfo (format "@uref{%s.texi,%s}" path-stem desc))
 	  (_ path))
       link)))
 

--- a/test/hact-tests.el
+++ b/test/hact-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    16-May-24 at 00:29:22
-;; Last-Mod:     16-May-24 at 23:51:18 by Mats Lidell
+;; Last-Mod:     22-Feb-25 at 09:35:56 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -23,8 +23,8 @@
 (ert-deftest hact-tests--action-params-with-lambdas ()
   "Lambda used with `action:params' should return the lambda parameters."
   (should (equal nil (action:params (lambda () nil))))
-  (should (equal '(x) (action:params (lambda (x) nil))))
-  (should (equal '(x y) (action:params (lambda (x y) nil)))))
+  (should (equal '(_x) (action:params (lambda (_x) nil))))
+  (should (equal '(_x _y) (action:params (lambda (_x _y) nil)))))
 
 (ert-deftest hact-tests--actype-act-with-lambdas ()
   "Lambda with `actype:act' should work over versions of Emacs.

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    18-May-24 at 23:59:48
-;; Last-Mod:      7-Feb-25 at 10:01:25 by Mats Lidell
+;; Last-Mod:     23-Feb-25 at 11:04:10 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -621,7 +621,7 @@ Both mod-time and checksum must be changed for a test to return true."
             (with-hywiki-buttonize-and-insert-hooks (insert "WikiWord "))
             (goto-char 4)
             (hywiki-convert-words-to-org-links)
-            (should (string= "[[hy:WikiWord]] "
+            (should (string= "[[WikiWord]] "
                              (buffer-substring-no-properties (point-min) (point-max)))))
           (with-temp-buffer
             (hywiki-mode 1)
@@ -630,7 +630,7 @@ Both mod-time and checksum must be changed for a test to return true."
 	      (newline nil t))
             (goto-char 4)
             (hywiki-convert-words-to-org-links)
-            (should (string= "[[hy:WikiWord]]\n"
+            (should (string= "[[WikiWord]]\n"
                              (buffer-substring-no-properties (point-min) (point-max))))))
       (hywiki-tests--add-hywiki-hooks)
       (hywiki-mode 0)
@@ -694,24 +694,24 @@ Both mod-time and checksum must be changed for a test to return true."
   "Verify `hywiki-org-link-export' output for different formats."
   (let* ((hywiki-directory (make-temp-file "hywiki" t))
          (wikipage (cdr (hywiki-add-page "WikiWord")))
-	 (filename (when wikipage (file-name-nondirectory wikipage))))
+	 (filename (when wikipage (file-name-nondirectory wikipage)))
+	 (filename-stem (when filename (file-name-sans-extension filename))))
     (unwind-protect
         (progn
           (should (string-match-p
                    (format "\\[hy\\] <doc:.*%s>" filename)
                    (hywiki-org-link-export "WikiWord" "doc" 'ascii)))
           (should (string-match-p
-                   (format "<a href=\".*%s\">doc</a>"
-                           (replace-regexp-in-string "\\.org" ".html" filename))
+                   (format "<a href=\".*%s.html\">doc</a>" filename-stem)
                    (hywiki-org-link-export "WikiWord" "doc" 'html)))
           (should (string-match-p
-                   (format "\\[doc\\](.*%s)" filename)
+                   (format "\\[doc\\](.*%s.md)" filename-stem)
                    (hywiki-org-link-export "WikiWord" "doc" 'md)))
           (should (string-match-p
-                   (format "\\href{.*%s}{doc}" filename)
+                   (format "\\href{.*%s.latex}{doc}" filename-stem)
                    (hywiki-org-link-export "WikiWord" "doc" 'latex)))
           (should (string-match-p
-                   (format "@uref{.*%s,doc}" filename)
+                   (format "@uref{.*%s.texi,doc}" filename-stem)
                    (hywiki-org-link-export "WikiWord" "doc" 'texinfo)))
           (should (string-match-p
                    (format ".*%s" filename)
@@ -892,16 +892,14 @@ Note special meaning of `hywiki-allow-plurals-flag'."
 (ert-deftest hywiki-tests--add-org-roam-node ()
   "Verify `hywiki-add-org-roam-node'."
   (let* ((hywiki-directory (make-temp-file "hywiki" t))
-         (wiki-page (cdr (hywiki-add-page "FirstWord")))
 	 (wikiword (hy-make-random-wikiword)))
     (unwind-protect
         (mocklet (((hypb:require-package 'org-roam) => t)
 		  ((org-roam-node-read) => "node")
-		  ((org-roam-node-title "node") => "node-title"))
+		  (org-roam-node-title => "node-title"))
 	  (hywiki-add-org-roam-node wikiword)
           (should (equal '(org-roam-node . "node-title")
 			 (hywiki-get-referent wikiword))))
-      (hy-delete-file-and-buffer wiki-page)
       (hy-delete-dir-and-buffer hywiki-directory))))
 
 ;;; FIXME


### PR DESCRIPTION
 [hui-select.el - Make Action Key on delimited pairs match hui-select](https://github.com/rswgnu/hyperbole/commit/982b97512419a98c176783fa187b2bc5200f7a1b)

[hycontrol.el - Eliminate error if frame-cmds library is missing](https://github.com/rswgnu/hyperbole/commit/40f5f900387606e6be7fc8ca41d05858f96ed20f)

[ert-should ibtype - Limit to single line when not ert-results-mode](https://github.com/rswgnu/hyperbole/commit/b2998ade3da449c84aafdb4d0b01ec3f0bf92e17)

[hkey-help - Put hbut and actype info at the top of help](https://github.com/rswgnu/hyperbole/commit/d57be5a4582aeae518e29ad079062571b9e9da04)

[hywiki.el - Many bug fixes and use section names for Org html ids](https://github.com/rswgnu/hyperbole/commit/deb608fa5f37f641c92f57d4e7da4939f9a22f25)

[Fix 2 hywiki tests for org links and org roam nodes](https://github.com/rswgnu/hyperbole/commit/12043802da75cb4f06f895610f266cf6d94fa217)