### PR TITLE
Fix hkey-alist vertico test

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2025-04-15  Mats Lidell  <matsl@gnu.org>
+
+* hui-mouse.el (hkey-alist): Cleanup. Remove whitespace.
+
+* test/hui-mouse-tests.el (hui-mouse-tests--hkey-alist): Defvar
+    vertico-mode for bound-and-true-p to see the let value.
+
 2025-04-14  Bob Weiner  <rsw@gnu.org>
 
 * test/hui-mouse-tests.el (hui-mouse-tests--hkey-alist): Update with new

--- a/hui-mouse.el
+++ b/hui-mouse.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-89
-;; Last-Mod:     13-Apr-25 at 14:49:05 by Bob Weiner
+;; Last-Mod:     15-Apr-25 at 12:51:50 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -260,7 +260,7 @@ Its default value is `smart-scroll-down'.  To disable it, set it to
     ((and (bound-and-true-p vertico-mode)
 	  ;; Is vertico prompting for an argument?
 	  (vertico--command-p nil (current-buffer)))
-     . ((funcall (lookup-key vertico-map (kbd "M-RET"))) 
+     . ((funcall (lookup-key vertico-map (kbd "M-RET")))
 	. (funcall (lookup-key vertico-map (kbd "M-RET")))))
     ;;
     ;; If in the minibuffer and reading a non-menu Hyperbole argument

--- a/test/hui-mouse-tests.el
+++ b/test/hui-mouse-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    15-Mar-25 at 22:39:37
-;; Last-Mod:     15-Apr-25 at 01:03:12 by Bob Weiner
+;; Last-Mod:     15-Apr-25 at 13:13:21 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -34,16 +34,14 @@
     (should (equal (hkey-actions)
                    (cons '(smart-dired-sidebar) '(smart-dired-sidebar)))))
 
-  ;; !! FIXME: In CI/CD tests, the hkey-alist smart-prog-at-tag-p is
-  ;; triggering instead of the vertico clause.  Works interactively
-  ;; but maybe needs more context specification.  Disable for now.
   ;; Vertico
-  ;; (let ((ivy-mode nil)
-  ;;       (vertico-mode t))
-  ;;   (mocklet ((vertico--command-p => t))
-  ;;     (should (equal (hkey-actions)
-  ;; 		     (cons '(funcall (lookup-key vertico-map (kbd "M-RET")))
-  ;; 			   '(funcall (lookup-key vertico-map (kbd "M-RET"))))))))
+  (defvar vertico-mode)
+  (let ((ivy-mode nil)
+        (vertico-mode t))
+    (mocklet ((vertico--command-p => t))
+      (should (equal (hkey-actions)
+		     (cons '(funcall (lookup-key vertico-map (kbd "M-RET")))
+			   '(funcall (lookup-key vertico-map (kbd "M-RET"))))))))
   )
 
 (provide 'hui-mouse-tests)


### PR DESCRIPTION
# What

Fix hkey-alist vertico tests.

# Why

Not sure why this ever worked but without defining the var vertico-mode
the call to bound-and-true-p will always return nil. So by adding the
defvar the precondition for vertico is fulfilled.
