### PR TITLE
hypb:in-string-p - Improve performance in large docs; kotl-mode:add-prior-cell - Fix to send raw C-u value with "*P"

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2025-05-18  Bob Weiner  <rsw@gnu.org>
+
+* hypb.el (hypb:in-string-p): Make heuristic to optimize performance; search
+    back only until the beginning of the first line prior to point that contains
+    a non-quoted double quote mark.  Also add support for 'texinfo-mode' strings
+    where both "String1" and ``String2'' may be used.  Add support for
+    'python-mode' single and triple string delimiters as well.
+          (hypb:in-string-modes-regexps): Add for use in 'hypb:in-string-p'.
+    Allows customization of major modes with unique string delimiters.
+
 * kotl/kotl-mode.el (kotl-mode:add-prior-cell): Fix to send raw C-u value
     with (interactive "*P") instead of "p".
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+* kotl/kotl-mode.el (kotl-mode:add-prior-cell): Fix to send raw C-u value
+    with (interactive "*P") instead of "p".
+
 2025-05-04  Bob Weiner  <rsw@gnu.org>
 
 * kotl/kotl-mode.el (kotl-mode:add-after-parent): Add back in to add successive

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:      4-May-25 at 11:13:26 by Bob Weiner
+;; Last-Mod:     18-May-25 at 10:16:26 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -2518,12 +2518,13 @@ last cell added.
 Add new cells with optional CONTENTS string, attributes in PLIST,
 a property list, and NO-FILL flag to prevent any filling of
 CONTENTS."
-  (interactive "*p")
+  (interactive "*P")
   (when (null cells-to-add) (setq cells-to-add 1))
-  (unless (and (natnump cells-to-add) (/= cells-to-add 0))
-    (error "(kotl-mode:add-prior-cell): `cells-to-add' must be a positive integer"))
-  (if (eq cells-to-add '(4))
+  (if (equal cells-to-add '(4))
       (kotl-mode:add-below-parent)
+    (setq cells-to-add (prefix-numeric-value cells-to-add))
+    (unless (and (natnump cells-to-add) (/= cells-to-add 0))
+      (error "(kotl-mode:add-prior-cell): `cells-to-add' must be a positive integer"))
     (cond ((zerop (kotl-mode:backward-cell 1))
 	   ;; Add preceding sibling if not on first cell at current level
 	   (kotl-mode:add-cell cells-to-add contents plist no-fill))
@@ -2533,7 +2534,8 @@ CONTENTS."
 	   (kotl-mode:add-child cells-to-add contents plist no-fill))
 	  (t
 	   ;; Add preceding sibling when on level 1 first cell
-	   (kotl-mode:add-below-parent cells-to-add contents plist no-fill)))))
+	   (kotl-mode:add-below-parent cells-to-add
+				       contents plist no-fill)))))
 
 (defun kotl-mode:demote-tree (arg)
   "Move current tree a maximum of prefix ARG levels lower in current view.


### PR DESCRIPTION
kotl-mode:add-prior-cell - Fix to send raw C-u value with "*P"

hypb:in-string-p - Improve performance in large docs