### PR TITLE
Add support for running tests that are known to fail

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,7 @@
 2025-04-06  Mats Lidell  <matsl@gnu.org>
 
-* test/hy-test-helpers.el (hy-test-failure): Set to non-nil to activate
-    failing test cases. Used by HYPB_ERT_FAILURE.
+* test/hy-test-helpers.el (hy-test-run-failing-flag): Set to non-nil to
+    activate failing test cases. Used by HYPB_ERT_FAILURE.
 
 * Makefile (HYPB_ERT_FAILURE): Command line controlled macro that tells if
     failing test cases should be run.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 2025-04-06  Mats Lidell  <matsl@gnu.org>
 
+* test/hy-test-helpers.el (hy-test-failure): Set to non-nil to activate
+    failing test cases. Used by HYPB_ERT_FAILURE.
+
+* Makefile (HYPB_ERT_FAILURE): Command line controlled macro that tells if
+    failing test cases should be run.
+
 * test/hywiki-tests.el (hywiki-tests--run-test-case): Remove per char
     verification in DSL. Just verify after each insert or remove as whole.
     (hywiki-tests--wikiword-step-check): Simplify tests after DSL change.

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:     20-Mar-25 at 18:49:45 by Mats Lidell
+# Last-Mod:     31-Mar-25 at 00:35:45 by Mats Lidell
 #
 # Copyright (C) 1994-2023  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -538,6 +538,9 @@ else
 HYPB_ERT_BATCH = (ert-run-tests-batch-and-exit)
 HYPB_ERT_INTERACTIVE = (ert-run-tests-interactively t)
 endif
+ifeq ($(origin failure), command line)
+HYPB_ERT_FAILURE = (setq hy-test-failure ${failure})
+endif
 
 # For full backtrace run make test FULL_BT=<anything or even empty>
 ifeq ($(origin FULL_BT), command line)
@@ -553,7 +556,7 @@ test-ert:
 	--eval "(let ((auto-save-default) (ert-batch-print-level 10) \
 	              (ert-batch-print-length nil) \
 	              $(HYPB_ERT_BATCH_BT) (ert-batch-backtrace-right-margin 2048)) \
-	           $(LOAD_TEST_ERT_FILES) $(HYPB_ERT_BATCH))"
+	           $(LOAD_TEST_ERT_FILES) $(HYPB_ERT_FAILURE) $(HYPB_ERT_BATCH))"
 
 # Run all tests by starting an Emacs that runs the tests interactively in windowed mode.
 all-tests: test-all
@@ -562,14 +565,14 @@ test-all:
 ifeq ($(TERM), dumb)
 ifneq (,$(findstring .apple.,$(DISPLAY)))
         # Found, on MacOS
-	TERM=xterm-256color $(EMACS) --quick $(PRELOADS) --eval "(load-file \"test/hy-test-dependencies.el\")" --eval "(let ((auto-save-default)) $(LOAD_TEST_ERT_FILES) $(HYPB_ERT_INTERACTIVE))"
+	TERM=xterm-256color $(EMACS) --quick $(PRELOADS) --eval "(load-file \"test/hy-test-dependencies.el\")" --eval "(let ((auto-save-default)) $(LOAD_TEST_ERT_FILES) $(HYPB_ERT_FAILURE) $(HYPB_ERT_INTERACTIVE))"
 else
         # Not found, set TERM so tests will at least run within parent Emacs session
-	TERM=vt100 $(EMACS) --quick $(PRELOADS) --eval "(load-file \"test/hy-test-dependencies.el\")" --eval "(let ($(LET_VARIABLES)) $(LOAD_TEST_ERT_FILES) $(HYPB_ERT_INTERACTIVE))"
+	TERM=vt100 $(EMACS) --quick $(PRELOADS) --eval "(load-file \"test/hy-test-dependencies.el\")" --eval "(let ($(LET_VARIABLES)) $(LOAD_TEST_ERT_FILES) $(HYPB_ERT_FAILURE) $(HYPB_ERT_INTERACTIVE))"
 endif
 else
         # Typical case, run emacs normally
-	$(EMACS) --quick $(PRELOADS) --eval "(load-file \"test/hy-test-dependencies.el\")" --eval "(let ($(LET_VARIABLES)) $(LOAD_TEST_ERT_FILES) $(HYPB_ERT_INTERACTIVE))"
+	$(EMACS) --quick $(PRELOADS) --eval "(load-file \"test/hy-test-dependencies.el\")" --eval "(let ($(LET_VARIABLES)) $(LOAD_TEST_ERT_FILES) $(HYPB_ERT_FAILURE) $(HYPB_ERT_INTERACTIVE))"
 endif
 
 test-all-output:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:     31-Mar-25 at 00:35:45 by Mats Lidell
+# Last-Mod:      6-Apr-25 at 19:45:20 by Mats Lidell
 #
 # Copyright (C) 1994-2023  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -539,7 +539,7 @@ HYPB_ERT_BATCH = (ert-run-tests-batch-and-exit)
 HYPB_ERT_INTERACTIVE = (ert-run-tests-interactively t)
 endif
 ifeq ($(origin failure), command line)
-HYPB_ERT_FAILURE = (setq hy-test-failure ${failure})
+HYPB_ERT_FAILURE = (setq hy-test-run-failing-flag ${failure})
 endif
 
 # For full backtrace run make test FULL_BT=<anything or even empty>

--- a/test/hy-test-helpers.el
+++ b/test/hy-test-helpers.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     26-Jan-25 at 18:24:56 by Bob Weiner
+;; Last-Mod:     31-Mar-25 at 00:38:43 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -123,6 +123,9 @@ and the default WORD-LENGTH is 4."
         (setq result (concat result " ")))
       (setq result (concat result (char-to-string (elt chars (random (length chars)))))))
     (replace-regexp-in-string "[[:space:]]" "" (capitalize result))))
+
+(defvar hy-test-failure nil
+  "When non-nil run test cases that are known to fail.")
 
 (provide 'hy-test-helpers)
 ;;; hy-test-helpers.el ends here

--- a/test/hy-test-helpers.el
+++ b/test/hy-test-helpers.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     31-Mar-25 at 00:38:43 by Mats Lidell
+;; Last-Mod:      6-Apr-25 at 19:45:02 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -124,8 +124,8 @@ and the default WORD-LENGTH is 4."
       (setq result (concat result (char-to-string (elt chars (random (length chars)))))))
     (replace-regexp-in-string "[[:space:]]" "" (capitalize result))))
 
-(defvar hy-test-failure nil
-  "When non-nil run test cases that are known to fail.")
+(defvar hy-test-run-failing-flag nil
+  "Non-nil means test cases that are known to fail will be tried.")
 
 (provide 'hy-test-helpers)
 ;;; hy-test-helpers.el ends here


### PR DESCRIPTION
# What

Add support for running tests that are known to fail.

# Why

We want to be able to add failing test cases to master so that they
can be run from the command line, i.e. using make, but not affect the
regular CI builds.

# Note

Test that are known to fail can for normal runs be skipped by starting
the test with (skip-unless hy-test-failure). This skips the test on
regular execution of the tests either in batch or interactive mode.

For running these test cases add 'failure=t' on the command line. This
can be combined with 'test=<selector>' to further select which test
cases to run.
