### PR TITLE
accept M RET on all input with vertico

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,13 @@
 
 * hui-mouse.el (hkey-alist): Accept M-RET with vertico for all vertico input.
 
+* test/MANIFEST: Add hui-mouse-tests.el
+
+* test/hui-mouse-tests.el (hui-mouse-tests--hkey-alist): Verify a
+    predicate setting leads to the proper action.
+    (hui-mouse-tests--hkey-get-action): Helper that gets primary action
+    and assist action from hkey-alist for the predicates in effect.
+
 2025-04-06  Mats Lidell  <matsl@gnu.org>
 
 * test/hy-test-helpers.el (hy-test-run-failing-flag): Set to non-nil to

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2025-04-07  Mats Lidell  <matsl@gnu.org>
+
+* hui-mouse.el (hkey-alist): Accept M-RET with vertico for all vertico input.
+
 2025-04-06  Mats Lidell  <matsl@gnu.org>
 
 * test/hy-test-helpers.el (hy-test-run-failing-flag): Set to non-nil to

--- a/hui-mouse.el
+++ b/hui-mouse.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-89
-;; Last-Mod:     22-Feb-25 at 16:18:02 by Bob Weiner
+;; Last-Mod:     16-Mar-25 at 00:15:09 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -256,8 +256,7 @@ Its default value is `smart-scroll-down'.  To disable it, set it to
     ;; If in the minibuffer and reading an argument with vertico
     ;; run the vertico command on {M-RET} which accepts the first
     ;; line of minibuffer input, rather than any candidate.
-    ((and hargs:reading-type
-	  (> (minibuffer-depth) 0)
+    ((and (> (minibuffer-depth) 0)
 	  (eq (selected-window) (minibuffer-window))
 	  (not (bound-and-true-p ivy-mode))
 	  (and (bound-and-true-p vertico-mode)

--- a/test/MANIFEST
+++ b/test/MANIFEST
@@ -13,6 +13,7 @@ hpath-tests.el          - unit tests for hpath
 hsettings-test.el       - unit tests for hsettings
 hsys-org-tests.el       - hsys-org tests
 hui-mini-tests.el       - hui-mini tests
+hui-mouse-tests.el      - hui-mouse tests
 hui-register-tests.el   - test for hui-register
 hui-select-tests.el     - hui-select tests
 hui-tests.el            - tests for hui.el Hyperbole UI

--- a/test/hui-mouse-tests.el
+++ b/test/hui-mouse-tests.el
@@ -1,0 +1,71 @@
+;;; hui-mouse-tests.el --- unit tests for hui-mouse -*- lexical-binding: t; -*-
+;;
+;; Author:       Mats Lidell
+;;
+;; Orig-Date:    15-Mar-25 at 22:39:37
+;; Last-Mod:     16-Mar-25 at 01:14:39 by Mats Lidell
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
+;; Copyright (C) 2025 Free Software Foundation, Inc.
+;; See the "HY-COPY" file for license information.
+;;
+;; This file is part of GNU Hyperbole.
+
+;;; Commentary:
+;;
+;; Unit tests for "../hui-mouse.el".
+
+;;; Code:
+
+(require 'ert)
+(require 'el-mock)
+
+(defun hui-mouse-tests--hkey-get-action ()
+  "Return the action given by the predicate that is true.
+See `hkey-execute' for where this type of lookup is used."
+  (let ((hkey-forms hkey-alist)
+	pred-value hkey-actions hkey-form pred)
+    (while (and (null pred-value) (setq hkey-form (car hkey-forms)))
+      (if (setq hkey-actions (cdr hkey-form)
+	        pred (car hkey-form)
+		pred-value (hypb:eval-debug pred))
+          nil
+	(setq hkey-forms (cdr hkey-forms))))
+    hkey-actions))
+
+;; FIXME: Add more predicate cases from hkey-alist.
+(ert-deftest hui-mouse-tests--hkey-alist ()
+  "Verify that given predicate values triggers the proper action."
+  ;; Treemacs
+  (let ((major-mode 'treemacs-mode))
+    (should (equal (hui-mouse-tests--hkey-get-action)
+                   (cons '(smart-treemacs) '(smart-treemacs)))))
+
+  ;; dired-sidebar-mode
+  (let ((major-mode 'dired-sidebar-mode))
+    (should (equal (hui-mouse-tests--hkey-get-action)
+                   (cons '(smart-dired-sidebar) '(smart-dired-sidebar)))))
+
+  ;; Vertico
+  (defvar ivy-mode)
+  (defvar vertico-mode)
+  (let ((ivy-mode nil)
+        (vertico-mode t))
+    (mocklet (((minibuffer-depth) => 1)
+              ((selected-window) => t)
+              ((minibuffer-window) => t)
+              (vertico--command-p => t))
+      (should (equal (hui-mouse-tests--hkey-get-action)
+                     (cons '(vertico-exit-input) '(vertico-exit-input)))))))
+
+(provide 'hui-mouse-tests)
+
+;; This file can't be byte-compiled without the `el-mock' package
+;; which is not a dependency of Hyperbole.
+;;
+;; Local Variables:
+;; no-byte-compile: t
+;; End:
+
+;;; hui-mouse-tests.el ends here


### PR DESCRIPTION
# What

- **Treat M-RET on input as by vertico when active**
- **Add hui-mouse-tests for hkey-alist actions**

# Why

Vertico uses the keybinding M-RET for vertico-exit-input for exiting
the minibuffer using the current minibuffer input. For example when
creating a new file where there is no candidate to select. An
alternative is to use the uparrow to go to the input prompt and use
RET there. That fails however for the case when there is no input and
the empty input is used to terminate. The user gets stuck in this case
and only way out is to use M-x vertico-exit-input or similar tricks.

This PR takes the approach to always respect vertico's view when
reading an argument.

The PR is also a start for verifying that the hkey-alist will call the
expected actions from a given state and not something else.
