### PR TITLE
Use or

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,9 @@
 2025-04-27  Mats Lidell  <matsl@gnu.org>
 
+* hywiki.el (hywiki-word-face-at-p):
+* hibtypes.el (smerge): Use or instead of setq. Thanks Stefan Monnier for
+    the suggestion.
+
 * man/hyperbole.texi (Implicit Button Types): smerge ibut.
     (Smart Key - Magit Mode): Merge conflict lines.
 

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:     27-Apr-25 at 17:17:18 by Mats Lidell
+;; Last-Mod:     27-Apr-25 at 17:30:02 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -45,7 +45,7 @@
 (require 'org-macs) ;; for org-uuid-regexp
 (require 'subr-x) ;; for string-trim
 (require 'thingatpt)
-(require 'smerge-mode) ;; for smerge-keep-{all,upper,lower}
+(require 'smerge-mode) ;; for smerge-keep-{all, upper, lower}
 
 ;;; ************************************************************************
 ;;; Public declarations
@@ -1747,12 +1747,11 @@ If a boolean function or variable, display its value."
 On a merge conflict marker, keep either the upper, both or the lower
 version of the conflict."
   (when (bound-and-true-p smerge-mode)
-    (let ((op
-           (save-excursion
-             (beginning-of-line)
-             (cond ((looking-at smerge-end-re) #'smerge-keep-lower)
-                   ((looking-at smerge-begin-re) #'smerge-keep-upper)
-                   ((looking-at smerge-lower-re) #'smerge-keep-all)))))
+    (let ((op (save-excursion
+                (beginning-of-line)
+                (cond ((looking-at smerge-end-re) #'smerge-keep-lower)
+                      ((looking-at smerge-begin-re) #'smerge-keep-upper)
+                      ((looking-at smerge-lower-re) #'smerge-keep-all)))))
       (when op
         (save-excursion
           (ibut:label-set (match-string-no-properties 0) (match-beginning 0) (match-end 0))

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:     27-Apr-25 at 17:09:24 by Mats Lidell
+;; Last-Mod:     27-Apr-25 at 17:17:18 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -45,7 +45,7 @@
 (require 'org-macs) ;; for org-uuid-regexp
 (require 'subr-x) ;; for string-trim
 (require 'thingatpt)
-(eval-when-compile (require 'smerge-mode))
+(require 'smerge-mode) ;; for smerge-keep-{all,upper,lower}
 
 ;;; ************************************************************************
 ;;; Public declarations
@@ -1747,15 +1747,12 @@ If a boolean function or variable, display its value."
 On a merge conflict marker, keep either the upper, both or the lower
 version of the conflict."
   (when (bound-and-true-p smerge-mode)
-    (let (op)
-      (save-excursion
-        (beginning-of-line)
-        (cond ((looking-at smerge-end-re)
-               (setq op 'smerge-keep-lower))
-              ((looking-at smerge-begin-re)
-               (setq op 'smerge-keep-upper))
-              ((looking-at smerge-lower-re)
-               (setq op 'smerge-keep-all))))
+    (let ((op
+           (save-excursion
+             (beginning-of-line)
+             (cond ((looking-at smerge-end-re) #'smerge-keep-lower)
+                   ((looking-at smerge-begin-re) #'smerge-keep-upper)
+                   ((looking-at smerge-lower-re) #'smerge-keep-all)))))
       (when op
         (save-excursion
           (ibut:label-set (match-string-no-properties 0) (match-beginning 0) (match-end 0))

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Acpr-24 at 22:41:13
-;; Last-Mod:     27-Apr-25 at 01:21:36 by Bob Weiner
+;; Last-Mod:     27-Apr-25 at 14:35:33 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -3181,11 +3181,9 @@ a HyWikiWord at point."
 
 (defun hywiki-word-face-at-p (&optional pos)
   "Non-nil if but at point or optional POS has `hywiki-word-face' property."
-  (unless pos
-    (setq pos (point)))
   ;; Sometimes this can return a left over button/overlay that points
   ;; to no buffer.  Ignore this case.
-  (hproperty:but-get pos 'face hywiki-word-face))
+  (hproperty:but-get (or pos (point)) 'face hywiki-word-face))
 
 ;;;###autoload
 (defun hywiki-word-consult-grep (word)


### PR DESCRIPTION
# What

Use or.

# Why

More compact code. Suggested by Stefan Monnier.

# Note

Changed also to a plain require of smerge since the function
attribution on the smerge-keep-* functions still caused a warning when
using eval-when-compile!? Not sure why but :shrug:
