### PR TITLE
speed up docker runs by using local elpa volume

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,8 @@
     runs.
     (recompile-docker-elpa): Recompile elpa folder to ensure files are
     compiled with the same Emacs as used.
+    (docker-clean): Remove the elpa volume, useful for starting with a
+    fresh download of the required packages.
 
 2025-03-18  Mats Lidell  <matsl@gnu.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2025-03-20  Mats Lidell  <matsl@gnu.org>
+
+* Makefile (DOCKER_VERSIONS): Include 30.1.
+
 2025-03-18  Mats Lidell  <matsl@gnu.org>
 
 * test/hywiki-tests.el

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,10 @@
 2025-03-20  Mats Lidell  <matsl@gnu.org>
 
 * Makefile (DOCKER_VERSIONS): Include 30.1.
+    (docker-run): Use a volume for the elpa folder to reuse between docker
+    runs.
+    (recompile-docker-elpa): Recompile elpa folder to ensure files are
+    compiled with the same Emacs as used.
 
 2025-03-18  Mats Lidell  <matsl@gnu.org>
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:     20-Mar-25 at 18:36:15 by Mats Lidell
+# Last-Mod:     20-Mar-25 at 18:49:45 by Mats Lidell
 #
 # Copyright (C) 1994-2023  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -656,6 +656,9 @@ docker-update:
 # Example: make docker version=29.4 targets="clean bin run-emacs"
 run-emacs:
 	emacs --eval "(progn (add-to-list 'load-path \"/hyperbole\") (require 'hyperbole) (hyperbole-mode 1))"
+
+docker-clean:
+	docker rm elpa-local
 
 # Run with coverage. Run tests given by testspec and monitor the
 # coverage for the specified file.

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:      3-Mar-25 at 20:27:54 by Mats Lidell
+# Last-Mod:     20-Mar-25 at 18:36:15 by Mats Lidell
 #
 # Copyright (C) 1994-2023  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -181,7 +181,7 @@ HYPB_WEB_REPO_LOCATION = ../hyweb/hyperbole/
 HYPB_WEB_REPO_LOCATION_DEVEL = $(HYPB_WEB_REPO_LOCATION)devel/
 
 # CI/CD Emacs versions for local docker based tests
-DOCKER_VERSIONS=28.2 29.4 master
+DOCKER_VERSIONS=28.2 29.4 30.1 master
 
 ##########################################################################
 #                     NO CHANGES REQUIRED BELOW HERE.                    #

--- a/Makefile
+++ b/Makefile
@@ -637,11 +637,16 @@ else
 DOCKER_VERSION = master-ci
 endif
 
+recompile-docker-elpa:
+	$(EMACS_BATCH) --eval "(byte-recompile-directory \"/root/.emacs.d/elpa\" 0 'force)"
+
 docker: docker-update
-	docker run -v $$(pwd):/hypb -v /tmp:/hypb-tmp -it --rm silex/emacs:${DOCKER_VERSION} bash -c "cp -a /hypb /hyperbole && make -C hyperbole ${DOCKER_TARGETS}"
+	docker run --mount type=volume,src=elpa-local,dst=/root/.emacs.d/elpa \
+	-v $$(pwd):/hypb -v /tmp:/hypb-tmp -it --rm silex/emacs:${DOCKER_VERSION} bash -c "cp -a /hypb /hyperbole && make -C hyperbole recompile-docker-elpa ${DOCKER_TARGETS}"
 
 docker-run: docker-update
-	docker run -v $$(pwd):/hypb -v /tmp:/hypb-tmp -it --rm silex/emacs:${DOCKER_VERSION}
+	docker run --mount type=volume,src=elpa-local,dst=/root/.emacs.d/elpa \
+	-v $$(pwd):/hypb -v /tmp:/hypb-tmp -it --rm silex/emacs:${DOCKER_VERSION}
 
 # Update the docker image for the specified version of Emacs
 docker-update:


### PR DESCRIPTION
# What

- **Include 30.1 for local docker based tests**
- **Use volume to keep elpa files between docker runs**
- **Add clean target for docker**

# Why

By keeping or sharing the required elpa packages between runs we can
speed up local docker runs considerable. No more waiting for download
from the package repos, except the first time. This makes it even more
useful to use the docker target for running tests since this ensures a
well defined environment and standard Emacs config.

# Note

Slides in the 30.1 update to the DOCKER_VERSIONS as well since we did
not add that after 30.1 was released.

Running "make docker-batch-test" takes now 54 secs on my machine. That
is full batch test for four versions of Emacs in less than one minute.

Similar for the simple "make docker targets='clean test'". That is
batch test for the development version of Emacs. It completes in less
that 12 seconds.
