### PR TITLE
Use ert-with-message-capture

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2025-06-01  Mats Lidell  <matsl@gnu.org>
+
+* test/hy-test-helpers.el (hy-test-helpers:should-last-message): Remove
+    helper. Use ert-with-message-capture instead.
+
 2025-05-31  Mats Lidell  <matsl@gnu.org>
 
 * hyrolo.el (consult-preview-key): Defvar var from consult.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,8 @@
 2025-06-01  Mats Lidell  <matsl@gnu.org>
 
-* test/hy-test-helpers.el (hy-test-helpers:should-last-message): Remove
-    helper. Use ert-with-message-capture instead.
+* test/hy-test-helpers.el (hy-test-helpers:should-last-message): Change
+    helper to work on captured messages by ert-with-message-capture. Add
+    use of ert-with-message-capture where the helper is used.
 
 2025-05-31  Mats Lidell  <matsl@gnu.org>
 

--- a/test/demo-tests.el
+++ b/test/demo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:      1-Jun-25 at 10:43:57 by Mats Lidell
+;; Last-Mod:      1-Jun-25 at 23:31:35 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -213,7 +213,7 @@
     (goto-char 2)
     (ert-with-message-capture cap
       (action-key)
-      (should (string-search "4" cap)))))
+      (hy-test-helpers:should-last-message "4" cap))))
 
 (ert-deftest demo-implicit-button-action-button-sexp-test ()
   (with-temp-buffer
@@ -231,8 +231,8 @@
  	     (hsettings-buf (buffer-name (nth 0 bufs)))
 	     (hactypes-buf  (buffer-name (nth 1 bufs)))
 	     (hibtypes-buf  (buffer-name (nth 2 bufs))))
-        (should (and (string-search "Last 3 buffers are" cap)
-		     (string-search "hsettings.el" hsettings-buf)
+        (hy-test-helpers:should-last-message "Last 3 buffers are" cap)
+        (should (and (string-search "hsettings.el" hsettings-buf)
 		     (string-search "hactypes.el"  hactypes-buf)
 		     (string-search "hibtypes.el"  hibtypes-buf)))))))
 
@@ -242,7 +242,7 @@
     (goto-char 2)
     (ert-with-message-capture cap
       (action-key)
-      (should (string-search "Result = nil; Boolean value = False" cap)))))
+      (hy-test-helpers:should-last-message "Result = nil; Boolean value = False" cap))))
 
 (ert-deftest demo-implicit-button-hash-link-test ()
   (unwind-protect

--- a/test/demo-tests.el
+++ b/test/demo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:      1-Jun-25 at 23:31:35 by Mats Lidell
+;; Last-Mod:      2-Jun-25 at 10:39:14 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -409,7 +409,7 @@
         (ert-with-message-capture cap
           (should (hact 'kbd-key "C-h h a factorial RET"))
           (hy-test-helpers:consume-input-events)
-          (string-search "Factorial of 5 = 120" cap)))
+          (hy-test-helpers:should-last-message "Factorial of 5 = 120" cap)))
     (hy-test-helpers:kill-buffer "DEMO")))
 
 (ert-deftest demo-factorial-ebutton-test ()
@@ -421,7 +421,7 @@
         (forward-char -5)
         (ert-with-message-capture cap
           (action-key)
-          (string-search "Factorial of 5 = 120" cap)))
+          (hy-test-helpers:should-last-message "Factorial of 5 = 120" cap)))
     (hy-test-helpers:kill-buffer "DEMO")))
 
 ;;; Fast demo
@@ -788,7 +788,7 @@ enough files with matching mode loaded."
     (goto-char 2)
     (ert-with-message-capture cap
       (action-key)
-      (string-search (format "fill-column = %d" (current-fill-column)) cap))))
+      (hy-test-helpers:should-last-message (format "fill-column = %d" (current-fill-column)) cap))))
 
 (ert-deftest fast-demo-display-demo-using-action-buttons ()
   "Verify the three ways show in the demo works."

--- a/test/hactypes-tests.el
+++ b/test/hactypes-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:      1-Jun-25 at 10:43:19 by Mats Lidell
+;; Last-Mod:      1-Jun-25 at 23:31:35 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -19,6 +19,7 @@
 ;;; Code:
 
 (require 'ert)
+(require 'ert-x)
 (require 'el-mock)
 (require 'hactypes)
 (require 'hy-test-helpers "test/hy-test-helpers")
@@ -26,12 +27,12 @@
 (ert-deftest display-boolean-true-test ()
   (ert-with-message-capture cap
     (should (actypes::display-boolean t))
-    (should (string-search "Result = t; Boolean value = True" cap))))
+    (hy-test-helpers:should-last-message "Result = t; Boolean value = True" cap)))
 
 (ert-deftest display-boolean-false-test ()
   (ert-with-message-capture cap
-  (should (actypes::display-boolean nil))
-    (should (string-search "Result = nil; Boolean value = False" cap))))
+    (should (actypes::display-boolean nil))
+    (hy-test-helpers:should-last-message "Result = nil; Boolean value = False" cap)))
 
 (ert-deftest hactypes-tests--link-to-Info-index-item ()
   "Verify `actypes::link-to-Info-index-item'."

--- a/test/hactypes-tests.el
+++ b/test/hactypes-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:      4-Mar-25 at 17:05:59 by Mats Lidell
+;; Last-Mod:      1-Jun-25 at 10:43:19 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -23,15 +23,15 @@
 (require 'hactypes)
 (require 'hy-test-helpers "test/hy-test-helpers")
 
-(declare-function hy-test-helpers:should-last-message "hy-test-helpers")
-
 (ert-deftest display-boolean-true-test ()
-  (should (actypes::display-boolean t))
-  (hy-test-helpers:should-last-message "Result = t; Boolean value = True"))
+  (ert-with-message-capture cap
+    (should (actypes::display-boolean t))
+    (should (string-search "Result = t; Boolean value = True" cap))))
 
 (ert-deftest display-boolean-false-test ()
+  (ert-with-message-capture cap
   (should (actypes::display-boolean nil))
-    (hy-test-helpers:should-last-message "Result = nil; Boolean value = False"))
+    (should (string-search "Result = nil; Boolean value = False" cap))))
 
 (ert-deftest hactypes-tests--link-to-Info-index-item ()
   "Verify `actypes::link-to-Info-index-item'."

--- a/test/hib-kbd-tests.el
+++ b/test/hib-kbd-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     20-Jan-24 at 15:43:57 by Mats Lidell
+;; Last-Mod:      1-Jun-25 at 10:52:33 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -23,7 +23,6 @@
 (require 'hy-test-helpers "test/hy-test-helpers")
 
 (declare-function hy-test-helpers:consume-input-events "hy-test-helpers")
-(declare-function hy-test-helpers:should-last-message "hy-test-helpers")
 
 (ert-deftest kbd-key-hy-about-test ()
   "Test if HY-ABOUT file is displayed properly from the Hyperbole menus."

--- a/test/hibtypes-tests.el
+++ b/test/hibtypes-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    20-Feb-21 at 23:45:00
-;; Last-Mod:     24-Apr-25 at 23:49:38 by Mats Lidell
+;; Last-Mod:      1-Jun-25 at 10:41:15 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -26,7 +26,6 @@
 (require 'hy-test-helpers "test/hy-test-helpers")
 
 (declare-function hy-test-helpers:consume-input-events "hy-test-helpers")
-(declare-function hy-test-helpers:should-last-message "hy-test-helpers")
 
 ;; Mail address
 (ert-deftest mail-address-at-p-test ()
@@ -149,9 +148,10 @@
   (with-temp-buffer
     (insert "\"-${hyperb:dir}/test/hy-test-dependencies.el\"")
     (goto-char 2)
-    (ibtypes::pathname)
-    (hy-test-helpers:should-last-message "Loading")
-    (hy-test-helpers:should-last-message "hy-test-dependencies.el")))
+    (ert-with-message-capture cap
+      (ibtypes::pathname)
+      (string-search "Loading" cap)
+      (string-search "hy-test-dependencies.el" cap))))
 
 (ert-deftest ibtypes::pathname-dot-slash-in-other-folder-test ()
   "Invalid pathname that starts with ./ triggers an error when resolved."

--- a/test/hibtypes-tests.el
+++ b/test/hibtypes-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    20-Feb-21 at 23:45:00
-;; Last-Mod:      1-Jun-25 at 10:41:15 by Mats Lidell
+;; Last-Mod:      2-Jun-25 at 10:39:56 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -150,8 +150,8 @@
     (goto-char 2)
     (ert-with-message-capture cap
       (ibtypes::pathname)
-      (string-search "Loading" cap)
-      (string-search "hy-test-dependencies.el" cap))))
+      (hy-test-helpers:should-last-message "Loading" cap)
+      (hy-test-helpers:should-last-message "hy-test-dependencies.el" cap))))
 
 (ert-deftest ibtypes::pathname-dot-slash-in-other-folder-test ()
   "Invalid pathname that starts with ./ triggers an error when resolved."

--- a/test/hmouse-drv-tests.el
+++ b/test/hmouse-drv-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    28-Feb-21 at 22:52:00
-;; Last-Mod:     19-May-25 at 22:53:55 by Bob Weiner
+;; Last-Mod:      1-Jun-25 at 00:48:17 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -421,10 +421,11 @@
   (with-temp-buffer
     (insert "\"-${hyperb:dir}/test/hy-test-dependencies.el\"")
     (goto-char 2)
-    (action-key)
-    (should (hattr:ibtype-is-p 'pathname))
-    (hy-test-helpers:should-last-message "Loading")
-    (hy-test-helpers:should-last-message "hy-test-dependencies.el")))
+    (ert-with-message-capture cap
+      (action-key)
+      (should (hattr:ibtype-is-p 'pathname))
+      (should (string-search "Loading" cap))
+      (should (string-search "hy-test-dependencies.el" cap)))))
 
 (ert-deftest hbut-pathname-directory-test ()
   "Pathname with directory opens Dired."

--- a/test/hmouse-drv-tests.el
+++ b/test/hmouse-drv-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    28-Feb-21 at 22:52:00
-;; Last-Mod:      1-Jun-25 at 00:48:17 by Mats Lidell
+;; Last-Mod:      1-Jun-25 at 23:31:35 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -424,8 +424,8 @@
     (ert-with-message-capture cap
       (action-key)
       (should (hattr:ibtype-is-p 'pathname))
-      (should (string-search "Loading" cap))
-      (should (string-search "hy-test-dependencies.el" cap)))))
+      (hy-test-helpers:should-last-message "Loading" cap)
+      (hy-test-helpers:should-last-message "hy-test-dependencies.el" cap))))
 
 (ert-deftest hbut-pathname-directory-test ()
   "Pathname with directory opens Dired."

--- a/test/hui-select-tests.el
+++ b/test/hui-select-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    14-Apr-22 at 23:45:52
-;; Last-Mod:      1-Jun-25 at 11:12:02 by Mats Lidell
+;; Last-Mod:      1-Jun-25 at 23:40:09 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -120,7 +120,7 @@
     ;; error
     (ert-with-message-capture cap
       (should-not (hui-select-thing))
-      (should (string-search "(hui-select-boundaries): ‘buffer’ is the largest selectable region" cap)))))
+      (hy-test-helpers:should-last-message "(hui-select-boundaries): ‘buffer’ is the largest selectable region" cap))))
 
 (ert-deftest hui-select--thing-interactive-prints-type-of-match ()
   "`hui-select-thing' selects bigger sections of text when called repeatedly.
@@ -134,40 +134,40 @@ Verifies right type of match is printed when `hui-select-display-type' is set to
 
       (ert-with-message-capture cap
         (should (call-interactively 'hui-select-thing))
-        (should (string-search "word" cap)))
+        (hy-test-helpers:should-last-message "word" cap))
       (should (string= (buffer-substring-no-properties (region-beginning) (region-end)) "word"))
 
       (ert-with-message-capture cap
         (should (call-interactively 'hui-select-thing))
-        (should (string-search "symbol" cap)))
+        (hy-test-helpers:should-last-message "symbol" cap))
       (should (string= (buffer-substring-no-properties (region-beginning) (region-end)) "word."))
 
       (ert-with-message-capture cap
         (should (call-interactively 'hui-select-thing))
-        (should (string-search "sentence" cap)))
+        (hy-test-helpers:should-last-message "sentence" cap))
       (should (string= (buffer-substring-no-properties (region-beginning) (region-end)) "One word."))
 
       (ert-with-message-capture cap
         (should (call-interactively 'hui-select-thing))
-        (should (string-search "line" cap)))
+        (hy-test-helpers:should-last-message "line" cap))
       (should (string= (buffer-substring-no-properties (region-beginning) (region-end))
                        "line.  One word."))
 
       (ert-with-message-capture cap
         (should (call-interactively 'hui-select-thing))
-        (should (string-search "paragraph" cap)))
+        (hy-test-helpers:should-last-message "paragraph" cap))
       (should (string= (buffer-substring-no-properties (region-beginning) (region-end))
                        "\nParagraph\nline.  One word."))
 
       (ert-with-message-capture cap
         (should (call-interactively 'hui-select-thing))
-        (should (string-search "buffer" cap)))
+        (hy-test-helpers:should-last-message "buffer" cap))
       (should (string= (buffer-substring-no-properties (region-beginning) (region-end))
                        "Buffer\n\nParagraph\nline.  One word."))
 
       (ert-with-message-capture cap
         (should-not (call-interactively 'hui-select-thing))
-        (should (string-search "(hui-select-boundaries): ‘buffer’ is the largest selectable region" cap))))))
+        (hy-test-helpers:should-last-message "(hui-select-boundaries): ‘buffer’ is the largest selectable region" cap)))))
 
 (provide 'hui-select-tests)
 ;;; hui-select-tests.el ends here

--- a/test/hui-select-tests.el
+++ b/test/hui-select-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    14-Apr-22 at 23:45:52
-;; Last-Mod:     20-Jan-24 at 15:44:04 by Mats Lidell
+;; Last-Mod:      1-Jun-25 at 11:12:02 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -24,10 +24,9 @@
 ;;; ************************************************************************
 
 (require 'ert)
+(require 'ert-x)
 (require 'hui-select)
 (require 'hy-test-helpers "test/hy-test-helpers")
-
-(declare-function hy-test-helpers:should-last-message "hy-test-helpers")
 
 (ert-deftest hui-select--at-delimited-thing-p ()
   "At delimited thing p returns type of thing."
@@ -119,9 +118,9 @@
                      "Buffer\n\nParagraph\nline.  One word."))
 
     ;; error
-    (should-not (hui-select-thing))
-    (hy-test-helpers:should-last-message
-     "(hui-select-boundaries): ‘buffer’ is the largest selectable region")))
+    (ert-with-message-capture cap
+      (should-not (hui-select-thing))
+      (should (string-search "(hui-select-boundaries): ‘buffer’ is the largest selectable region" cap)))))
 
 (ert-deftest hui-select--thing-interactive-prints-type-of-match ()
   "`hui-select-thing' selects bigger sections of text when called repeatedly.
@@ -133,36 +132,42 @@ Verifies right type of match is printed when `hui-select-display-type' is set to
       (insert "Buffer\n\nParagraph\nline.  One word.")
       (forward-char -3)
 
-      (should (call-interactively 'hui-select-thing))
-      (hy-test-helpers:should-last-message "word")
+      (ert-with-message-capture cap
+        (should (call-interactively 'hui-select-thing))
+        (should (string-search "word" cap)))
       (should (string= (buffer-substring-no-properties (region-beginning) (region-end)) "word"))
 
-      (should (call-interactively 'hui-select-thing))
-      (hy-test-helpers:should-last-message "symbol")
+      (ert-with-message-capture cap
+        (should (call-interactively 'hui-select-thing))
+        (should (string-search "symbol" cap)))
       (should (string= (buffer-substring-no-properties (region-beginning) (region-end)) "word."))
 
-      (should (call-interactively 'hui-select-thing))
-      (hy-test-helpers:should-last-message "sentence")
+      (ert-with-message-capture cap
+        (should (call-interactively 'hui-select-thing))
+        (should (string-search "sentence" cap)))
       (should (string= (buffer-substring-no-properties (region-beginning) (region-end)) "One word."))
 
-      (should (call-interactively 'hui-select-thing))
-      (hy-test-helpers:should-last-message "line")
+      (ert-with-message-capture cap
+        (should (call-interactively 'hui-select-thing))
+        (should (string-search "line" cap)))
       (should (string= (buffer-substring-no-properties (region-beginning) (region-end))
                        "line.  One word."))
 
-      (should (call-interactively 'hui-select-thing))
-      (hy-test-helpers:should-last-message "paragraph")
+      (ert-with-message-capture cap
+        (should (call-interactively 'hui-select-thing))
+        (should (string-search "paragraph" cap)))
       (should (string= (buffer-substring-no-properties (region-beginning) (region-end))
                        "\nParagraph\nline.  One word."))
 
-      (should (call-interactively 'hui-select-thing))
-      (hy-test-helpers:should-last-message "Buffer")
+      (ert-with-message-capture cap
+        (should (call-interactively 'hui-select-thing))
+        (should (string-search "buffer" cap)))
       (should (string= (buffer-substring-no-properties (region-beginning) (region-end))
                        "Buffer\n\nParagraph\nline.  One word."))
 
-      (should-not (call-interactively 'hui-select-thing))
-      (hy-test-helpers:should-last-message
-       "(hui-select-boundaries): ‘buffer’ is the largest selectable region"))))
+      (ert-with-message-capture cap
+        (should-not (call-interactively 'hui-select-thing))
+        (should (string-search "(hui-select-boundaries): ‘buffer’ is the largest selectable region" cap))))))
 
 (provide 'hui-select-tests)
 ;;; hui-select-tests.el ends here

--- a/test/hy-test-helpers.el
+++ b/test/hy-test-helpers.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:      6-Apr-25 at 19:45:02 by Mats Lidell
+;; Last-Mod:      1-Jun-25 at 10:40:15 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -33,13 +33,6 @@
 	 (first-type (caar possible-types)))
     (should (= (length possible-types) 1))
     (should (equal first-type type))))
-
-(defun hy-test-helpers:should-last-message (msg)
-  "Verify last message is MSG."
-  (with-current-buffer (messages-buffer)
-    (should (save-excursion
-              (goto-char (point-max))
-              (search-backward msg (- (point-max) 350) t)))))
 
 (defun hy-test-helpers:action-key-should-call-hpath:find (str)
   "Call action-key and check that hpath:find was called with STR."

--- a/test/hy-test-helpers.el
+++ b/test/hy-test-helpers.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:      1-Jun-25 at 10:40:15 by Mats Lidell
+;; Last-Mod:      1-Jun-25 at 23:22:27 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -33,6 +33,10 @@
 	 (first-type (caar possible-types)))
     (should (= (length possible-types) 1))
     (should (equal first-type type))))
+
+(defun hy-test-helpers:should-last-message (msg captured)
+  "Verify MSG is in CAPTURED text."
+  (should (string-search msg captured)))
 
 (defun hy-test-helpers:action-key-should-call-hpath:find (str)
   "Call action-key and check that hpath:find was called with STR."

--- a/test/hyrolo-tests.el
+++ b/test/hyrolo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    19-Jun-21 at 22:42:00
-;; Last-Mod:     27-May-25 at 02:28:30 by Bob Weiner
+;; Last-Mod:      1-Jun-25 at 10:16:31 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -28,7 +28,6 @@
 (require 'kotl-mode)
 
 (declare-function hy-test-helpers:consume-input-events "hy-test-helpers")
-(declare-function hy-test-helpers:should-last-message "hy-test-helpers")
 
 (ert-deftest hyrolo-add-items-at-multiple-levels ()
   "`hyrolo-add` can add items at different levels."


### PR DESCRIPTION
# What

Use ert-with-message-capture.

# Why

Ert has support for capturing messages in the Message buffer so we can
remove use of our own home baked solution.
