### PR TITLE
Fix warnings and a typo

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,15 @@
 2025-05-31  Mats Lidell  <matsl@gnu.org>
 
+* hyrolo.el (consult-preview-key): Defvar var from consult.
+
+* hsys-consult.el (consult--grep, consult--grep-make-builder)
+    (consult--ripgrep-make-builder): Declare functions from consult.
+
+* hibtypes.el (mail-address): Fix docstring single quotes.
+
+* hactypes.el (mapc): Require hsys-www.
+    (link-to-compose-mail): Fix docstring typo.
+
 * hsys-org.el (org-link): Add interactive spec for prompting user for an
     org link.
 

--- a/hactypes.el
+++ b/hactypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    23-Sep-91 at 20:34:36
-;; Last-Mod:     27-May-25 at 01:53:49 by Bob Weiner
+;; Last-Mod:     27-May-25 at 23:33:07 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -18,7 +18,7 @@
 ;;; Other required Elisp libraries
 ;;; ************************************************************************
 
-(eval-and-compile (mapc #'require '(bookmark hvar hsettings comint hbut hpath hargs hmail hsys-org)))
+(eval-and-compile (mapc #'require '(bookmark hvar hsettings comint hbut hpath hargs hmail hsys-org hsys-www)))
 
 ;;; ************************************************************************
 ;;; Public declarations
@@ -294,7 +294,7 @@ This type of link is for use within a single editor session.  Use
     (hypb:error "(link-to-buffer-tmp): Not a current buffer: %s" buffer)))
 
 (defact link-to-compose-mail (to &optional subject body &rest _ignore)
-  "Compose an email TO address with optionmal SUBJECT and BODY.
+  "Compose an email TO address with optional SUBJECT and BODY.
 If `mail-user-agent' is `browse-url', do this in the default web browser."
   (if (eq mail-user-agent 'browse-url)
       (www-url-compose-mail to subject body)

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:     27-May-25 at 01:13:32 by Bob Weiner
+;; Last-Mod:     27-May-25 at 23:37:48 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -216,11 +216,11 @@ If the referenced location is found, return non-nil."
 (defib mail-address ()
   "If on an e-mail address, compose mail to that address in another window.
 To compose email in your default web browser:
-  (setq mail-user-agent 'browse-url)
-  (put mail-user-agent 'composefunc #'www-url-compose-mail)
+  (setq mail-user-agent \\='browse-url)
+  (put mail-user-agent \\='composefunc #\\='www-url-compose-mail)
 
 To restore to using Emacs to compose mail:
-  (setq mail-user-agent 'message-user-agent)
+  (setq mail-user-agent \\='message-user-agent)
 
 This implicit button type applies in any major mode listed in
 `hypb:mail-address-mode-list', the HyRolo match buffer, any buffer

--- a/hsys-consult.el
+++ b/hsys-consult.el
@@ -2,7 +2,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     4-Jul-24 at 09:57:18
-;; Last-Mod:     26-May-25 at 03:30:20 by Bob Weiner
+;; Last-Mod:     27-May-25 at 23:40:50 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -43,6 +43,9 @@
 (declare-function hsys-org-directory-at-tags-p "hsys-org")
 (declare-function hsys-org-at-tags-p "hsys-org")
 
+(declare-function consult--grep "ext:consult")
+(declare-function consult--grep-make-builder"ext:consult")
+(declare-function consult--ripgrep-make-builder "ext:consult")
 (declare-function consult-grep "ext:consult")
 (declare-function consult-ripgrep "ext:consult")
 (declare-function org-roam-db-autosync-mode "ext:org-roam")

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Jun-89 at 22:08:29
-;; Last-Mod:     27-May-25 at 01:22:36 by Bob Weiner
+;; Last-Mod:     27-May-25 at 23:47:02 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -92,6 +92,7 @@
 (declare-function hbut:get-key-src "hbut")
 (declare-function org-outline-level "org")
 
+(defvar consult-preview-key)            ; "ext:consult.el"
 (defvar org-directory)                  ; "org.el"
 (defvar org-mode-map)                   ; "org-keys.el"
 (defvar org-mode-syntax-table)          ; "org.el"


### PR DESCRIPTION
# What

Fix some warnings and a typo.

# Why

Always try to keep warnings to a minimum.

# Note

These warnings still remains:

## In hsys-consult-selected-candidate:
hsys-consult.el:220:26: Warning: Unused lexical argument ‘lambda’
hsys-consult.el:220:34: Warning: Unused lexical variable ‘state-function’
hsys-consult.el:220:34: Warning: Unused lexical variable ‘\`’
hsys-consult.el:220:34: Warning: Unused lexical variable ‘\,’
hsys-consult.el:221:30: Warning: Unused lexical variable ‘state-function’
hsys-consult.el:221:48: Warning: Unused lexical variable ‘cand’

Looks strange to get these warnings but it is beyond me to figure out
what the problem is. At least without a lot more investigation. Can
there be a problem here?

## In end of data:
hsys-www.el:144:48: Warning: the function ‘url-encode-string’ is not known to be defined.

I can't find where url-encode-string is defined? All our supported
versions of emacs warn for this. Can it be base64url-encode-string
that is meant to be used?
