### PR TITLE
Use ert-simulate-keys

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,14 @@
+2025-04-26  Mats Lidell  <matsl@gnu.org>
+
+* test/hywiki-tests.el:
+* test/hui-tests.el:
+* test/hmouse-info-tests.el:
+* test/hmouse-drv-tests.el:
+* test/hargs-tests.el: Use ert-simulate-keys. Replaces external dependency
+    on with-simulated-input.
+
+* test/hy-test-dependencies.el: Remove dependency on with-simulated-input.
+
 2025-04-25  Mats Lidell  <matsl@gnu.org>
 
 * hsys-org.el: Require 'warnings to get definition of variables

--- a/test/hargs-tests.el
+++ b/test/hargs-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    04-Feb-22 at 23:00:00
-;; Last-Mod:     20-Jan-24 at 19:38:11 by Mats Lidell
+;; Last-Mod:     25-Apr-25 at 19:57:44 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -19,7 +19,7 @@
 ;;; Code:
 
 (require 'ert)
-(require 'with-simulated-input)
+(require 'ert-x)
 (require 'hargs)
 (require 'hy-test-helpers "test/hy-test-helpers")
 
@@ -29,15 +29,15 @@
   (let ((file (make-temp-file "hypb")))
     (unwind-protect
         (progn
-          (with-simulated-input "xyz RET"
+          (ert-simulate-keys "xyz\r"
             (should (string= (hargs:get "+I: ") "xyz")))
-          (with-simulated-input "xyz RET"
+          (ert-simulate-keys "xyz\r"
             (should (string= (hargs:get "+L: ") "xyz")))
-          (with-simulated-input '((insert "xyz" file) "RET")'
+          (ert-simulate-keys (concat "(\"xyz\" \"" file "\")\r")
             (should (equal (hargs:get "+M: ") (list "xyz" file))))
-          (with-simulated-input "xyz RET"
+          (ert-simulate-keys "xyz\r"
             (should (string= (hargs:get "+V: ") "xyz")))
-          (with-simulated-input "xyz RET"
+          (ert-simulate-keys "xyz\r"
             (should (string= (hargs:get "+X: ") "(dir)xyz")))
           (should-error (hargs:get "+A: ") :type 'error))
       (hy-delete-file-and-buffer file))))
@@ -66,12 +66,6 @@
       (goto-char (car v))
       (should (string= (cadr v) (hargs:sexpression-p)))
       (should (string= (caddr v) (hargs:sexpression-p t))))))
-
-;; This file can't be byte-compiled without `with-simulated-input' which
-;; is not part of the actual dependencies, so:
-;;   Local Variables:
-;;   no-byte-compile: t
-;;   End:
 
 (provide 'hargs-tests)
 ;;; hargs-tests.el ends here

--- a/test/hmouse-drv-tests.el
+++ b/test/hmouse-drv-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    28-Feb-21 at 22:52:00
-;; Last-Mod:     24-Apr-25 at 23:21:25 by Mats Lidell
+;; Last-Mod:     25-Apr-25 at 10:01:41 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -23,7 +23,6 @@
 (require 'ert-x)
 (require 'hbut)
 (require 'el-mock)
-(require 'with-simulated-input)
 (require 'hy-test-helpers "test/hy-test-helpers")
 
 (ert-deftest hbut-defal ()
@@ -191,7 +190,7 @@
   (with-temp-buffer
     (insert "\"/tmp\"\n")
     (goto-char 3)
-    (with-simulated-input "TMP RET"
+    (ert-simulate-keys "TMP\r"
       (let ((enable-recursive-minibuffers t))
 	(hui:ibut-label-create)
 	(should (string= "<[TMP]> - \"/tmp\"\n" (buffer-string)))))))
@@ -201,7 +200,7 @@
   (with-temp-buffer
     (insert "<[LBL]>: \"/tmp\"\n")
     (goto-char 14)
-    (with-simulated-input "TMP RET"
+    (ert-simulate-keys "TMP\r"
       (condition-case err
           (hui:ibut-label-create)
         (error
@@ -656,10 +655,8 @@ The frame setup is mocked."
       (hy-delete-file-and-buffer filea)
       (hy-delete-file-and-buffer fileb))))
 
-;; This file can't be byte-compiled without the `el-mock' and
-;; `with-simulated-input' package (because of the use of the
-;; `with-mock' and `with-simulated-input' macro), which is not a
-;; dependency of Hyperbole.
+;; This file can't be byte-compiled without the `el-mock' package
+;; which is not a dependency of Hyperbole.
 ;;  Local Variables:
 ;;  no-byte-compile: t
 ;;  End:

--- a/test/hmouse-info-tests.el
+++ b/test/hmouse-info-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    29-Dec-21 at 09:02:00
-;; Last-Mod:     22-May-22 at 11:11:53 by Mats Lidell
+;; Last-Mod:     25-Apr-25 at 19:56:35 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -19,12 +19,12 @@
 ;;; Code:
 
 (require 'ert)
+(require 'ert-x)
 (require 'hmouse-info)
-(require 'with-simulated-input)
 
 (ert-deftest hmouse-info-read-index-with-completion ()
   "Read a completion that completes."
-  (with-simulated-input "(emacs)regex TAB RET"
+  (ert-simulate-keys "(emacs)regex\t\r"
     (should (string= "(emacs)regexp" (Info-read-index-item-name "Prompt: ")))))
 
 (ert-deftest hmouse-info-build-completions-no-match ()
@@ -45,13 +45,6 @@
         (dolist (m (Info-build-menu-item-completions "regexp" nil t))
           (should (string-prefix-p "regexp" m t))))
     (kill-buffer "*info*")))
-
-;; This file can't be byte-compiled without the `with-simulated-input'
-;; package (because of the use of the `with-simulated-input' macro),
-;; which is not a dependency of Hyperbole.
-;;  Local Variables:
-;;  no-byte-compile: t
-;;  End:
 
 (provide 'hmouse-info-tests)
 ;;; hmouse-info-tests.el ends here

--- a/test/hpath-tests.el
+++ b/test/hpath-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    28-Feb-21 at 23:26:00
-;; Last-Mod:      7-Mar-25 at 10:21:48 by Mats Lidell
+;; Last-Mod:     25-Apr-25 at 21:51:39 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -491,7 +491,7 @@ dir/subdir:
 
 (provide 'hpath-tests)
 
-:; This file can't be byte-compiled without the `el-mock' package
+;; This file can't be byte-compiled without the `el-mock' package
 ;; which is not a dependency of Hyperbole.
 ;;
 ;; Local Variables:

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     20-Apr-25 at 15:12:11 by Bob Weiner
+;; Last-Mod:     25-Apr-25 at 19:50:39 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -19,7 +19,7 @@
 ;;; Code:
 
 (require 'ert)
-(require 'with-simulated-input)
+(require 'ert-x)
 (require 'el-mock)
 (require 'hy-test-helpers "test/hy-test-helpers")
 (require 'hibtypes)
@@ -56,7 +56,7 @@
 		   (setenv "HOME" "/tmp")
 
 		   (set-buffer gbut-file-buffer)
-		   (with-simulated-input create-gbut
+		   (ert-simulate-keys (kbd create-gbut)
 		     (hact (lambda () (call-interactively 'hui:gbut-create))))
 
 		   ;; Create using program
@@ -66,7 +66,7 @@
 		   (should (eq (hattr:get (hbut:at-p) 'actype) 'actypes::link-to-file))
 
 		   (goto-char (point-max)) ;; Move past button so does not prompt with label
-		   (with-simulated-input edit-gbut
+		   (ert-simulate-keys (kbd edit-gbut)
 		     (hact (lambda () (call-interactively 'hui:gbut-edit))))
 
 		   ;; (set-buffer gbut-file-buffer)
@@ -149,7 +149,7 @@
   (with-temp-buffer
     (insert "\"/tmp\"\n")
     (goto-char 3)
-    (with-simulated-input "TMP RET"
+    (ert-simulate-keys "TMP\r"
       (hui:ibut-label-create)
       (should (string= "<[TMP]> - \"/tmp\"\n" (buffer-string))))))
 
@@ -158,7 +158,7 @@
   (with-temp-buffer
     (insert "<[LBL]>: \"/tmp\"\n")
     (goto-char 14)
-    (with-simulated-input "TMP RET"
+    (ert-simulate-keys "TMP\r"
       (condition-case err
           (hui:ibut-label-create)
         (error
@@ -183,7 +183,7 @@
   (let ((file (make-temp-file "hypb_" nil ".txt")))
     (unwind-protect
         (find-file file)
-        (with-simulated-input "label RET www-url RET www.hypb.org RET"
+        (ert-simulate-keys "label\rwww-url\rwww.hypb.org\r"
           (hui:ebut-create)
           (hy-test-helpers-verify-hattr-at-p :actype 'actypes::www-url :args '("www.hypb.org") :loc file :lbl-key "label"))
       (hy-delete-file-and-buffer file))))
@@ -194,10 +194,10 @@ Ensure modifying the button but keeping the label does not create a double label
   (let ((file (make-temp-file "hypb_" nil ".txt")))
     (unwind-protect
         (find-file file)
-        (with-simulated-input "label RET www-url RET www.hypb.org RET"
+        (ert-simulate-keys "label\rwww-url\rwww.hypb.org\r"
           (hui:ebut-create)
           (hy-test-helpers-verify-hattr-at-p :actype 'actypes::www-url :args '("www.hypb.org") :loc file :lbl-key "label"))
-        (with-simulated-input "RET RET RET RET"
+        (ert-simulate-keys "\r\r\r\r"
           (hui:ebut-edit "label")
           (hy-test-helpers-verify-hattr-at-p :actype 'actypes::www-url :args '("www.hypb.org") :loc file :lbl-key "label")
           (should (string= "<(label)>" (buffer-string)))))
@@ -628,7 +628,7 @@ Ensure modifying the button but keeping the label does not create a double label
     (unwind-protect
         (progn
           (find-file file)
-	  (with-simulated-input "ibut RET link-to-rfc RET 123 RET"
+	  (ert-simulate-keys "ibut\rlink-to-rfc\r123\r"
 	    (hact (lambda () (call-interactively 'hui:ibut-create))))
           (should (string= "<[ibut]> - rfc123" (buffer-string))))
       (hy-delete-file-and-buffer file))))
@@ -642,7 +642,7 @@ Ensure modifying the button but keeping the label does not create a double label
           (insert "ibut")
           (set-mark (point-min))
           (goto-char (point-max))
-	  (with-simulated-input "RET link-to-rfc RET 123 RET"
+	  (ert-simulate-keys "\rlink-to-rfc\r123\r"
 	    (hact (lambda () (call-interactively 'hui:ibut-create))))
           (should (string= "<[ibut]> - rfc123" (buffer-string))))
       (hy-delete-file-and-buffer file))))
@@ -655,7 +655,7 @@ Ensure modifying the button but keeping the label does not create a double label
         (progn
           (find-file file)
           (insert "(sexp)")
-	  (with-simulated-input "ibut RET link-to-rfc RET 123 RET"
+	  (ert-simulate-keys "ibut\rlink-to-rfc\r123\r"
 	    (hact (lambda () (call-interactively 'hui:ibut-create))))
           (should (string= "(sexp); <[ibut]> - rfc123" (buffer-string))))
       (hy-delete-file-and-buffer file))))
@@ -668,7 +668,7 @@ Ensure modifying the button but keeping the label does not create a double label
           (find-file file)
           (insert "\"/tmp\"")
           (goto-char 3)
-	  (with-simulated-input "label RET"
+	  (ert-simulate-keys "label\r"
 	    (hact (lambda () (call-interactively 'hui:ibut-label-create))))
           (should (string= "<[label]> - \"/tmp\"" (buffer-string))))
       (hy-delete-file-and-buffer file))))
@@ -682,7 +682,7 @@ With point on label suggest that ibut for rename."
           (find-file file)
           (insert "<[label]> - rfc123")
           (goto-char 3)
-	  (with-simulated-input "M-DEL renamed RET"
+	  (ert-simulate-keys (kbd "M-DEL renamed RET")
 	    (hact (lambda () (call-interactively 'hui:ibut-rename))))
           (should (string= "<[renamed]> - rfc123" (buffer-string))))
       (hy-delete-file-and-buffer file))))
@@ -695,7 +695,7 @@ With point on label suggest that ibut for rename."
           (find-file file)
           (insert "<[label]> - rfc123")
           (goto-char (point-max))
-	  (with-simulated-input "label RET M-DEL renamed RET"
+	  (ert-simulate-keys (kbd "label RET M-DEL renamed RET")
 	    (hact (lambda () (call-interactively 'hui:ibut-rename))))
           (should (string= "<[renamed]> - rfc123" (buffer-string))))
       (hy-delete-file-and-buffer file))))
@@ -708,7 +708,7 @@ With point on label suggest that ibut for rename."
           (find-file file)
           (insert "<[label]> - rfc123")
           (goto-char (point-max))
-          (with-simulated-input "RET"
+          (ert-simulate-keys "\r"
 	    (should-error (hui:ibut-rename "notalabel") :type 'error)))
       (hy-delete-file-and-buffer file))))
 
@@ -828,7 +828,7 @@ With point on label suggest that ibut for rename."
           (goto-char (point-max))
           (split-window)
           (find-file filea)
-          (with-simulated-input "label RET"
+          (ert-simulate-keys "label\r"
             (hui:ibut-link-directly (get-buffer-window) (get-buffer-window (get-file-buffer fileb)) 4))
           (should (string= (buffer-string) (concat "<[label]> - " "\""
 				       (file-name-nondirectory fileb)
@@ -917,7 +917,7 @@ With point on label suggest that ibut for rename."
           (goto-char (point-max))
           (split-window)
           (find-file filea)
-          (with-simulated-input "button RET"
+          (ert-simulate-keys "button\r"
             (hui:ebut-link-directly (get-buffer-window)
                                     (get-buffer-window (get-file-buffer fileb)))
             (should (string= (buffer-string) "<(button)>"))
@@ -946,7 +946,7 @@ With point on label suggest that ibut for rename."
 	    (goto-char (1- (point))))
           (split-window)
           (find-file file)
-          (with-simulated-input "button RET"
+          (ert-simulate-keys "button\r"
             (hui:ebut-link-directly (get-buffer-window) (get-buffer-window dir-buf))
 	    ;; Implicit link should be the `dir' dired directory,
 	    ;; possibly minus the final directory '/'.
@@ -979,7 +979,7 @@ With point on label suggest that ibut for rename."
         (mocklet ((gbut:file => global-but-file))
           (delete-other-windows)
           (find-file file)
-          (with-simulated-input "button RET"
+          (ert-simulate-keys "button\r"
             (hui:gbut-link-directly t)
             (with-current-buffer (find-buffer-visiting global-but-file)
               (should (string= (buffer-string)
@@ -998,7 +998,7 @@ With point on label suggest that ibut for rename."
         (mocklet ((gbut:file => global-but-file))
           (delete-other-windows)
           (find-file file)
-          (with-simulated-input "button RET"
+          (ert-simulate-keys "button\r"
             (hui:gbut-link-directly)
             (with-current-buffer (find-buffer-visiting global-but-file)
               (should (string= (buffer-string) "First\n<(button)>\n"))
@@ -1445,7 +1445,7 @@ line 1
       (should (string= "abcjkl" (buffer-string)))
       (should (string= "{def}{ghi}" (car kill-ring))))))
 
-;; This file can't be byte-compiled without `with-simulated-input' which
+;; This file can't be byte-compiled without the `el-mock' which
 ;; is not part of the actual dependencies, so:
 ;;   Local Variables:
 ;;   no-byte-compile: t

--- a/test/hy-test-dependencies.el
+++ b/test/hy-test-dependencies.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    20-Feb-21 at 23:16:00
-;; Last-Mod:     26-Dec-24 at 22:40:40 by Bob Weiner
+;; Last-Mod:     25-Apr-25 at 19:28:36 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -36,7 +36,7 @@
   (require pkg-symbol))
 
 (mapc (lambda (sym) (hy-test-ensure-package-installed sym))
-      '(el-mock with-simulated-input))
+      '(el-mock))
 
 ;; Needed when `hypb:display-file-with-logo' uses `org-mode'
 (setq hsys-org-enable-smart-keys t)

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -19,7 +19,7 @@
 
 (require 'ert)
 (require 'el-mock)
-(require 'with-simulated-input)
+(require 'ert-x)
 (require 'hy-test-helpers)
 (require 'hywiki)
 (require 'hsys-org)
@@ -866,10 +866,10 @@ Note special meaning of `hywiki-allow-plurals-flag'."
     (unwind-protect
         (progn
           (find-file file)
-          (with-simulated-input "RET"
+          (ert-simulate-keys "\r"
             (should-error (hywiki-add-bookmark "WikiWord")))
           (bookmark-set "bookmark")
-          (with-simulated-input "bookmark RET"
+          (ert-simulate-keys "bookmark\r"
             (hywiki-add-bookmark "WikiWord")
             (should (equal '(bookmark . "bookmark") (hywiki-get-referent "WikiWord")))))
       (hy-delete-file-and-buffer file)
@@ -880,7 +880,7 @@ Note special meaning of `hywiki-allow-plurals-flag'."
   (let ((hywiki-directory (make-temp-file "hywiki" t))
 	(wikiword "WikiWord"))
     (unwind-protect
-	(with-simulated-input "hpath:find RET"
+	(ert-simulate-keys "hpath:find\r"
 	  (hywiki-add-command wikiword)
 	  (should (equal '(command . hpath:find)
 			 (hywiki-get-referent wikiword))))
@@ -918,7 +918,7 @@ Note special meaning of `hywiki-allow-plurals-flag'."
   "Verify `hywiki-add-info-index'."
   (let ((hywiki-directory (make-temp-file "hywiki" t)))
     (unwind-protect
-        (with-simulated-input "files RET"
+        (ert-simulate-keys "files\r"
           (info "emacs")
 	  (hywiki-add-info-index "WikiWord")
 	  (should (equal '(info-index . "(emacs)files") (hywiki-get-referent "WikiWord"))))
@@ -928,7 +928,7 @@ Note special meaning of `hywiki-allow-plurals-flag'."
   "Verify `hywiki-add-info-node'."
   (let ((hywiki-directory (make-temp-file "hywiki" t)))
     (unwind-protect
-	(with-simulated-input "(emacs) RET"
+	(ert-simulate-keys "(emacs)\r"
 	  (hywiki-add-info-node "WikiWord")
 	  (should (equal '(info-node . "(emacs)") (hywiki-get-referent "WikiWord"))))
       (hy-delete-dir-and-buffer hywiki-directory))))
@@ -938,10 +938,10 @@ Note special meaning of `hywiki-allow-plurals-flag'."
   (let ((hywiki-directory (make-temp-file "hywiki" t)))
     (unwind-protect
 	(progn
-	  (with-simulated-input "ABC RET"
+	  (ert-simulate-keys "ABC\r"
 	    (hywiki-add-key-series "WikiWord")
 	    (should (equal '(key-series . "{ABC}") (hywiki-get-referent "WikiWord"))))
-	  (with-simulated-input "{ABC} RET"
+	  (ert-simulate-keys "{ABC}\r"
 	    (hywiki-add-key-series "WikiWord")
 	    (should (equal '(key-series . "{ABC}") (hywiki-get-referent "WikiWord")))))
       (hy-delete-dir-and-buffer hywiki-directory))))
@@ -1042,7 +1042,7 @@ up the test."
   "Verify saving and loading a referent keyseries works ."
   (hywiki-tests--referent-test
    (cons 'key-series "{ABC}")
-   (with-simulated-input "ABC RET"
+   (ert-simulate-keys "ABC\r"
      (hywiki-add-key-series wiki-referent))))
 
 ;; FIXME: Not stable. Can sometimes succeed.
@@ -1062,7 +1062,7 @@ up the test."
   (hywiki-tests--referent-test
    (cons 'bookmark "bmark")
    (bookmark-set "bmark")
-   (with-simulated-input "bmark RET"
+   (ert-simulate-keys "bmark\r"
      (hywiki-add-bookmark wiki-referent))))
 
 (ert-deftest hywiki-tests--save-referent-bookmark-use-menu ()
@@ -1085,7 +1085,7 @@ up the test."
   "Verify saving and loading a referent command works."
   (hywiki-tests--referent-test
     (cons 'command #'hywiki-tests--command)
-    (with-simulated-input "hywiki-tests--command RET"
+    (ert-simulate-keys "hywiki-tests--command\r"
       (hywiki-add-command wiki-referent))))
 
 (ert-deftest hywiki-tests--save-referent-command-use-menu ()
@@ -1154,7 +1154,7 @@ up the test."
   (hywiki-tests--referent-test
    (cons 'info-index "(emacs)files")
    (save-excursion
-     (with-simulated-input "files RET"
+     (ert-simulate-keys "files\r"
        (info "emacs")
        (hywiki-add-info-index wiki-referent)))))
 
@@ -1177,7 +1177,7 @@ up the test."
    (cons 'info-node "(emacs)")
    (save-excursion
      (unwind-protect
-         (with-simulated-input "(emacs) RET"
+         (ert-simulate-keys "(emacs)\r"
            (hywiki-add-info-node wiki-referent))
        (kill-buffer "*info*")))))
 


### PR DESCRIPTION
# What

Refactor: Use ert-simulate-keys.

# Why

Replaces external dependency on with-simulated-input with similar
functionality from the ert-x package, which is part of Emacs.

