### PR TITLE
Fix hsys-org non-org-mode activate link tests to call proper action

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 2025-04-13  Bob Weiner  <rsw@gnu.org>
 
+* hbut.el (hattr:is-p): Add to abstract testing of hattr values.
+
 * hsys-org.el (hsys-org-thing-at-p): Fix to work outside of Org mode by
     suppressing warnings and ignoring Org regex errors.  This fixes two
     hsys-org tests where the 'www-url' ibtype fired instead of

--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:      5-Jan-25 at 11:27:31 by Bob Weiner
+;; Last-Mod:     13-Apr-25 at 11:20:12 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -946,6 +946,13 @@ Return TO-HBUT."
 (defun    hattr:get (obj-symbol attr-symbol)
   "Return value of OBJ-SYMBOL's attribute ATTR-SYMBOL."
   (get obj-symbol attr-symbol))
+
+(defun hattr:is-p (attr value &optional hbut-symbol)
+  "Return t if ATTR has VALUE for 'hbut:current or optional HBUT-SYMBOL."
+  (and (symbolp attr) attr 
+       (eq (hattr:get (or (and (symbolp hbut-symbol) hbut-symbol) 'hbut:current)
+		      attr)
+	   value)))
 
 (defun    hattr:list (obj)
   "Return a property list of OBJ's attributes.

--- a/test/hsys-org-tests.el
+++ b/test/hsys-org-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    23-Apr-21 at 20:55:00
-;; Last-Mod:     13-Apr-25 at 03:23:46 by Bob Weiner
+;; Last-Mod:     13-Apr-25 at 11:23:02 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -140,7 +140,8 @@ This is independent of the setting of `hsys-org-enable-smart-keys'."
             (insert "[[file:/tmp/abc][file]]\n")
             (goto-char 6)
             (should (equal hsys-org-enable-smart-keys v)) ; Traceability
-            (should (action-key)))))))
+            (should (action-key))
+	    (should (hattr:is-p 'actype #'org-open-at-point-global)))))))
 
 (ert-deftest hsys-org--org-outside-org-mode-tmp-file ()
   "Org links in a non `org-mode' file should work.
@@ -155,7 +156,8 @@ This is independent of the setting of `hsys-org-enable-smart-keys'."
             (let ((hsys-org-enable-smart-keys v))
               (mocklet (((org-open-at-point-global) => t))
                 (should (equal hsys-org-enable-smart-keys v)) ; Traceability
-                (should (action-key))))))
+                (should (action-key))
+		(should (hattr:is-p 'actype #'org-open-at-point-global))))))
       (hy-delete-file-and-buffer file))))
 
 (ert-deftest hsys-org--at-tags-p ()


### PR DESCRIPTION
Fixes `hsys-org--org-outside-org-mode-tmp-buffer' and
      `hsys-org--org-outside-org-mode-tmp-file'.