### PR TITLE
kotl-mode:setup-keymap - Remap goto-line and goto-relative-line keys

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,14 @@
 2025-05-27  Bob Weiner  <rsw@gnu.org>
 
+* hypb.el (hypb:in-string-p): Fix 'texinfo-mode' string not returning a list
+    when 'range-flag' is given.
+  test/hypb-tests.el (hypb--in-string-p): Enable this test since fixed now.
+
+* kotl/kotl-mode.el (kotl-mode:setup-keymap): Remap 'goto-line' and
+    'goto-line-relative' keys to 'kotl-mode:goto-line-relative'.
+                    (kotl-mode:goto-line, kotl-mode:goto-line-relative): Add
+    to goto a relative line number in the Koutline.
+
 * test/hyrolo-tests.el (hyrolo-tests--mail-to): Fix to latest action updates
     in ibtype 'mail-address' which 'hyrolo-mail-to' relies on.
 

--- a/hypb.el
+++ b/hypb.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     6-Oct-91 at 03:42:38
-;; Last-Mod:     22-May-25 at 23:01:15 by Bob Weiner
+;; Last-Mod:     27-May-25 at 22:00:10 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -747,7 +747,12 @@ Quoting conventions recognized are:
 					    (regexp-quote texinfo-close-quote))
 				    start (point))))
 		       (search-forward texinfo-close-quote nil t)
-		       t)
+		       (if range-flag
+			   (progn
+			     (setq str-end (match-beginning 0))
+			     (list (buffer-substring-no-properties str-start str-end)
+				   str-start str-end))
+			 t))
 		(and (cl-oddp (- (count-matches (regexp-quote open-match-string)
 						start (point))
 				 ;; Subtract any backslash quoted delimiters
@@ -759,7 +764,8 @@ Quoting conventions recognized are:
 		     (if range-flag
 			 (progn
 			   (setq str-end (match-beginning 2))
-			   (list (buffer-substring-no-properties str-start str-end) str-start str-end))
+			   (list (buffer-substring-no-properties str-start str-end)
+				 str-start str-end))
 		       t))))))))))
 
 (defun hypb:indirect-function (obj)

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:     20-May-25 at 00:35:26 by Mats Lidell
+;; Last-Mod:     27-May-25 at 21:28:51 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1927,6 +1927,60 @@ not move)."
       (goto-char opoint)
       nil)))
 
+(defun kotl-mode:goto-line (line &optional buffer relative)
+  "Go to LINE, counting from line 1 at beginning of buffer.
+If called interactively, a numeric prefix argument specifies
+LINE; without a numeric prefix argument, read LINE from the
+minibuffer.
+
+If optional argument BUFFER is non-nil, switch to that buffer and
+move to line LINE there.  If called interactively with \\[universal-argument]
+as argument, BUFFER is the most recently selected other buffer.
+
+Optional argument RELATIVE is ignored and its value is always set to
+t, so counting starts at the beginning of the accessible portion of
+the narrowed Koutline buffer.
+
+Prior to moving point, this function sets the mark (without
+activating it), unless Transient Mark mode is enabled and the
+mark is already active.
+
+This function is usually the wrong thing to use in a Lisp program.
+What you probably want instead is something like:
+  (goto-char (point-min))
+  (forward-line (1- N))
+If at all possible, an even better solution is to use char counts
+rather than line counts."
+  (declare (interactive-only forward-line))
+  (interactive (goto-line-read-args))
+  (setq relative t) ;; Always use relative lines in `kotl-mode'.
+  ;; Switch to the desired buffer, one way or another.
+  (if buffer
+      (let ((window (get-buffer-window buffer)))
+	(if window (select-window window)
+	  (switch-to-buffer-other-window buffer))))
+  ;; Leave mark at previous position
+  (or (region-active-p) (push-mark))
+  ;; Move to the specified line number in that buffer.
+  (let ((pos (save-restriction
+               (unless relative (widen))
+               (goto-char (point-min))
+               (if (eq selective-display t)
+                   (re-search-forward "[\n\C-m]" nil 'end (1- line))
+                 (forward-line (1- line)))
+               (point))))
+    (goto-char pos)
+    (kotl-mode:to-valid-position)))
+
+(defun kotl-mode:goto-line-relative (line &optional buffer)
+  "Go to LINE, counting from line at (point-min).
+The line number is relative to the accessible portion of the narrowed
+buffer.  The argument BUFFER is the same as in the function `goto-line'."
+  (declare (interactive-only forward-line))
+  (interactive (goto-line-read-args t))
+  (with-suppressed-warnings ((interactive-only goto-line))
+    (kotl-mode:goto-line line buffer t)))
+
 (defun kotl-mode:head-cell ()
   "Move point to the start of first visible cell at same level as current cell.
 If at head cell already, do nothing and return nil."
@@ -3799,6 +3853,8 @@ Leave point at end of line now residing at START."
 	     forward-para
 	     forward-paragraph
 	     forward-sentence
+	     goto-line
+	     goto-line-relative
 	     just-one-space
 	     kill-word
 	     kill-line

--- a/test/hypb-tests.el
+++ b/test/hypb-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:     5-Apr-21 at 18:53:10
-;; Last-Mod:     24-May-25 at 00:14:16 by Mats Lidell
+;; Last-Mod:     27-May-25 at 22:01:13 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -86,7 +86,6 @@ See Emacs bug#74042 related to usage of texi2any."
 
 (ert-deftest hypb--in-string-p ()
   "Verify basic quote handing by `hypb:in-string-p'."
-  :expected-result :failed
   (let ((s '(("\"str\"" . text-mode)            ;; double-quotes:
              ("'str'" . python-mode)            ;; Python single-quotes:
              ("'''str'''" . python-mode)        ;; Python triple single-quotes:


### PR DESCRIPTION
hypb.el (hypb:in-string-p): Fix 'texinfo-mode' string not returning a list
  when 'range-flag' is given.
test/hypb-tests.el (hypb--in-string-p): Enable this test since fixed now.