### PR TITLE
Add before-save-hook for automating date updates to manual

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2025-04-28  Mats Lidell  <matsl@gnu.org>
+
+* man/.dir-locals.el: Add before-save-hook for automating date updates.
+
 2025-04-27  Mats Lidell  <matsl@gnu.org>
 
 * man/hyperbole.texi (Implicit Button Types): Add anchor to all ibtypes.

--- a/man/.dir-locals.el
+++ b/man/.dir-locals.el
@@ -1,0 +1,19 @@
+((texinfo-mode
+  . ((before-save-hook
+      . (lambda ()
+          (let ((day (format-time-string "%d" (current-time)))
+                (month (capitalize (format-time-string "%B" (current-time))))
+                (year (format-time-string "%Y" (current-time))))
+            (save-excursion
+              (goto-char (point-min))
+              (when (re-search-forward "\\(@set UPDATED [[:word:]]+, [[:digit:]]+\\)" nil t)
+                (replace-match (format "@set UPDATED %s, %s" month year) nil t nil nil))
+              (goto-char (point-min))
+              (when (re-search-forward "\\(@set UPDATED-MONTH [[:word:]]+ [[:digit:]]+\\)" nil t)
+                (replace-match (format "@set UPDATED-MONTH %s %s" month year) nil t nil nil))
+              (goto-char (point-min))
+              (when (re-search-forward "\\(Printed [[:word:]]+ [[:digit:]]+, [[:digit:]]+\.\\)" nil t)
+                (replace-match (format "Printed %s %s, %s." month day year) nil t nil nil))
+              (goto-char (point-min))
+              (when (re-search-forward "\\([[:word:]]+ [[:digit:]]+, [[:digit:]]+ @c AUTO-REPLACE-ON-SAVE\\)" nil t)
+                (replace-match (format "%s %s, %s @c AUTO-REPLACE-ON-SAVE" month day year) nil t nil nil)))))))))


### PR DESCRIPTION
# What

Add before-save-hook for automating date updates.

# Why

It is easy to forget.

# Notes

What do you think of this? To gross? :smile:

Could maybe be extended to save `hyperb:version` as well?

Last replacement uses a trick to use a command as anchor for the
search. The anchor could be made smaller, to look prettier, and the
technique might be worth adding to all substitutions since it also
works as documentation.

