### PR TITLE
Use ert test resources

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,18 @@
+2025-04-25  Mats Lidell  <matsl@gnu.org>
+
+* test/MANIFEST: Add resource folders.
+
+* test/hmouse-drv-resources/test-data.el:
+  test/hmouse-drv-resources/TAGS:
+  test/hibtypes-resources/test-data.el:
+  test/hibtypes-resources/TAGS: Test resources.
+
+* test/hmouse-drv-tests.el (hbut-ctags-vgrind-test, hbut-etags-test): Use
+    test resources.
+
+* test/hibtypes-tests.el (ibtypes::ctags-vgrind-test)
+    (ibtypes::etags-test): Use test resources.
+
 2025-04-23  Mats Lidell  <matsl@gnu.org>
 
 * test/hywiki-tests.el (hywiki-tests--word-n-face-at): Verify that point

--- a/test/MANIFEST
+++ b/test/MANIFEST
@@ -33,3 +33,7 @@ kotl-orgtbl-tests.el    - kotl orgtbl tests
 set-tests.el            - mathematical set library tests
 smart-org-tests.el      - smart-org-el tests
 test-helpers-tests.el   - unit test of the test helpers
+
+--- HYPERBOLE TEST RESOURCES ---
+hibtypes-resources      - test resources for hibtypes-tests
+hmouse-drv-resources    - test resources for hmouse-drv-tests

--- a/test/hibtypes-resources/TAGS
+++ b/test/hibtypes-resources/TAGS
@@ -1,0 +1,3 @@
+
+test-data.el,25
+(defun test-func 19,386

--- a/test/hibtypes-resources/test-data.el
+++ b/test/hibtypes-resources/test-data.el
@@ -1,0 +1,21 @@
+;;; test-data.el
+
+;; Author:       Mats Lidell <matsl@gnu.org>
+;;
+;; Orig-Date:    24-Apr-25 at 22:20:39
+;; Last-Mod:     24-Apr-25 at 22:22:16 by Mats Lidell
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
+;; Copyright (C) 2025  Free Software Foundation, Inc.
+;; See the "HY-COPY" file for license information.
+;;
+;; This file is part of GNU Hyperbole.
+
+;;; Commentary:
+
+;;; Code:
+
+(defun test-func ()
+  "Test function."
+  nil)

--- a/test/hibtypes-tests.el
+++ b/test/hibtypes-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    20-Feb-21 at 23:45:00
-;; Last-Mod:      8-Sep-24 at 00:48:52 by Mats Lidell
+;; Last-Mod:     24-Apr-25 at 23:49:38 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -19,6 +19,7 @@
 ;;; Code:
 
 (require 'ert)
+(require 'ert-x)
 (require 'hibtypes)
 (require 'info)
 (require 'el-mock)
@@ -215,36 +216,32 @@
 
 ;; ctags
 ;; Seems ctags -v does not give the proper answer
-;; FIXME: Rewrite to not depend on hy-test-helpers.el
 (ert-deftest ibtypes::ctags-vgrind-test ()
-  (unwind-protect
-      (with-temp-buffer
-        (insert "hy-test-helpers:consume-input-events hy-test-helpers.el 25\n")
-        (goto-char (point-min))
-        (forward-char 4)
-        (let ((default-directory (expand-file-name "test" hyperb:dir)))
+  (let ((default-directory (ert-resource-directory)))
+    (unwind-protect
+        (with-temp-buffer
+          (insert "test-func test-data.el 19\n")
+          (goto-char (point-min))
+          (forward-char 4)
           (ibtypes::ctags)
-          (set-buffer "hy-test-helpers.el")
-          (should (looking-at "(defun hy-test-helpers:consume-input-events"))))
-    (kill-buffer "hy-test-helpers.el")))
+          (set-buffer "test-data.el")
+          (should (looking-at "(defun test-func")))
+      (hy-test-helpers:kill-buffer "test-data.el"))))
 
 ;; etags
-;; FIXME: Rewrite to not depend on hy-test-helpers.el
 (ert-deftest ibtypes::etags-test ()
-  (unwind-protect
-      (with-temp-buffer
-        (insert "\n")
-        (insert "hy-test-helpers.el,237\n")
-        (insert "(defun hy-test-helpers:consume-input-events 25,518\n")
-        (rename-buffer (concat "TAGS" (buffer-name)))
-        (goto-char (point-min))
-        (forward-line 2)
-        (forward-char 10)
-        (let ((default-directory (expand-file-name "test" hyperb:dir)))
+  (let ((tags (find-file (ert-resource-file "TAGS")))
+        (default-directory (ert-resource-directory)))
+    (unwind-protect
+        (with-current-buffer tags
+          (goto-char (point-min))
+          (forward-line 2)
+          (forward-char 10)
           (ibtypes::etags)
-          (set-buffer "hy-test-helpers.el")
-          (should (looking-at "(defun hy-test-helpers:consume-input-events"))))
-    (kill-buffer "hy-test-helpers.el")))
+          (set-buffer "test-data.el")
+          (should (looking-at "(defun test-func")))
+      (hy-test-helpers:kill-buffer "test-data.el")
+      (hy-test-helpers:kill-buffer tags))))
 
 ;; cscope
 

--- a/test/hmouse-drv-resources/TAGS
+++ b/test/hmouse-drv-resources/TAGS
@@ -1,0 +1,3 @@
+
+test-data.el,25
+(defun test-func 19,386

--- a/test/hmouse-drv-resources/test-data.el
+++ b/test/hmouse-drv-resources/test-data.el
@@ -1,0 +1,21 @@
+;;; test-data.el
+
+;; Author:       Mats Lidell <matsl@gnu.org>
+;;
+;; Orig-Date:    24-Apr-25 at 22:20:39
+;; Last-Mod:     24-Apr-25 at 22:22:16 by Mats Lidell
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
+;; Copyright (C) 2025  Free Software Foundation, Inc.
+;; See the "HY-COPY" file for license information.
+;;
+;; This file is part of GNU Hyperbole.
+
+;;; Commentary:
+
+;;; Code:
+
+(defun test-func ()
+  "Test function."
+  nil)

--- a/test/hmouse-drv-tests.el
+++ b/test/hmouse-drv-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    28-Feb-21 at 22:52:00
-;; Last-Mod:     13-Apr-25 at 15:43:05 by Bob Weiner
+;; Last-Mod:     24-Apr-25 at 23:21:25 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -20,6 +20,7 @@
 ;;; Code:
 
 (require 'ert)
+(require 'ert-x)
 (require 'hbut)
 (require 'el-mock)
 (require 'with-simulated-input)
@@ -457,37 +458,33 @@
 
 ;; ctags
 ; Seems ctags -v does not give the proper answer
-;; FIXME: Rewrite to not depend on hy-test-helpers.el
 (ert-deftest hbut-ctags-vgrind-test ()
   (unwind-protect
       (with-temp-buffer
-        (insert "hy-test-helpers:consume-input-events hy-test-helpers.el 25\n")
+        (insert "test-func test-data.el 19\n")
         (goto-char (point-min))
         (forward-char 4)
-        (let ((default-directory (expand-file-name "test" hyperb:dir)))
+        (let ((default-directory (ert-resource-directory)))
           (action-key)
 	  (should (hattr:ibtype-is-p 'ctags))
-          (should (looking-at "(defun hy-test-helpers:consume-input-events"))))
-    (hy-test-helpers:kill-buffer "hy-test-helpers.el")))
+          (should (looking-at "(defun test-func"))))
+    (hy-test-helpers:kill-buffer "test-data.el")))
 
 ;; etags
-;; FIXME: Rewrite to not depend on hy-test-helpers.el
 (ert-deftest hbut-etags-test ()
-  (unwind-protect
-      (with-temp-buffer
-        (insert "\n")
-        (insert "hy-test-helpers.el,237\n")
-        (insert "(defun hy-test-helpers:consume-input-events 25,518\n")
-        (rename-buffer (concat "TAGS" (buffer-name)))
-        (goto-char (point-min))
-        (forward-line 2)
-        (forward-char 10)
-        (let ((default-directory (expand-file-name "test" hyperb:dir)))
-          (action-key)
-	  (should (hattr:ibtype-is-p 'etags))
-          (set-buffer "hy-test-helpers.el")
-          (should (looking-at "(defun hy-test-helpers:consume-input-events"))))
-    (hy-test-helpers:kill-buffer "hy-test-helpers.el")))
+  (let ((tags (find-file (ert-resource-file "TAGS"))))
+    (unwind-protect
+        (with-current-buffer tags
+          (goto-char (point-min))
+          (forward-line 2)
+          (forward-char 10)
+          (let ((default-directory (ert-resource-directory)))
+            (action-key)
+	    (should (hattr:ibtype-is-p 'etags))
+            (set-buffer "test-data.el")
+            (should (looking-at "(defun test-func"))))
+      (hy-test-helpers:kill-buffer "test-data.el")
+      (hy-test-helpers:kill-buffer tags))))
 
 ;; text-toc
 (ert-deftest hbut-text-toc-test ()


### PR DESCRIPTION
# What

Remove dependency on test file for test data.

# Why

Using a file use for testing as test data in test causes many odd test
failures when the file needs updates. That is bad. This replaces that
construct with ert test resources. That is a feature we have not been
using that we might want to explore further in the future.

