### PR TITLE
Add predicate function, hywiki-word-face-at-p

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2025-03-03  Mats Lidell  <matsl@gnu.org>
+
+* test/hywiki-tests.el (hywiki-tests--word-face-at-p): Add unit test.
+    (with-hywiki-buttonize-and-insert-hooks): Move debuttonize before body.
+
+* hywiki.el (hywiki-word-face-at-p): Add predicate for hywiki-word-face
+    and use it in hywiki-tests.
+
 2025-03-02  Mats Lidell  <matsl@gnu.org>
 
 * test/hywiki-tests.el (hywiki-tests--referent-test): Add macro with

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Acpr-24 at 22:41:13
-;; Last-Mod:     23-Feb-25 at 11:50:21 by Bob Weiner
+;; Last-Mod:      3-Mar-25 at 00:01:19 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -2928,6 +2928,10 @@ or this will return nil."
   "Return singular HyWikiWord at point with its suffix stripped or nil.
 Point should be on the HyWikiWord itself."
   (hywiki-get-singular-wikiword (hywiki-word-strip-suffix (hywiki-word-at))))
+
+(defun hywiki-word-face-at-p ()
+  "Non-nil if but at point has `hywiki-word-face' property."
+  (hproperty:but-get (point) 'face hywiki-word-face))
 
 ;;;###autoload
 (defun hywiki-word-consult-grep (word)

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    18-May-24 at 23:59:48
-;; Last-Mod:     27-Feb-25 at 09:28:06 by Mats Lidell
+;; Last-Mod:      3-Mar-25 at 00:10:35 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -501,8 +501,8 @@ Both mod-time and checksum must be changed for a test to return true."
   "Call BODY wrapped in hywiki hooks to simulate Emacs redisplay."
   (declare (indent 0) (debug t))
   `(progn
-     (progn ,@body)
      (funcall 'hywiki-debuttonize-non-character-commands)
+     (progn ,@body)
      (funcall 'hywiki-buttonize-character-commands)
      (funcall 'hywiki-buttonize-non-character-commands)))
 
@@ -519,14 +519,14 @@ Both mod-time and checksum must be changed for a test to return true."
             (hywiki-mode 1)
             (with-hywiki-buttonize-and-insert-hooks (insert "WikiWord "))
             (goto-char 4)
-            (should (hproperty:but-get (point) 'face hywiki-word-face)))
+            (should (hywiki-word-face-at-p)))
           (with-temp-buffer
             (hywiki-mode 1)
             (with-hywiki-buttonize-and-insert-hooks
               (insert "WikiWord")
 	      (command-execute #'newline))
             (goto-char 4)
-            (should (hproperty:but-get (point) 'face hywiki-word-face))))
+            (should (hywiki-word-face-at-p))))
       (hywiki-tests--add-hywiki-hooks)
       (hywiki-mode 0)
       (hy-delete-file-and-buffer wikipage)
@@ -546,7 +546,7 @@ Both mod-time and checksum must be changed for a test to return true."
               (insert "WikiWord")
 	      (newline nil t))
             (goto-char 4)
-            (should-not (hproperty:but-get (point) 'face hywiki-word-face))))
+            (should-not (hywiki-word-face-at-p))))
       (hywiki-tests--add-hywiki-hooks)
       (hy-delete-dir-and-buffer hywiki-directory))))
 
@@ -563,16 +563,16 @@ Both mod-time and checksum must be changed for a test to return true."
             (with-hywiki-buttonize-and-insert-hooks (insert "Wikiord "))
             (goto-char 5)
             (should (looking-at-p "ord"))
-            (should-not (hproperty:but-get (point) 'face hywiki-word-face))
+            (should-not (hywiki-word-face-at-p))
 
             (with-hywiki-buttonize-and-insert-hooks (insert "W"))
             (goto-char 5)
             (should (looking-at-p "Word"))
-            (should (hproperty:but-get (point) 'face hywiki-word-face))
+            (should (hywiki-word-face-at-p))
 
             (with-hywiki-buttonize-and-insert-hooks (delete-char 1))
             (should (looking-at-p "ord"))
-            (should-not (hproperty:but-get (point) 'face hywiki-word-face))))
+            (should-not (hywiki-word-face-at-p))))
       (hywiki-tests--add-hywiki-hooks)
       (hywiki-mode 0)
       (hy-delete-files-and-buffers (list wikipage))
@@ -591,17 +591,17 @@ Both mod-time and checksum must be changed for a test to return true."
             (with-hywiki-buttonize-and-insert-hooks (insert "WikiWord "))
             (goto-char 1)
             (should (looking-at-p "Wiki"))
-            (should (hproperty:but-get (point) 'face hywiki-word-face))
+            (should (hywiki-word-face-at-p))
 
 	    (delete-char 1)
 	    (hywiki-maybe-dehighlight-page-name t)
             (should (looking-at-p "iki"))
-            (should-not (hproperty:but-get (point) 'face hywiki-word-face))
+            (should-not (hywiki-word-face-at-p))
 
             (with-hywiki-buttonize-and-insert-hooks (insert "W"))
             (goto-char 1)
             (should (looking-at-p "Wiki"))
-            (should (hproperty:but-get (point) 'face hywiki-word-face))))
+            (should (hywiki-word-face-at-p))))
       (hywiki-tests--add-hywiki-hooks)
       (hywiki-mode 0)
       (hy-delete-files-and-buffers (list wikipage))
@@ -1360,6 +1360,23 @@ See gh#rswgnu/hyperbole/669."
       (with-hywiki-buttonize-hooks
         (delete-char 1)))
     (should (string= "()" (buffer-substring-no-properties (point-min) (point-max))))))
+
+(ert-deftest hywiki-tests--word-face-at-p ()
+  "Verify `hywiki-word-face-at-p'."
+  (with-temp-buffer
+    (insert "WikiWord")
+    (goto-char 4)
+    (should-not (hywiki-word-face-at-p))
+
+    (erase-buffer)
+    (unwind-protect
+        (progn
+          (hywiki-tests--remove-hywiki-hooks)
+          (hywiki-mode 1)
+          (with-hywiki-buttonize-and-insert-hooks (insert "WikiWord"))
+          (goto-char 4)
+          (should (hywiki-word-face-at-p)))
+      (hywiki-tests--add-hywiki-hooks))))
 
 (provide 'hywiki-tests)
 ;;; hywiki-tests.el ends here

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -1363,20 +1363,26 @@ See gh#rswgnu/hyperbole/669."
 
 (ert-deftest hywiki-tests--word-face-at-p ()
   "Verify `hywiki-word-face-at-p'."
-  (with-temp-buffer
-    (insert "WikiWord")
-    (goto-char 4)
-    (should-not (hywiki-word-face-at-p))
-
-    (erase-buffer)
+  (skip-unless (not noninteractive))
+  (let* ((hywiki-directory (make-temp-file "hywiki" t))
+         (wiki-page (cdr (hywiki-add-page "WikiWord"))))
+    (with-temp-buffer
+      (insert "WikiWord")
+      (goto-char 4)
+      (should-not (hywiki-word-face-at-p)))
     (unwind-protect
         (progn
           (hywiki-tests--remove-hywiki-hooks)
-          (hywiki-mode 1)
-          (with-hywiki-buttonize-and-insert-hooks (insert "WikiWord"))
-          (goto-char 4)
-          (should (hywiki-word-face-at-p)))
-      (hywiki-tests--add-hywiki-hooks))))
+          (with-temp-buffer
+            (hywiki-mode 1)
+            (with-hywiki-buttonize-and-insert-hooks
+              (insert "WikiWord")
+              (command-execute #'newline))
+            (goto-char 4)
+            (should (hywiki-word-face-at-p))))
+      (hywiki-tests--add-hywiki-hooks)
+      (hy-delete-file-and-buffer wiki-page)
+      (hy-delete-dir-and-buffer hywiki-directory))))
 
 (provide 'hywiki-tests)
 ;;; hywiki-tests.el ends here


### PR DESCRIPTION
# What

Includes unit test and use of it in hywiki-tests.

# Why

Makes test more compact and allows for easier change of how a WikiWord
is identified.

# Note

Includes a small refactoring of the macro
with-hywiki-buttonize-and-insert-hooks where the debuttonize was 
performed after the insert which looked like a typo. (But does not seem to 
make any difference.)

I also could not come up with any non-interactive test to verify the new
predicate function which is sad. I had to copy but creation code from the
other non-interactive tests to make it work. So will have to look over this 
again.

