### PR TITLE
Fix bad should check

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2025-03-18  Mats Lidell  <matsl@gnu.org>
+
+* test/hywiki-tests.el
+    (hywiki-tests--published-html-links-to-word-and-section): Fix should
+    check.
+
 2025-03-17  Mats Lidell  <matsl@gnu.org>
 
 * test/hywiki-tests.el (hywiki-tests--add-hywiki-hooks)

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    18-May-24 at 23:59:48
-;; Last-Mod:     17-Mar-25 at 11:44:34 by Mats Lidell
+;; Last-Mod:     18-Mar-25 at 16:19:07 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -771,7 +771,7 @@ WikiWord#Bsection-subsection
           ;; Verify links are generated
           (with-current-buffer (find-file-noselect wikipage-html)
             ;; (First check we even get the wikipage with sections)
-            (should (>= 1 (count-matches (regexp-quote "WikiWord") (point-min) (point-max))))
+            (should (<= 1 (count-matches (regexp-quote "WikiWord") (point-min) (point-max))))
             (should (= 1 (count-matches (regexp-quote "WikiWord#Asection") (point-min) (point-max))))
             (should (= 1 (count-matches (regexp-quote "WikiWord#Bsection-subsection") (point-min) (point-max))))
 


### PR DESCRIPTION
# What

Check that there are at least 1 occurrence of WikiWord in the exported
result.

# Why

The tests was flipped so were checking that there were 1 or less
occurrence of WikiWord in the exported file which was not the
intent. It was missed since the text still fails due to the generated
html not containing the proper links.

# Note

Noticed this error in the test case. Could fix it with something else
but in case I forget it here it is.
