### PR TITLE
Avoid byte compile error messages for test dependencies

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,14 @@
 2025-03-04  Mats Lidell  <matsl@gnu.org>
 
+* test/hywiki-tests.el:
+  test/hycontrol-tests.el:
+  test/hui-mini-tests.el:
+  test/hproperty-tests.el:
+  test/hactypes-tests.el: Add local-variable section disabling
+    byte-compilation to avoid error message during user
+    installation. The message comes from these files depend on el-mock
+    which is not a package dependency.
+
 * .github/workflows/main.yml (jobs): Add 30.1 to CI
 
 2025-03-03  Mats Lidell  <matsl@gnu.org>

--- a/test/hactypes-tests.el
+++ b/test/hactypes-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:      3-Jan-25 at 23:52:37 by Mats Lidell
+;; Last-Mod:      4-Mar-25 at 17:05:59 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -49,4 +49,12 @@
     (kill-matching-buffers "^\\*info\\*" nil t)))
 
 (provide 'hactypes-tests)
+
+;; This file can't be byte-compiled without the `el-mock' package
+;; which is not a dependency of Hyperbole.
+;;
+;; Local Variables:
+;; no-byte-compile: t
+;; End:
+
 ;;; hactypes-tests.el ends here

--- a/test/hproperty-tests.el
+++ b/test/hproperty-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:     6-Aug-24 at 20:32:51
-;; Last-Mod:      6-Aug-24 at 21:59:39 by Mats Lidell
+;; Last-Mod:      4-Mar-25 at 17:04:46 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -37,4 +37,12 @@
       (should (hproperty:but-p)))))
 
 (provide 'hproperty-tests)
+
+;; This file can't be byte-compiled without the `el-mock' package
+;; which is not a dependency of Hyperbole.
+;;
+;; Local Variables:
+;; no-byte-compile: t
+;; End:
+
 ;;; hproperty-tests.el ends here

--- a/test/hui-mini-tests.el
+++ b/test/hui-mini-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    30-Jan-25 at 22:39:37
-;; Last-Mod:     30-Jan-25 at 23:28:18 by Mats Lidell
+;; Last-Mod:      4-Mar-25 at 17:06:50 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -33,4 +33,12 @@
         (should (hui:menu-read-from-minibuffer "" (format "Org M-RET %s" menu-string) hui:menu-mode-map nil t))))))
 
 (provide 'hui-mini-tests)
+
+;; This file can't be byte-compiled without the `el-mock' package
+;; which is not a dependency of Hyperbole.
+;;
+;; Local Variables:
+;; no-byte-compile: t
+;; End:
+
 ;;; hui-mini-tests.el ends here

--- a/test/hycontrol-tests.el
+++ b/test/hycontrol-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:     8-Jan-25 at 22:52:00
-;; Last-Mod:     21-Jan-25 at 17:03:54 by Mats Lidell
+;; Last-Mod:      4-Mar-25 at 17:06:26 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -30,4 +30,12 @@
       (should (string-match "Requires manual installation" (cadr err))))))
 
 (provide 'hycontrol-tests)
+
+;; This file can't be byte-compiled without the `el-mock' package
+;; which is not a dependency of Hyperbole.
+;;
+;; Local Variables:
+;; no-byte-compile: t
+;; End:
+
 ;;; hycontrol-tests.el ends here

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -1385,4 +1385,12 @@ See gh#rswgnu/hyperbole/669."
       (hy-delete-dir-and-buffer hywiki-directory))))
 
 (provide 'hywiki-tests)
+
+;; This file can't be byte-compiled without the `el-mock' package
+;; which is not a dependency of Hyperbole.
+;;
+;; Local Variables:
+;; no-byte-compile: t
+;; End:
+
 ;;; hywiki-tests.el ends here


### PR DESCRIPTION
# What

Do not byte compile test files which requires test
dependencies. i.e. el-mock and with-simulated-input.

# Why

This affects byte compiling during package installation.

All el-files are byte compiled by package managers. Files that require
a test dependency will not be possible to byte compile. This creates
an error message. 

We have already covered for this in the past but missed new files
where these test dependencies have been introduced. The problem has
been reported in bug#76742.

This PR inserts a local variable section that turns off byte
compilation in the files we have missed.
