### PR TITLE
Require warnings to silence byte compilation warnings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,9 @@
 2025-04-25  Mats Lidell  <matsl@gnu.org>
 
+* hsys-org.el: Require 'warnings to get definition of variables
+    `warning-minimum-level' and `warning-suppress-log-types' else causing
+    byte compilation warnings.
+
 * test/MANIFEST: Add resource folders.
 
 * test/hmouse-drv-resources/test-data.el:
@@ -12,12 +16,6 @@
 
 * test/hibtypes-tests.el (ibtypes::ctags-vgrind-test)
     (ibtypes::etags-test): Use test resources.
-
-2025-04-24  Mats Lidell  <matsl@gnu.org>
-
-* hsys-org.el: Require 'warnings to get definition of variables
-    `warning-minimum-level' and `warning-suppress-log-types' else causing
-    byte compilation warnings.
 
 2025-04-23  Mats Lidell  <matsl@gnu.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,12 @@
 * test/hibtypes-tests.el (ibtypes::ctags-vgrind-test)
     (ibtypes::etags-test): Use test resources.
 
+2025-04-24  Mats Lidell  <matsl@gnu.org>
+
+* hsys-org.el: Require 'warnings to get definition of variables
+    `warning-minimum-level' and `warning-suppress-log-types' else causing
+    byte compilation warnings.
+
 2025-04-23  Mats Lidell  <matsl@gnu.org>
 
 * test/hywiki-tests.el (hywiki-tests--word-n-face-at): Verify that point

--- a/hsys-org.el
+++ b/hsys-org.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Jul-16 at 14:54:14
-;; Last-Mod:     20-Apr-25 at 22:25:14 by Mats Lidell
+;; Last-Mod:     24-Apr-25 at 15:31:03 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -39,6 +39,7 @@
 (require 'org-fold nil t)
 (require 'org-macs)
 (require 'package)
+(require 'warnings)
 ;; Avoid any potential library name conflict by giving the load directory.
 (require 'set (expand-file-name "set" hyperb:dir))
 


### PR DESCRIPTION
# What

Require warnings to get the definition of variables in the package.

# Why

The variables `warning-minimum-level` and `warning-suppress-log-types`
are not autoloaded. So not seen when byte compiling. By requiring
'warnings the variables are defined.

We could defvar them but requiring warnings cause no risk of circular
dependencies so is the preferred way to resolve this, IMHO.
