### PR TITLE
refactor hkey execute

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2025-05-12  Mats Lidell  <matsl@gnu.org>
+
+* test/hmouse-drv-tests.el (hmouse-drv--hkey-actions): Test hkey-actions.
+    (hmouse-drv--hkey-exekute): Test hkey-execute.
+    (hmouse-drv--hkey-execute-called, hmouse-drv--hkey-execute-action)
+    (hmouse-drv--hkey-execute-assist): Helpers used in hkey-execute
+    verification.
+
 2025-05-08  Mats Lidell  <matsl@gnu.org>
 
 * hui-mouse.el (hkey-alist): Use deprecated but still supported calling

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,7 @@
 2025-05-12  Mats Lidell  <matsl@gnu.org>
 
 * test/hmouse-drv-tests.el (hmouse-drv--hkey-actions): Test hkey-actions.
-    (hmouse-drv--hkey-exekute): Test hkey-execute.
+    (hmouse-drv--hkey-execute): Test hkey-execute.
     (hmouse-drv--hkey-execute-called, hmouse-drv--hkey-execute-action)
     (hmouse-drv--hkey-execute-assist): Helpers used in hkey-execute
     verification.

--- a/hmouse-drv.el
+++ b/hmouse-drv.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-90
-;; Last-Mod:      7-May-25 at 22:20:47 by Mats Lidell
+;; Last-Mod:     10-May-25 at 00:19:45 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -992,29 +992,6 @@ frame instead."
           (mouse-drag-frame-move start-event)
         (mouse-drag-frame start-event 'move))))))
 
-(defun hkey-actions ()
-  "Return the cons of the Action and Assist Key actions at point.
-Useful in testing Smart Key contexts."
-  (let ((hkey-forms hkey-alist)
-        (pred-point (point-marker))
-	pred-value hkey-actions hkey-form pred)
-    (progn
-      (while (and (null pred-value) (setq hkey-form (car hkey-forms)))
-	(setq pred (car hkey-form)
-	      pred-value (hypb:eval-debug pred))
-	(unless (equal (point-marker) pred-point)
-	  (hypb:error "(Hyperbole): predicate %s improperly moved point from %s to %s"
-		      pred (point) pred-point))
-	(if pred-value
-            (progn
-              ;; Conditionally debug after Smart Key release and evaluation
-	      ;; of matching predicate but before hkey-action is executed.
-	      (when hkey-debug
-		(hkey-debug pred pred-value (if assist-flag (cdr hkey-actions) (car hkey-actions))))
-              (setq hkey-actions (cdr hkey-form)))
-	  (setq hkey-forms (cdr hkey-forms))))
-      hkey-actions)))
-
 (defun hkey-debug (pred pred-value hkey-action)
   "Display a message with the context and values from Smart Key activation."
   (message (concat "(HyDebug) %sContext: %s; %s: %s; Buf: %s; Mode: %s; MinibufDepth: %s\n"
@@ -1043,6 +1020,29 @@ Useful in testing Smart Key contexts."
 	   action-key-release-window
 	   assist-key-depress-window
 	   assist-key-release-window))
+
+(defun hkey-actions ()
+  "Return the cons of the Action and Assist Key actions at point.
+Useful in testing Smart Key contexts."
+  (let ((hkey-forms hkey-alist)
+        (pred-point (point-marker))
+	pred-value hkey-actions hkey-form pred)
+    (progn
+      (while (and (null pred-value) (setq hkey-form (car hkey-forms)))
+	(setq pred (car hkey-form)
+	      pred-value (hypb:eval-debug pred))
+	(unless (equal (point-marker) pred-point)
+	  (hypb:error "(Hyperbole): predicate %s improperly moved point from %s to %s"
+		      pred (point) pred-point))
+	(if pred-value
+            (progn
+              (setq hkey-actions (cdr hkey-form))
+              ;; Conditionally debug after Smart Key release and evaluation
+	      ;; of matching predicate but before hkey-action is executed.
+	      (when hkey-debug
+		(hkey-debug pred pred-value (if assist-flag (cdr hkey-actions) (car hkey-actions)))))
+	  (setq hkey-forms (cdr hkey-forms))))
+      hkey-actions)))
 
 (defun hkey-execute (assisting)
   "Evaluate Action Key form for first non-nil predicate from `hkey-alist'.

--- a/test/hmouse-drv-tests.el
+++ b/test/hmouse-drv-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    28-Feb-21 at 22:52:00
-;; Last-Mod:     12-May-25 at 15:57:39 by Mats Lidell
+;; Last-Mod:     17-May-25 at 16:07:56 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -685,7 +685,7 @@ The frame setup is mocked."
 (defun hmouse-drv--hkey-execute-action () "Action." (setq hmouse-drv--hkey-execute-called "action"))
 (defun hmouse-drv--hkey-execute-assist () "Assist." (setq hmouse-drv--hkey-execute-called "assist"))
 
-(ert-deftest hmouse-drv--hkey-exekute ()
+(ert-deftest hmouse-drv--hkey-execute ()
   "Verify `hkey-execute'."
   ;; No action
   (let ((hkey-alist '((nil . ("action" . "assist")))))

--- a/test/hmouse-drv-tests.el
+++ b/test/hmouse-drv-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    28-Feb-21 at 22:52:00
-;; Last-Mod:     25-Apr-25 at 10:01:41 by Mats Lidell
+;; Last-Mod:     12-May-25 at 15:57:39 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -654,6 +654,57 @@ The frame setup is mocked."
                              result)))))
       (hy-delete-file-and-buffer filea)
       (hy-delete-file-and-buffer fileb))))
+
+(ert-deftest hmouse-drv--hkey-actions ()
+  "Verify `hkey-actions'."
+  ;; No action
+  (let ((hkey-alist '((nil . ((action) . (assist))))))
+    (should-not (hkey-actions)))
+
+  (let ((hkey-alist '((t . ((action) . (assist))))))
+    ;; Normal case
+    (should (equal (hkey-actions) '((action) assist)))
+
+    ;; Point is moved by predicate
+    (let ((marker 1))
+      (cl-letf (((symbol-function 'point-marker)
+                 (lambda () (setq marker (1+ marker)))))
+        (let ((err (should-error (hkey-actions) :type 'error)))
+          (should (string-match-p
+                   (format "(Hyperbole): predicate %s improperly moved point from %s to %s" t 1 2)
+                   (cadr err))))))
+
+    ;; Debug is called for action and assist.
+    (let ((hkey-debug t))
+      (dolist (v '(nil t))
+        (let ((assist-flag v))
+          (mocklet (((hkey-debug t t (if assist-flag '(assist) '(action))) => t))
+            (should (equal (hkey-actions) '((action) assist)))))))))
+
+(defvar hmouse-drv--hkey-execute-called nil "For checking what method was called.")
+(defun hmouse-drv--hkey-execute-action () "Action." (setq hmouse-drv--hkey-execute-called "action"))
+(defun hmouse-drv--hkey-execute-assist () "Assist." (setq hmouse-drv--hkey-execute-called "assist"))
+
+(ert-deftest hmouse-drv--hkey-exekute ()
+  "Verify `hkey-execute'."
+  ;; No action
+  (let ((hkey-alist '((nil . ("action" . "assist")))))
+    (should-not (hkey-execute nil)))
+
+  ;; Normal case with action or assist
+  (let ((hkey-alist '((t . ((hmouse-drv--hkey-execute-action) . (hmouse-drv--hkey-execute-assist)))))
+        hmouse-drv--hkey-execute-called)
+    ;; Action
+    (should (equal (hkey-execute nil) '(hmouse-drv--hkey-execute-action)))
+    (should (string= hmouse-drv--hkey-execute-called "action"))
+    ;; Assist
+    (should (equal (hkey-execute t) '(hmouse-drv--hkey-execute-assist)))
+    (should (string= hmouse-drv--hkey-execute-called "assist"))
+
+    ;; Print debug info
+    (let ((hkey-debug t))
+      (mocklet (((hypb:eval-debug *) => t))
+        (should (equal (hkey-execute nil) '(hmouse-drv--hkey-execute-action)))))))
 
 ;; This file can't be byte-compiled without the `el-mock' package
 ;; which is not a dependency of Hyperbole.


### PR DESCRIPTION
# What

- **Base hkey-execute on hkey-actions**
- **Add tests for hkey-actions and hkey-execute**

# Why

We have tests for hkey-actions with hkey-alist to ensure the right
action/assist it selected in the given state or situation. 

This PR refactors hkey-execute to use hkey-actions instead of using a
copy of the same, or almost the same code.

# Note

There is some extra complication in the that hkey-debug call has been
moved into hkey-actions so that the loop vars does not have to be
returned from hkey-alist but can be local to hkey-actions.

There is also a small code duplication in that the point-marker both
needs to be present in hkey-actions and hkey-execute. 

There might be other ways to solve this including changing what
information hkey-debug should display. I have left is as it is for not
making an unnecessary large change.

