### PR TITLE
add missing wikipage in test

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 2025-04-26  Mats Lidell  <matsl@gnu.org>
 
+* hywiki.el (hywiki-word-face-at-p): Add optional pos to enable reuse.
+
+* test/hy-test-helpers.el (hy-test-word-face-at-region): Simplify by
+    reusing hywiki-word-face-at-p.
+
 * test/hywiki-tests.el
     (hywiki-tests--wikiword-step-check-verification-with-faces): Add
     missing WikiWord, Hiho, required by the test. Enable the test for CI.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,9 @@
 2025-04-26  Mats Lidell  <matsl@gnu.org>
 
+* test/hywiki-tests.el
+    (hywiki-tests--wikiword-step-check-verification-with-faces): Add
+    missing WikiWord, Hiho, required by the test. Enable the test for CI.
+
 * test/hywiki-tests.el:
 * test/hui-tests.el:
 * test/hmouse-info-tests.el:

--- a/hywiki.el
+++ b/hywiki.el
@@ -3173,9 +3173,11 @@ a HyWikiWord at point."
 	    (= (matching-paren (char-before (nth 1 range)))
 	       (char-after (nth 2 range))))))))
 
-(defun hywiki-word-face-at-p ()
-  "Non-nil if but at point has `hywiki-word-face' property."
-  (hproperty:but-get (point) 'face hywiki-word-face))
+(defun hywiki-word-face-at-p (&optional pos)
+  "Non-nil if but at point or optional POS has `hywiki-word-face' property."
+  (unless pos
+    (setq pos (point)))
+  (hproperty:but-get pos 'face hywiki-word-face))
 
 ;;;###autoload
 (defun hywiki-word-consult-grep (word)

--- a/test/hy-test-helpers.el
+++ b/test/hy-test-helpers.el
@@ -21,6 +21,7 @@
 (require 'ert)
 (require 'hmouse-drv)                   ; For `action-key'
 (eval-when-compile (require 'cl-lib))
+(require 'hywiki)
 
 (defun hy-test-helpers:consume-input-events ()
   "Use `recursive-edit' to consume the events kbd-key generates."
@@ -127,20 +128,12 @@ and the default WORD-LENGTH is 4."
 (defvar hy-test-run-failing-flag nil
   "Non-nil means test cases that are known to fail will be tried.")
 
-(defun hy-test-word-face-at-point (&optional pos)
-  "Non-nil if `hywiki--word-face' at POS."
-  (unless pos
-    (setq pos (point)))
-  (cl-dolist (ol (overlays-at pos) nil)
-    (if (equal (overlay-get ol 'face) 'hywiki--word-face)
-        (cl-return t))))
-
 (defun hy-test-word-face-at-region (beg end)
   "Non-nil if all chars in region [BEG, END] have `hywiki--word-face'."
   (interactive "r")
   (let (no-face)
     (while (and (< beg end) (not no-face))
-      (unless (hy-test-word-face-at-point beg)
+      (unless (hywiki-word-face-at-p beg)
         (setq no-face t))
       (setq beg (1+ beg)))
     (not no-face)))

--- a/test/hy-test-helpers.el
+++ b/test/hy-test-helpers.el
@@ -21,7 +21,6 @@
 (require 'ert)
 (require 'hmouse-drv)                   ; For `action-key'
 (eval-when-compile (require 'cl-lib))
-(require 'hywiki)
 
 (defun hy-test-helpers:consume-input-events ()
   "Use `recursive-edit' to consume the events kbd-key generates."

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -1386,6 +1386,7 @@ resulting state at point is a WikiWord or not."
   "Run the step check to verify WikiWord is identified under change.
 Performs each operation from the step check and verifies if the
 resulting state at point is a WikiWord or not."
+  (skip-unless (not noninteractive))
   (hywiki-tests--preserve-hywiki-mode
     (let* ((hywiki-directory (make-temp-file "hywiki" t))
            (wikiHiHo (cdr (hywiki-add-page "HiHo")))

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -1386,13 +1386,13 @@ resulting state at point is a WikiWord or not."
   "Run the step check to verify WikiWord is identified under change.
 Performs each operation from the step check and verifies if the
 resulting state at point is a WikiWord or not."
-  (skip-unless hy-test-run-failing-flag)
   (hywiki-tests--preserve-hywiki-mode
     (let* ((hywiki-directory (make-temp-file "hywiki" t))
            (wikiHiHo (cdr (hywiki-add-page "HiHo")))
+           (wikiHiho (cdr (hywiki-add-page "Hiho")))
            (wikiHi (cdr (hywiki-add-page "Hi")))
            (wikiHo (cdr (hywiki-add-page "Ho")))
-           (wiki-page-list (list wikiHiHo wikiHi wikiHo))
+           (wiki-page-list (list wikiHiHo wikiHiho wikiHi wikiHo))
            (hywiki-tests--with-face-test t))
       (unwind-protect
           (progn


### PR DESCRIPTION
# What

- **Add missing WikiPage required for successful test**
- **Refactor: Reuse hywiki-word-face-at-p**
- **Add skip-unless guard for face test**

# Why

The good news: The with face test was failing due to that the WikiPage
Hiho was not created. So now plain textual WikiWord verification works
as well when the overlay face is checked.  

The bad news: The test of course needs to be run interactively only to
work.

The even odder and possibly worse news: I have a simple test, that
when I run manually in my Emacs fails, but works in the CI or if I run
it in dockerized Emacs!? The test recipe is simple:
  1. Enter a WikiWord (WikiWord is highlighted)
  2. Add a space after (WikiWord is still highlighted)
  3. Remove the space (WikiWord is still highlighted)
  4. Add space again after. WikiWord is not highlighted.
 

