### PR TITLE
Do not build and test for Emacs 27.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [27.2, 28.2, 29.4, master]
+        version: [28.2, 29.4, master]
     container: silex/emacs:${{ matrix.version }}-ci
 
     steps:

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2025-02-28  Mats Lidell  <matsl@gnu.org>
+
+* .github/workflows/main.yml (jobs): Remove 27.2 from the versions to
+    test in the CI.
+
 2025-02-24  Mats Lidell  <matsl@gnu.org>
 
 * test/hywiki-tests.el (hywiki-tests--action-key-moves-to-word-and-section):


### PR DESCRIPTION
# What

Do not build 27.2 in CI.

# Why

We are bumping the required version of Emacs to 28.1 due to markdown
mode not being available for Emacs 27.2 any more.
