### PR TITLE
hywiki words - Fix to recognize delimited filenames with wikiwords

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+* hibtypes.el (hywiki-existing-word):
+  hywiki.el (hywiki-word): Fix so if point is on an existing pathname that
+    is also a WikiWord, it jumps to the pathname rather than displaying the
+    WikiWord referent.  Also add (require 'hibtypes) to support this.
+
+* hywiki.el (hywiki-referent-exists-p): Remove (hywiki-word-at :range)
+    call since this did not also check for whether a referent exists.  This
+    fixes a bug in 'hywiki-existing-word'.
+
 2025-04-18  Bob Weiner  <rsw@gnu.org>
 
 * hywiki.el (hywiki-word-at): Remove unneeded clause that checks for opening

--- a/hact.el
+++ b/hact.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:     22-Dec-24 at 16:03:11 by Bob Weiner
+;; Last-Mod:     19-Apr-25 at 19:03:44 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -218,7 +218,7 @@ Assume PROPERTY is a valid set.  Use `eq' for comparison."
   (and htype-sym (hypb:indirect-function htype-sym)))
 
 (defun    htype:category (type-category)
-  "Return list of symbols in Hyperbole TYPE-CATEGORY in priority order.
+  "Return list of Elisp symbols in Hyperbole TYPE-CATEGORY in priority order.
 Symbols contain category component.
 TYPE-CATEGORY should be `actypes', `ibtypes' or nil for all."
   (let ((def-symbols (symset:get type-category 'symbols))
@@ -512,7 +512,11 @@ The type uses PARAMS to perform DEFAULT-ACTION (list of the rest of the
 arguments).  A call to this function is syntactically the same as for
 `defun', but a doc string is required.
 Return symbol created when successful, else nil."
-  (declare (doc-string 3))
+  (declare (indent defun)
+           (doc-string 3)
+           (debug (&define name lambda-list
+                           [&optional stringp] ; Doc string, if present.
+                           def-body)))
   `(progn
      (symtable:add ',type symtable:actypes)
      (htype:create ,type actypes ,doc ,params ,default-action nil)))

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:      2-Mar-25 at 12:05:51 by Bob Weiner
+;; Last-Mod:     19-Apr-25 at 17:51:14 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1710,10 +1710,12 @@ If a boolean function or variable, display its value."
   (cl-destructuring-bind (wikiword start end)
       (hywiki-referent-exists-p :range)
     (when wikiword
-      (if (and start end)
-	  (ibut:label-set wikiword start end)
-	(ibut:label-set wikiword))
-      (hact 'hywiki-find-referent wikiword))))
+      (unless (or (ibtypes::pathname-line-and-column)
+		  (ibtypes::pathname))
+	(if (and start end)
+	    (ibut:label-set wikiword start end)
+	  (ibut:label-set wikiword))
+	(hact 'hywiki-find-referent wikiword)))))
 
 ;;; ========================================================================
 ;;; Inserts completion into minibuffer or other window.


### PR DESCRIPTION
hibtypes.el (hywiki-existing-word):
hywiki.el (hywiki-word): Fix so if point is on an existing pathname that
    is also a WikiWord, it jumps to the pathname rather than displaying the
    WikiWord referent.  Also add (require 'hibtypes) to support this.

hywiki.el (hywiki-referent-exists-p): Remove (hywiki-word-at :range)
    call since this did not also check for whether a referent exists.  This
    fixes a bug in 'hywiki-existing-word'.