### PR TITLE
Remove byte compile warnings

### DIFF
--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:     14-Apr-25 at 23:07:21 by Bob Weiner
+;; Last-Mod:     16-Apr-25 at 10:42:06 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -892,8 +892,8 @@ Return the symbol for the button when found, else nil."
 ;;; ========================================================================
 
 (defun hattr:actype-is-p (actype-symbol &optional hbut-symbol)
-  "Return t if ACTYPE-SYMBOL matches an hbut's 'actype attr value.
-The hbut used defaults to 'hbut:current or the optional HBUT-SYMBOL."
+  "Return t if ACTYPE-SYMBOL matches an hbut's \='actype attr value.
+The hbut used defaults to \='hbut:current or the optional HBUT-SYMBOL."
   (hattr:is-p 'actype
 	      (or (actype:def-symbol actype-symbol) actype-symbol)
 	      hbut-symbol))
@@ -955,14 +955,14 @@ Return TO-HBUT."
   (get obj-symbol attr-symbol))
 
 (defun hattr:ibtype-is-p (ibtype-symbol &optional ibut-symbol)
-  "Return t if IBTYPE-SYMBOL matches an ibut's 'categ attr value.
-The ibut used defaults to 'hbut:current or the optional IBUT-SYMBOL."
+  "Return t if IBTYPE-SYMBOL matches an ibut's \='categ attr value.
+The ibut used defaults to \='hbut:current or the optional IBUT-SYMBOL."
   (hattr:is-p 'categ
 	      (or (ibtype:elisp-symbol ibtype-symbol) ibtype-symbol)
 	      ibut-symbol))
 
 (defun hattr:is-p (attr value &optional hbut-symbol)
-  "Return t if ATTR has VALUE for 'hbut:current or optional HBUT-SYMBOL."
+  "Return t if ATTR has VALUE for \='hbut:current or optional HBUT-SYMBOL."
   (and (symbolp attr) attr 
        (eq (hattr:get (or (and (symbolp hbut-symbol) hbut-symbol) 'hbut:current)
 		      attr)

--- a/hsys-org.el
+++ b/hsys-org.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Jul-16 at 14:54:14
-;; Last-Mod:     13-Apr-25 at 04:30:30 by Bob Weiner
+;; Last-Mod:     14-Apr-25 at 15:47:21 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -509,7 +509,6 @@ a non-Org buffer type."
     (if (derived-mode-p 'org-mode)
 	(let* ((org-plist (hsys-org-thing-at-p))
 	       (type (plist-get org-plist :type))
-	       (path (plist-get org-plist :path))
 	       label-start-end)
 	  (when (eq type 'link)
 	    (save-match-data

--- a/hsys-org.el
+++ b/hsys-org.el
@@ -537,10 +537,9 @@ a non-Org buffer type."
 	    (save-match-data
 	      ;; If this Org link matches a potential HyWiki word, ignore it.
 	      (when (not (and (fboundp 'hywiki-word-at) (hywiki-word-at)))
-                (let ((label-start-end (ibut:label-p t "[" "]" t)))
-		  (if label-start-end
-		      (cons (nth 1 label-start-end) (nth 2 label-start-end))
-		    t))))))))))
+		(if (setq label-start-end (ibut:label-p t "[" "]" t))
+		    (cons (nth 1 label-start-end) (nth 2 label-start-end))
+		  t)))))))))
 
 ;; Assume caller has already checked that the current buffer is in org-mode.
 (defun hsys-org-heading-at-p (&optional _)

--- a/hsys-xref.el
+++ b/hsys-xref.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    24-Aug-91
-;; Last-Mod:      2-Mar-25 at 18:11:45 by Bob Weiner
+;; Last-Mod:     14-Apr-25 at 15:51:27 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -27,6 +27,7 @@
 ;;; ************************************************************************
 
 (declare-function smart-emacs-lisp-mode-p "hmouse-tag")
+(declare-function hpath:at-p "hpath")
 
 ;;; ************************************************************************
 ;;; Public functions
@@ -49,7 +50,7 @@
   (car (hsys-xref-definitions identifier)))
 
 (defun hsys-xref-identifier-at-point ()
-  ;; Return nil if xref returns a pathname as an identifier
+  "Return nil if xref returns a pathname as an identifier."
   (unless (hpath:at-p nil t)
     (xref-backend-identifier-at-point (xref-find-backend))))
 

--- a/hui-select.el
+++ b/hui-select.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Oct-96 at 02:25:27
-;; Last-Mod:     27-Feb-25 at 21:24:19 by Bob Weiner
+;; Last-Mod:     14-Apr-25 at 15:53:22 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -327,6 +327,7 @@ Used to include a final line when marking indented code.")
 ;;; Public declarations
 ;;; ************************************************************************
 
+(defvar hbut:syntax-table)              ; "hbut.el"
 (defvar help-mode-syntax-table)         ; "help-mode.el"
 (defvar hkey-init)                      ; "hyperbole.el"
 (defvar hkey-value)                     ; "hui-mouse.el"

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Acpr-24 at 22:41:13
-;; Last-Mod:     13-Apr-25 at 02:03:01 by Bob Weiner
+;; Last-Mod:     14-Apr-25 at 15:54:03 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -2833,7 +2833,7 @@ Word may be of form:
  2. If WORD is the symbol, :range, and there is a HyWikiWord at point
     with an existing referent, return the tuple of values: (word
     word-start word-end) instead of the word; otherwise, return the tuple
-    '(nil nil nil).
+    \='(nil nil nil).
 
 When using the word at point, a call to `hywiki-active-in-current-buffer-p'
 at point must return non-nil or this function will return nil."


### PR DESCRIPTION
# What

Remove byte compile warnings

# Why

We should have as little warnings as possible.
