### PR TITLE
Add face verification for hywiki--word-face

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,20 @@
+2025-04-23  Mats Lidell  <matsl@gnu.org>
+
+* test/hywiki-tests.el (hywiki-tests--word-n-face-at): Verify that point
+    is at a WikiWord where WikiWord has hywiki--word-face set.
+    (hywiki-tests--with-face-test): Control type of WikiWord check.
+    (hywiki-tests--word-at): Use either hywiki-word-at or
+    hywiki-tests--word-n-face-at controlled by
+    hywiki-tests--with-face-test.
+    (hywiki-tests--verify-hywiki-word): Use hywiki-tests--word-at.
+    (hywiki-tests--wikiword-step-check-verification-with-faces): Run the
+    step-check test verifying WikiWords and faces. Test is behind failure
+    flag.
+
+* test/hy-test-helpers.el (hy-test-word-face-at-point): Check if
+    hywiki--word-face is set at point.
+    (hy-test-word-face-at-region): Check that region has hywiki--word-face set.
+
 2025-04-21  Mats Lidell  <matsl@gnu.org>
 
 * test/hywiki-tests.el (hywiki-tests--wikiword-step-check): Update test

--- a/test/hy-test-helpers.el
+++ b/test/hy-test-helpers.el
@@ -136,7 +136,7 @@ and the default WORD-LENGTH is 4."
         (cl-return t))))
 
 (defun hy-test-word-face-at-region (beg end)
-  "Non-nil if all chars in region [BEG, END] has `hywiki--word-face'."
+  "Non-nil if all chars in region [BEG, END] have `hywiki--word-face'."
   (interactive "r")
   (let (no-face)
     (while (and (< beg end) (not no-face))

--- a/test/hy-test-helpers.el
+++ b/test/hy-test-helpers.el
@@ -127,5 +127,23 @@ and the default WORD-LENGTH is 4."
 (defvar hy-test-run-failing-flag nil
   "Non-nil means test cases that are known to fail will be tried.")
 
+(defun hy-test-word-face-at-point (&optional pos)
+  "Non-nil if `hywiki--word-face' at POS."
+  (unless pos
+    (setq pos (point)))
+  (cl-dolist (ol (overlays-at pos) nil)
+    (if (equal (overlay-get ol 'face) 'hywiki--word-face)
+        (cl-return t))))
+
+(defun hy-test-word-face-at-region (beg end)
+  "Non-nil if all chars in region [BEG, END] has `hywiki--word-face'."
+  (interactive "r")
+  (let (no-face)
+    (while (and (< beg end) (not no-face))
+      (unless (hy-test-word-face-at-point beg)
+        (setq no-face t))
+      (setq beg (1+ beg)))
+    (not no-face)))
+
 (provide 'hy-test-helpers)
 ;;; hy-test-helpers.el ends here


### PR DESCRIPTION
# What

Add face verification for hywiki--word-face.

Make a copy of the step check that does the same verification but adds
a check of the face of the matching WikiWord.

# Why

WikiWords should not only be recognized as text but should also have
the right face for visual feedback to the user. 

This combines the check of the text with a check that an overlay
exists with the right face.

# Note

The test does fails due to the face check. Is it thus put behind the
failure flag to not be executed in the CI.



