### PR TITLE
fix prefix arg issue and silence some warnings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2025-05-18  Mats Lidell  <matsl@gnu.org>
+
+* kotl/kotl-mode.el (kotl-mode:add-prior-cell): Prefix arg with
+    interactive "p" is a number.
+
+* test/kotl-mode-tests.el (kotl-mode--add-prior-cell): Add test.
+
 2025-05-12  Mats Lidell  <matsl@gnu.org>
 
 * test/hmouse-drv-tests.el (hmouse-drv--hkey-actions): Test hkey-actions.

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:      4-May-25 at 11:13:26 by Bob Weiner
+;; Last-Mod:     17-May-25 at 23:52:45 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -2400,7 +2400,7 @@ Optional prefix arg RELATIVE-LEVEL means one of the following:
 
  1. when = 0, add as the parent's first child cell (first cell in list);
  2. when < 0, add that number of cells as preceding siblings;
- 3. when '(4) (universal arg, C-u), add as the first child of the current cell;
+ 3. when \\='(4) (universal arg, \\`C-u'), add as the first child of the current cell;
  4. when > 0 or nil (meaning 1), add that number of cells as following siblings."
   (interactive "*P")
   (unless (or (integerp relative-level) (listp relative-level) )
@@ -2511,7 +2511,7 @@ Optional prefix arg RELATIVE-LEVEL means one of the following:
 (defun kotl-mode:add-prior-cell (&optional cells-to-add contents plist no-fill)
   "Add prior sibling cells to the current cell.
 Optional prefix arg number of CELLS-TO-ADD defaults to 1.  Given
-a single universal arg, C-u, for CELLS-TO-ADD, add a single cell
+a single universal arg, \\`C-u', for CELLS-TO-ADD, add a single cell
 as the first child of the current cell's parent.  Always return the
 last cell added.
 

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -2522,7 +2522,7 @@ CONTENTS."
   (when (null cells-to-add) (setq cells-to-add 1))
   (unless (and (natnump cells-to-add) (/= cells-to-add 0))
     (error "(kotl-mode:add-prior-cell): `cells-to-add' must be a positive integer"))
-  (if (eq cells-to-add '(4))
+  (if (eq cells-to-add 4)
       (kotl-mode:add-below-parent)
     (cond ((zerop (kotl-mode:backward-cell 1))
 	   ;; Add preceding sibling if not on first cell at current level

--- a/test/kotl-mode-tests.el
+++ b/test/kotl-mode-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    18-May-21 at 22:14:10
-;; Last-Mod:      4-May-25 at 11:16:56 by Bob Weiner
+;; Last-Mod:     18-May-25 at 00:41:55 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1101,6 +1101,27 @@ marked with :ignore t")
     (unless (kotl-mode-tests--func-ignore f)
       (kotl-mode--sanity-check-function (kotl-mode-tests--func-func f)
                                         (kotl-mode-tests--func-args f)))))
+
+(ert-deftest kotl-mode--add-prior-cell ()
+  "Verify `kotl-mode:add-prior-cell'."
+  (with-temp-buffer
+    (kotl-mode)
+    (let ((current-prefix-arg -4))
+      (should-error (call-interactively #'kotl-mode:add-prior-cell)))
+    (let ((current-prefix-arg 4))
+      (mocklet (((kotl-mode:add-below-parent) => t))
+        (should (call-interactively #'kotl-mode:add-prior-cell))))
+    (let ((current-prefix-arg 1))
+      (mocklet (((kotl-mode:backward-cell 1) => 0)
+                ((kotl-mode:add-cell 1 nil nil nil) => t))
+        (should (call-interactively #'kotl-mode:add-prior-cell)))
+      (mocklet (((kotl-mode:backward-cell 1) => 1))
+        (mocklet (((kotl-mode:up-level 1) => t)
+                  ((kotl-mode:add-child 1 nil nil nil) => t))
+          (should (call-interactively #'kotl-mode:add-prior-cell)))
+        (mocklet (((kotl-mode:up-level 1) => nil)
+                  ((kotl-mode:add-below-parent 1 nil nil nil) => t))
+          (should (call-interactively #'kotl-mode:add-prior-cell)))))))
 
 (provide 'kotl-mode-tests)
 


### PR DESCRIPTION
# What

- **Prefix arg with "p" spec is a number**
- **Silence warnings**

# Why

Fixing a problem with kotl-mode:add-prior-cell with prefix args. It
seems interactive spec "p" gives a prefix arg that is a number where
"P" gives the raw input. For C-u that means 4 vs '(4). So changing the
code to check for a number instead of a list.

Not sure which form is preferred but it matters for the check in the
function.

Some warnings are also fixed in a separate commit.
