### PR TITLE
Use new actype, link-to-compose-mail, in ibtype, mail address; fix bad HyWikiWord#section page filename creation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,9 @@
 2025-05-27  Bob Weiner  <rsw@gnu.org>
 
+* hywiki.el (hywiki-word-is-p): Save match data so when returns it represents
+    the match to the whole HyWikiWord referent, if any.  This fixes a bug
+    that created HyWikiWord page files with the section name attached.
+
 * hsmail.el (mail-send-hook): Remove this setting since 'message-send-hook'
     has replaced it in modern Emacs.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2025-05-27  Bob Weiner  <rsw@gnu.org>
 
+* test/hywiki-tests.el (hywiki-tests--published-html-links-to-word-and-section):
+    Bug is fixed, so remove expected fail and enable this test.
+
 * hywiki.el (hywiki-word-is-p): Save match data so when returns it represents
     the match to the whole HyWikiWord referent, if any.  This fixes a bug
     that created HyWikiWord page files with the section name attached.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,20 @@
+2025-05-27  Bob Weiner  <rsw@gnu.org>
+
+* hsmail.el (mail-send-hook): Remove this setting since 'message-send-hook'
+    has replaced it in modern Emacs.
+
+* hpath.el (hpath:display-buffer): When given a buffer name, create the
+    buffer if it doesn't exist.
+
 2025-05-26  Bob Weiner  <rsw@gnu.org>
+
+* hactypes.el (link-to-compose-mail): Add new actype.  Compose email inside
+    Emacs or in default web browser if 'mail-user-agent' is set to 'browse-url'.
+  hsys-www.el (www-url-compose-mail): Add and call this from above actype.
+  hibtypes.el (mail-address): Call above actype allowing any email address
+    to compose mail in a user's default external web browser.  Add to doc
+    string how to configure mail composition, {C-x m}, to use this
+    external browser.
 
 * hyrolo.el (hyrolo-set-display-buffer): Don't enable 'hyrolo-mode' when
     within a `hyrolo-yank' command so that the yanked-to-buffer's mode

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2025-05-27  Bob Weiner  <rsw@gnu.org>
 
+* test/hyrolo-tests.el (hyrolo-tests--mail-to): Fix to latest action updates
+    in ibtype 'mail-address' which 'hyrolo-mail-to' relies on.
+
 * test/hywiki-tests.el (hywiki-tests--published-html-links-to-word-and-section):
     Bug is fixed, so remove expected fail and enable this test.
 

--- a/hactypes.el
+++ b/hactypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    23-Sep-91 at 20:34:36
-;; Last-Mod:      5-Jan-25 at 11:15:09 by Bob Weiner
+;; Last-Mod:     27-May-25 at 01:53:49 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -292,6 +292,13 @@ This type of link is for use within a single editor session.  Use
 	   (progn (goto-char (min (point-max) point))
 		  (recenter 0)))
     (hypb:error "(link-to-buffer-tmp): Not a current buffer: %s" buffer)))
+
+(defact link-to-compose-mail (to &optional subject body &rest _ignore)
+  "Compose an email TO address with optionmal SUBJECT and BODY.
+If `mail-user-agent' is `browse-url', do this in the default web browser."
+  (if (eq mail-user-agent 'browse-url)
+      (www-url-compose-mail to subject body)
+    (compose-mail to subject nil nil #'hpath:display-buffer)))
 
 (defact link-to-directory (directory)
   "Display a DIRECTORY in Dired mode."

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:     27-Apr-25 at 17:30:02 by Mats Lidell
+;; Last-Mod:     27-May-25 at 01:13:32 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -215,10 +215,17 @@ If the referenced location is found, return non-nil."
 
 (defib mail-address ()
   "If on an e-mail address, compose mail to that address in another window.
+To compose email in your default web browser:
+  (setq mail-user-agent 'browse-url)
+  (put mail-user-agent 'composefunc #'www-url-compose-mail)
 
-Applies to any major mode in `hypb:mail-address-mode-list', the HyRolo match
-buffer, any buffer attached to a file in `hyrolo-file-list', or any buffer with
-\"mail\" or \"rolo\" (case-insensitive) within its name.
+To restore to using Emacs to compose mail:
+  (setq mail-user-agent 'message-user-agent)
+
+This implicit button type applies in any major mode listed in
+`hypb:mail-address-mode-list', the HyRolo match buffer, any buffer
+attached to a file in `hyrolo-file-list', or any buffer with \"mail\" or
+\"rolo\" (case-insensitive) within its name.
 
 If `hypb:mail-address-mode-list' is set to nil, this button type is active
 in all buffers."
@@ -244,7 +251,7 @@ in all buffers."
     (let ((address (mail-address-at-p)))
       (when address
         (ibut:label-set address (match-beginning 1) (match-end 1))
-        (hact 'compose-mail-other-window address)))))
+        (hact 'link-to-compose-mail address)))))
 
 ;;; ========================================================================
 ;;; Displays files and directories when a valid pathname is activated.

--- a/hpath.el
+++ b/hpath.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Nov-91 at 00:44:23
-;; Last-Mod:     26-Apr-25 at 10:22:42 by Bob Weiner
+;; Last-Mod:     27-May-25 at 00:41:20 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1178,14 +1178,15 @@ end-pos) or nil."
 
 ;;;###autoload
 (defun hpath:display-buffer (buffer &optional display-where)
-  "Display and select BUFFER at optional DISPLAY-WHERE or at `hpath:display-where'.
+  "Create and select BUFFER at optional DISPLAY-WHERE or at `hpath:display-where'.
 BUFFER must be a buffer or a buffer name.
 
 See the documentation of `hpath:display-buffer-alist' for valid
 values of DISPLAY-WHERE.  Return the window in which the buffer
 is displayed or nil if not displayed because BUFFER is invalid."
   (interactive "bDisplay buffer: ")
-  (if (stringp buffer) (setq buffer (get-buffer buffer)))
+  (when (stringp buffer)
+    (setq buffer (get-buffer-create buffer)))
   (when buffer
     ;; RSW 4/30/2016 - Commented out in case interferes with Smart Key
     ;; selection and yanking of the region via drags.
@@ -1209,8 +1210,8 @@ window in which the buffer is displayed."
   (if (= (length (frame-list)) 1)
       (select-frame (make-frame))
     (other-frame 1))
-  (if (br-in-browser)
-      (br-to-view-window))
+  (when (br-in-browser)
+    (br-to-view-window))
   (switch-to-buffer buffer)
   (selected-window))
 

--- a/hsmail.el
+++ b/hsmail.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     9-May-91 at 04:50:20
-;; Last-Mod:     27-Aug-23 at 12:39:11 by Bob Weiner
+;; Last-Mod:     27-May-25 at 00:29:16 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -41,8 +41,11 @@ for a comment.")
 
 ;; Used by 'message-send' in Emacs "message.el".
 (add-hook 'message-send-hook  #'smail:widen)
+
 ;; Used by 'mail-send' in Emacs "sendmail.el".
-(add-hook 'mail-send-hook  #'smail:widen)
+;; message-mode has replaced mail-mode, so remove the following hook
+;; -- rsw 2025-05-26
+;; (add-hook 'mail-send-hook  #'smail:widen)
 
 ;; For compatibility with Supercite and GNU Emacs.
 ;; message-mode defines message-yank-prefix - mail-yank-prefix removed

--- a/hsys-www.el
+++ b/hsys-www.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Apr-94 at 17:17:39 by Bob Weiner
-;; Last-Mod:     18-Jan-24 at 23:59:15 by Mats Lidell
+;; Last-Mod:     27-May-25 at 00:57:00 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -132,6 +132,22 @@ is used.  Valid values of this variable include `browse-url-default-browser' and
 	(browse-url url)
 	(message "Sending %s to %s...done" url browser))
     (error "(www-url): `browse-url-browser-function' must be set to a web browser invoking function")))
+
+(defun www-url-compose-mail (to &optional subject body &rest _ignore)
+  "Compose a mailto url and open it in the default `browse-url' web browser.
+TO is the recipient's email address.  Optional SUBJECT and BODY
+are included as parameters in the mailto url."
+  (let ((browse-url-mailto-function browse-url-browser-function)
+	(mailto (if (string-prefix-p "mailto:" to) to (concat "mailto:" to))))
+    ;; Add subject if provided
+    (when subject
+      (setq mailto (concat mailto "?subject=" (url-encode-string subject))))
+    ;; Add body if provided
+    (when body
+      (unless subject
+        (setq mailto (concat mailto "?")))
+      (setq mailto (concat mailto "&body=" (url-encode-string body))))
+    (hact 'www-url mailto)))
 
 ;;;###autoload
 (defun www-url-expand-file-name (path &optional dir)

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Jun-89 at 22:08:29
-;; Last-Mod:     26-May-25 at 03:29:26 by Bob Weiner
+;; Last-Mod:     27-May-25 at 01:22:36 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1519,6 +1519,9 @@ hyrolo-file-list."
 ;;;###autoload
 (defun hyrolo-yank (name &optional regexp-flag)
   "Insert at point the first rolo entry with a headline containing NAME.
+If the `consult' package is loaded, interactively select and complete
+the entry to be inserted.
+
 With optional prefix arg, REGEXP-FLAG, treat NAME as a regular expression
 instead of a string."
   (interactive (list 

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Acpr-24 at 22:41:13
-;; Last-Mod:     26-May-25 at 00:16:02 by Bob Weiner
+;; Last-Mod:     27-May-25 at 02:05:56 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -3242,10 +3242,11 @@ these are handled by the Org mode link handler."
 		  (eq 0 (string-match
 			 hywiki-word-with-optional-suffix-exact-regexp
 			 word)))
-	      ;; If has a #section, ensure there are no invalid chars
-	      (if (string-match "#" word)
-		  (string-match "#[^][#()<>{}\"\n\r\f]+\\'" word)
-		t)))))
+	      (save-match-data
+		;; If has a #section, ensure there are no invalid chars
+		(if (string-match "#" word)
+		    (string-match "#[^][#()<>{}\"\n\r\f]+\\'" word)
+		  t))))))
 
 (defun hywiki-word-read (&optional prompt)
   "Prompt with completion for and return an existing HyWikiWord.

--- a/test/hyrolo-tests.el
+++ b/test/hyrolo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    19-Jun-21 at 22:42:00
-;; Last-Mod:     19-Feb-25 at 21:08:39 by Bob Weiner
+;; Last-Mod:     27-May-25 at 02:28:30 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1506,10 +1506,10 @@ body
     (unwind-protect
         (let ((hypb:mail-address-mode-list '(hyrolo-mode)))
           (hyrolo-grep "receiver\\.org")
-          (mocklet (((compose-mail-other-window "first@receiver.org") => t))
+          (mocklet (((actypes::link-to-compose-mail "first@receiver.org") => t))
             (hyrolo-mail-to))
           (forward-line)
-          (mocklet (((compose-mail-other-window "second@receiver.org") => t))
+          (mocklet (((actypes::link-to-compose-mail "second@receiver.org") => t))
             (hyrolo-mail-to)))
       (kill-buffer hyrolo-display-buffer)
       (hy-delete-files-and-buffers hyrolo-file-list))))

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    18-May-24 at 23:59:48
-;; Last-Mod:     27-Apr-25 at 10:11:50 by Bob Weiner
+;; Last-Mod:     27-May-25 at 02:14:49 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1560,9 +1560,7 @@ Insert test in the middle of other text."
         (hy-delete-dir-and-buffer hywiki-directory)))))
 
 (ert-deftest hywiki-tests--nonexistent-wikiword-with-section-should-create-wikiword ()
-  "Verify that action-key on a new WikiWord with section only creates WikiWord.org.
-Bug - creates WikiWord.org#section"
-  :expected-result :failed
+  "Verify action-key on a new WikiWord#section creates proper page filename."
   (hywiki-tests--preserve-hywiki-mode
     (let* ((hywiki-directory (make-temp-file "hywiki" t))
            (hywiki-page (expand-file-name "WikiWord.org" hywiki-directory))


### PR DESCRIPTION
- hywiki-word-is-p - Fix invalid HyWikiWord page name creation
- hywiki-tests--published-html-links-to-word-and-section - Enable test