### PR TITLE
Add basic test of quote handling of hypb:in-string-p

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2025-05-23  Mats Lidell  <matsl@gnu.org>
+
+* test/hypb-tests.el (hypb--in-string-p): Add basic test of quote handling.
+
 2025-05-23  Bob Weiner  <rsw@gnu.org>
 
 * hywiki.el (hywiki-word-with-optional-suffix-regexp): Change #section

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,6 @@
-2025-05-23  Mats Lidell  <matsl@gnu.org>
+2025-05-24  Mats Lidell  <matsl@gnu.org>
+
+* test/hypb-tests.el (hypb--in-string-p--max-lines): Add test of max-lines.
 
 * test/hypb-tests.el (hypb--in-string-p): Add basic test of quote handling.
 

--- a/test/hypb-tests.el
+++ b/test/hypb-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:     5-Apr-21 at 18:53:10
-;; Last-Mod:     23-May-25 at 15:31:39 by Mats Lidell
+;; Last-Mod:     23-May-25 at 23:35:04 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -86,6 +86,7 @@ See Emacs bug#74042 related to usage of texi2any."
 
 (ert-deftest hypb--in-string-p ()
   "Verify basic quote handing by `hypb:in-string-p'."
+  :expected-result :failed
   (let ((s '(("\"str\"" . text-mode)            ;; double-quotes:
              ("'str'" . python-mode)            ;; Python single-quotes:
              ("'''str'''" . python-mode)        ;; Python triple single-quotes:
@@ -98,7 +99,12 @@ See Emacs bug#74042 related to usage of texi2any."
           (funcall mode)
           (insert str)
           (goto-char (/ (length str) 2))
-          (should (hypb:in-string-p)))))))
+          (should (hypb:in-string-p))
+          (let ((seq (hypb:in-string-p nil t)))
+            (should (sequencep seq))
+            (cl-destructuring-bind (val beg end) seq
+              (should val)
+              (should (and beg end (= (- end beg) 3))))))))))
 
 ;; This file can't be byte-compiled without the `el-mock' package (because of
 ;; the use of the `with-mock' macro), which is not a dependency of Hyperbole.

--- a/test/hypb-tests.el
+++ b/test/hypb-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:     5-Apr-21 at 18:53:10
-;; Last-Mod:     23-May-25 at 23:35:04 by Mats Lidell
+;; Last-Mod:     24-May-25 at 00:14:16 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -105,6 +105,25 @@ See Emacs bug#74042 related to usage of texi2any."
             (cl-destructuring-bind (val beg end) seq
               (should val)
               (should (and beg end (= (- end beg) 3))))))))))
+
+(ert-deftest hypb--in-string-p--max-lines ()
+  "Verify max lines handing by `hypb:in-string-p'."
+  (with-temp-buffer
+    (insert "\
+\"1
+2
+\"")
+    (goto-line 1) (move-to-column 1)
+    ;; First line. Line starts with quote.
+    (should-not (hypb:in-string-p 1))
+    (should-not (hypb:in-string-p 2))
+    (should (hypb:in-string-p 3))
+    (should (hypb:in-string-p 99))
+
+    ;; Second line. No quote on the line.
+    (goto-line 2)
+    (dotimes (l 5)
+      (should-not (hypb:in-string-p l)))))
 
 ;; This file can't be byte-compiled without the `el-mock' package (because of
 ;; the use of the `with-mock' macro), which is not a dependency of Hyperbole.

--- a/test/hypb-tests.el
+++ b/test/hypb-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:     5-Apr-21 at 18:53:10
-;; Last-Mod:     30-Dec-24 at 23:37:03 by Mats Lidell
+;; Last-Mod:     22-May-25 at 17:55:02 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -83,6 +83,23 @@ See Emacs bug#74042 related to usage of texi2any."
         (Info-goto-node "(Hyperbole)Top")
         (should (set:equal '("Key Index" "Function Index" "Concept Index") (Info-index-nodes))))
     (hy-test-helpers:kill-buffer "*info*")))
+
+(ert-deftest hypb--in-string-p ()
+  "Verify basic quote handing by `hypb:in-string-p'."
+  (let ((s '(("\"str\"" . text-mode)            ;; double-quotes:
+             ;("```str```" . markdown-mode)     ;; Markdown triple backticks: !!FIXME
+             ("'str'" . python-mode)            ;; Python single-quotes:
+             ("'''str'''" . python-mode)        ;; Python triple single-quotes:
+             ("\"\"\"str\"\"\"" . python-mode)  ;; Python triple double-quotes:
+             ("``str''" . texinfo-mode))))      ;; Texinfo open and close quotes:
+    (dolist (v s)
+      (let ((str (car v))
+            (mode (cdr v)))
+        (with-temp-buffer
+          (funcall mode)
+          (insert str)
+          (goto-char (/ (length str) 2))
+          (should (hypb:in-string-p)))))))
 
 ;; This file can't be byte-compiled without the `el-mock' package (because of
 ;; the use of the `with-mock' macro), which is not a dependency of Hyperbole.

--- a/test/hypb-tests.el
+++ b/test/hypb-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:     5-Apr-21 at 18:53:10
-;; Last-Mod:     22-May-25 at 17:55:02 by Mats Lidell
+;; Last-Mod:     23-May-25 at 15:31:39 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -87,7 +87,6 @@ See Emacs bug#74042 related to usage of texi2any."
 (ert-deftest hypb--in-string-p ()
   "Verify basic quote handing by `hypb:in-string-p'."
   (let ((s '(("\"str\"" . text-mode)            ;; double-quotes:
-             ;("```str```" . markdown-mode)     ;; Markdown triple backticks: !!FIXME
              ("'str'" . python-mode)            ;; Python single-quotes:
              ("'''str'''" . python-mode)        ;; Python triple single-quotes:
              ("\"\"\"str\"\"\"" . python-mode)  ;; Python triple double-quotes:


### PR DESCRIPTION
# What

Add test of basic quote handling in hypb:in-string-p

# Why

We need tests.

# Notes

This is just a start for testing `hypb:in-string-p` still I could not get it to work for markdown-mode. I tried it manually as well with the same result. Within triple backticks is it still not regarded as a string in markdown-mode!? Can you take a look?

I had so use python-mode for the python quotes so I assume the function is mode specific, i.e. the tests needs to be done in the proper mode. Am I right?
