### PR TITLE
Add 30.1 to Github CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [28.2, 29.4, master]
+        version: [28.2, 29.4, 30.1, master]
     container: silex/emacs:${{ matrix.version }}-ci
 
     steps:

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2025-03-04  Mats Lidell  <matsl@gnu.org>
+
+* .github/workflows/main.yml (jobs): Add 30.1 to CI
+
 2025-03-03  Mats Lidell  <matsl@gnu.org>
 
 * Makefile (DOCKER_VERSIONS): Remove 27.2.


### PR DESCRIPTION
# What

Add latest Emacs release 30.1 to Github CI. (And it is available as a docker image: https://github.com/Silex/docker-emacs/pull/114)

# Why

We want to regularly test with the latest released version.
