### PR TITLE
Add interactive spec for actypes::org-link

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,6 @@
 2025-05-31  Mats Lidell  <matsl@gnu.org>
 
-* hsys-org.el (org-link): Add interactive spec for promping user for an
+* hsys-org.el (org-link): Add interactive spec for prompting user for an
     org link.
 
 2025-05-27  Bob Weiner  <rsw@gnu.org>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2025-05-31  Mats Lidell  <matsl@gnu.org>
+
+* hsys-org.el (org-link): Add interactive spec for promping user for an
+    org link.
+
 2025-05-27  Bob Weiner  <rsw@gnu.org>
 
 * hypb.el (hypb:in-string-p): Fix 'texinfo-mode' string not returning a list

--- a/hsys-org.el
+++ b/hsys-org.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Jul-16 at 14:54:14
-;; Last-Mod:     26-May-25 at 00:15:37 by Bob Weiner
+;; Last-Mod:     31-May-25 at 15:35:55 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -126,6 +126,7 @@ operate as it normally does within Org mode contexts.
 (defact org-link (&optional link)
   "Follow an optional Org mode LINK to its target.
 If LINK is nil, follow any link at point.  Otherwise, trigger an error."
+  (interactive "sOrg link: ")
   (if (stringp link)
       ;; open as if in Org mode even if not
       (org-link-open-from-string link)


### PR DESCRIPTION
# What

Add interactive spec for actypes::org-link.

# Why

Allows org-link to be used as an ebut action. See bug#77838.

# Notes

Seems we did not fix this. 

On the other hand I can't see that org-link is available as a choice
if not the interactive spec is there!? So this error situation should
not really occur!? Or I might miss something.

Anyway, did not investigate this further. Can it be that it was
designed like this since there is less use of interactively adding an
org-link in a ebut!? Would not hyperbole links cover all cases?
