### PR TITLE
kotl-mode.el - Extend {C-j} kotl-mode:add-cell with 0 and neg. args

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,11 +1,44 @@
+2025-05-04  Bob Weiner  <rsw@gnu.org>
+
+* kotl/kotl-mode.el (kotl-mode:add-after-parent): Add back in to add successive
+    sibling cells of a parent cell or if at the top-level, as the first cells in
+    the outline.
+  test/kotl-mode-tests.el (kotl-mode-tests--sanity-check-function-list): Add
+    'kotl-mode:add-after-parent'.
+
+2025-05-03  Bob Weiner  <rsw@gnu.org>
+
+* kotl/kotl-mode.el (kotl-mode:add-cell): Update doc string and handling of
+    negative prefix args to add that many cells prior to the current cell.  Also,
+    change 0 arg to add a single cell as the parent's first child.
+                    (kotl-mode:add-child): Use prefix arg to add a sequence
+    of child cells.
+                    (kotl-mode:add-below-parent): Rename from
+    'kotl-mode:add-after-parent'.  Use prefix arg to add a sequence of initial
+    children cells below the parent of the current cell.
+                    (kotl-mode:add-prior-cell): Use prefix arg to add a sequence
+    of prior sibling cells or with C-u, add as the initial cells at the start of
+    the current cell level (first children of its parent).
+
+2025-04-29  Bob Weiner  <rsw@gnu.org>
+
+* kotl/kotl-mode.el (kotl-mode:add-prior-cell): Add optional prefix arg flag
+    to add that many prior sibling cells unless on a level 1 cell or when given
+    a single C-u prefand when given insert cell as the the parent's first child.
+    Bind this to {C-c p}.
+                   (kotl-mode:add-before-parent): Add prior sibling to parent
+    cell.  If on top-level, add first cell at that level.
+  kotl/kmenu.el (kotl-menu-common-body): Add above function to Koutline menu
+    as well as 'kotl-mode:add-below-parent'.
+
 2025-04-27  Mats Lidell  <matsl@gnu.org>
 
-* hywiki.el (hywiki-word-face-at-p):
-* hibtypes.el (smerge): Use or instead of setq. Thanks Stefan Monnier for
+* hywiki.el   (hywiki-word-face-at-p):
+  hibtypes.el (smerge): Use or instead of setq. Thanks Stefan Monnier for
     the suggestion.
 
 * man/hyperbole.texi (Implicit Button Types): smerge ibut.
-    (Smart Key - Magit Mode): Merge conflict lines.
+                     (Smart Key - Magit Mode): Merge conflict lines.
 
 2025-04-27  Bob Weiner  <rsw@gnu.org>
 
@@ -144,11 +177,11 @@
 * kotl/kotl-mode.el (kotl-mode:add-prior-cell): Add to insert a cell
     prior to the current cell at the same level as the current cell.
 
-* kotl/kmenu.el (kotl-menu-common-body): Change 'Add-Parent' to
-    'Add-After-Parent'.
+* kotl/kmenu.el (kotl-menu-common-body): Change 'Add-Parent' to two
+    commands: 'Add-After-Parent and 'Add-Below-Parent'.
 
 * kotl/kotl-mode.el (kotl-mode:add-parent): Rename to
-   'kotl-mode:add-after-parent'.
+   'kotl-mode:add-below-parent'.
 
 2025-04-19  Bob Weiner  <rsw@gnu.org>
 

--- a/hui-mouse.el
+++ b/hui-mouse.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-89
-;; Last-Mod:     27-Apr-25 at 16:49:19 by Mats Lidell
+;; Last-Mod:      4-May-25 at 10:38:03 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -348,13 +348,13 @@ Its default value is `smart-scroll-down'.  To disable it, set it to
 	. (smart-menu hkey-value)))
     ;;
     ;; View minor mode
-    ((if (boundp 'view-minor-mode) view-minor-mode)
+    ((bound-and-true-p view-mode)
      . ((cond ((last-line-p)
 	       (view-quit))
 	      ((pos-visible-in-window-p (point-max))
 	       (goto-char (point-max)))
-	      (t (scroll-up)))
-	. (scroll-down)))
+	      (t (View-scroll-page-forward)))
+	. (View-scroll-page-backward)))
     ;;
     ;; Direct access selection of helm-major-mode completions
     ((setq hkey-value (and (or (eq major-mode 'helm-major-mode)
@@ -380,10 +380,6 @@ Its default value is `smart-scroll-down'.  To disable it, set it to
 	      (stringp br-feature-tags-file)
 	      (equal br-feature-tags-file (hypb:buffer-file-name))))
      . ((smart-element) . (hkey-help)))
-    ;;
-    ;; View major mode
-    ((eq major-mode 'view-mode) .
-     ((View-scroll-lines-forward) . (View-scroll-lines-backward)))
     ;;
     ;; Select or select-and-kill a markup pair (e.g. hmtl tags), list,
     ;; array/vector, set, function, comment or string that begins or

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Acpr-24 at 22:41:13
-;; Last-Mod:     27-Apr-25 at 12:19:38 by Bob Weiner
+;; Last-Mod:      4-May-25 at 10:46:18 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -551,7 +551,7 @@ Non-nil is the default."
 
 (defun hywiki-debuttonize-non-character-commands ()
   "Store any HyWikiWord before or after point for later comparison.
-Triggered by `pre-command-hook' for non-character -commands, including
+Triggered by `pre-command-hook' for non-character commands, including
 deletion commands and those in `hywiki-non-character-commands'."
   (setq hywiki--word-pre-command nil)
   (set-marker hywiki--buttonize-start nil)

--- a/kotl/EXAMPLE.kotl
+++ b/kotl/EXAMPLE.kotl
@@ -14,20 +14,21 @@
 
    3. Features implemented include:
 
-     3a. Full on screen editing (just like a Macintosh).  Click to type in a
-         node (we call them cells) and just enter text.  Structure is
-         automatically maintained for you.  All of the standard Emacs editor
-         command set is supported both through keyboard, menu and mouse
-         interaction.  Menu usage is documented in the Hyperbole Manual; this
-         document discusses features and their associated keyboard commands
-         only.
+     3a. Full on-screen editing without the need for any markup.
+         Click to type in a node (we call them cells) and just enter
+         text.  Structure is automatically maintained for you.  All of
+         the standard Emacs editor command set is supported both
+         through keyboard, menu and mouse interaction.  Menu usage is
+         documented in the Hyperbole Manual; this document discusses
+         features and their associated keyboard commands only.
 
      3b. Advanced outline processing
 
-       3b1. Autonumbering: Full auto-numbering in Augment (1a2) or legal
-            (1.1.2) formats.  Augment style is the default.  Use {C-c C-l ?}
-            to see the full set of label types and to select a different
-            label type.
+       3b1. Autonumbering: Full auto-numbering in Augment (1a2) or
+            legal (1.1.2) formats.  Augment style is the default
+            because it is shorter and quicker to read.  Use {C-c C-l
+            ?}  to see the full set of label types and to select a
+            different label type.
 
        3b2. Label Separators: By default, the Koutliner separates labels from
             cell contents by two spaces.  If you want to change the separator
@@ -40,8 +41,17 @@
        3b3. Cell Creation: {C-j} adds a new cell as a sibling following the
             current cell.  {C-u C-j} or {C-c a} adds the cell as a child of
             the current cell.  Any other positive prefix arg to {C-j} adds
-            that many following cells at the same level as the current one.
-            {C-c p} adds the cell as the sibling of the current cell's
+            that many following cells at the same level as the current
+            one.  A negative prefix arg to {C-j} adds that many
+            preceding cells at the same level as the current one.  And
+            a zero prefix arg adds a new cell as the first one in the
+            outline at the top level.
+            
+            {C-c p} adds the cell as the preceding sibling of the current
+            cell, i.e. a new cell immediately prior to the current cell at
+            the same level; same as {C-u -1 C-j}.
+            
+            {C-u C-c p} adds the cell as the sibling of the current cell's
             parent.
 
        3b4. Cell and Tree Deletion: {C-c C-k} kills the current cell and its

--- a/kotl/kmenu.el
+++ b/kotl/kmenu.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    28-Mar-94 at 11:22:09
-;; Last-Mod:     20-Apr-25 at 00:28:33 by Bob Weiner
+;; Last-Mod:      4-May-25 at 11:24:29 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -44,6 +44,8 @@
        :active t :keys "M-TAB"]
       "----"
       ["Add-After-Parent"    kotl-mode:add-after-parent     t]
+      ["Add-Before-Parent"   kotl-mode:add-before-parent    t]
+      ["Add-Below-Parent"    kotl-mode:add-below-parent     t]
       ["Add-Child"           kotl-mode:add-child            t]
       ["Add-Cell"            kotl-mode:add-cell             t]
       ["Append-Cell"         kotl-mode:append-cell          t]

--- a/man/hyperbole.texi
+++ b/man/hyperbole.texi
@@ -7,7 +7,7 @@
 @c Author:       Bob Weiner
 @c
 @c Orig-Date:     6-Nov-91 at 11:18:03
-@c Last-Mod:     27-Apr-25 at 17:00:36 by Mats Lidell
+@c Last-Mod:      4-May-25 at 10:45:09 by Bob Weiner
 
 @c %**start of header (This is for running Texinfo on a region.)
 @setfilename hyperbole.info
@@ -30,8 +30,8 @@
 @set txicodequoteundirected
 @set txicodequotebacktick
 
-@set UPDATED April, 2025
-@set UPDATED-MONTH April 2025
+@set UPDATED May, 2025
+@set UPDATED-MONTH May 2025
 @set EDITION 9.0.2pre
 @set VERSION 9.0.2pre
 
@@ -171,7 +171,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.</P>
 
 <PRE>
 Edition 9.0.2pre
-Printed April 27, 2025.
+Printed May 4, 2025.
 
   Published by the Free Software Foundation, Inc.
   Author:    Bob Weiner
@@ -213,7 +213,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
 @example
 Edition 9.0.2pre
-April 27, 2025
+May 4, 2025
 
   Published by the Free Software Foundation, Inc.
   Author:    Bob Weiner
@@ -9510,8 +9510,8 @@ REFERENCE should be a cell-ref or a string containing "filename, cell-ref".
 See the documentation for @code{(kcell:ref-to-id)} for valid cell-ref
 formats.
 
-@findex kotl-mode:add-after-parent
-@item kotl-mode:add-after-parent  @bkbd{C-c p}
+@findex kotl-mode:add-below-parent
+@item kotl-mode:add-below-parent  @bkbd{C-c p}
 Add a new cell to current kview after current cell's parent.
 If parent is the hidden root cell 0, then add as the first cell of the
 outline.  Otherwise, add it as the next sibling of the parent cell.
@@ -10860,10 +10860,10 @@ When pressed on a Hyperbole button:
 @cindex view mode
 @format
 @group
-If pressed within a buffer in View major or minor mode:
+If pressed within a buffer in View minor mode:
   ACTION KEY
-     Scrolls the buffer forward a windowful.  If at the last line of the
-     buffer, instead quits from view mode.
+     Scrolls the buffer forward a windowful; if last line is visible, move to the
+     last line.  If at the last line of the buffer, instead quits from view mode.
   ASSIST KEY
      Scrolls the buffer backward a windowful.
 @end group

--- a/test/kotl-mode-tests.el
+++ b/test/kotl-mode-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    18-May-21 at 22:14:10
-;; Last-Mod:     20-Apr-25 at 00:28:41 by Bob Weiner
+;; Last-Mod:      4-May-25 at 11:16:56 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -975,9 +975,10 @@ optional DEPTH the number of sub cells are created to that depth."
     (make-kotl-mode-tests--func :func #'kimport:insert-file :ignore t)
     (make-kotl-mode-tests--func :func #'kimport:insert-register :args '(?a))
     (make-kotl-mode-tests--func :func #'klink:create :args '("1a"))
+    (make-kotl-mode-tests--func :func #'kotl-mode:add-after-parent)
     (make-kotl-mode-tests--func :func #'kotl-mode:add-cell)
     (make-kotl-mode-tests--func :func #'kotl-mode:add-child)
-    (make-kotl-mode-tests--func :func #'kotl-mode:add-after-parent)
+    (make-kotl-mode-tests--func :func #'kotl-mode:add-below-parent)
     (make-kotl-mode-tests--func :func #'kotl-mode:append-cell :args '("1a" "1a1"))
     (make-kotl-mode-tests--func :func #'kotl-mode:back-to-indentation)
     (make-kotl-mode-tests--func :func #'kotl-mode:backward-cell :args '(1))
@@ -1073,7 +1074,7 @@ optional DEPTH the number of sub cells are created to that depth."
     (make-kotl-mode-tests--func :func #'kvspec:activate)
     (make-kotl-mode-tests--func :func #'kvspec:toggle-blank-lines))
   "List of functions to sanity check and their arguments if needed.
-Functions that does not allow themselves to be checked in this way are
+Functions that do not allow themselves to be checked in this way are
 marked with :ignore t")
 
 (defun kotl-mode--sanity-check-function (function args)


### PR DESCRIPTION
kotl-mode.el - Extend {C-j} kotl-mode:add-cell with 0 and neg. args

kotl-mode.el - Extend supporting commands to take contents, plist and
   no-fill args.

hui-mouse.el - Remove outdated View major mode support and update
  View minor mode handler.