### PR TITLE
Remove hywiki-directory when test is done

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2025-03-30  Mats Lidell  <matsl@gnu.org>
+
+* test/hywiki-tests.el (hywiki-tests--add-find): Remove hywiki-directory
+    at end of test case.
+
 2025-03-23  Mats Lidell  <matsl@gnu.org>
 
 * test/hywiki-tests.el (hywiki-tests--run-test-case): Run DSL for testing

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -879,11 +879,14 @@ Note special meaning of `hywiki-allow-plurals-flag'."
 
 (ert-deftest hywiki-tests--add-find ()
   "Verify `hywiki-add-find'."
-  (let ((hywiki-directory (make-temp-file "hywiki" t))
-        (wikiword "WikiWord")
-	(referent '(find . hywiki-word-grep)))
-    (hywiki-add-find wikiword)
-    (should (equal referent (hywiki-get-referent wikiword)))))
+  (let* ((hywiki-directory (make-temp-file "hywiki" t))
+         (wikiword "WikiWord")
+	 (referent '(find . hywiki-word-grep)))
+    (unwind-protect
+        (progn
+          (hywiki-add-find wikiword)
+          (should (equal referent (hywiki-get-referent wikiword))))
+      (hy-delete-dir-and-buffer hywiki-directory))))
 
 (ert-deftest hywiki-tests--add-global-button ()
   "Verify `hywiki-add-global-button'."


### PR DESCRIPTION
# What

Remove hywiki-directory when test is done.

# Why

Temporary test files should be removed after a test is done so that
the environment is as clean as possible.

# Note

It was one test case that was missing the removal of the `hywiki-directory`. 

