### PR TITLE
Add test for yanking in WikiWord

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2025-06-06  Mats Lidell  <matsl@gnu.org>
+
+* test/hywiki-tests.el (hywiki-tests--wikiword-yanked-with-extra-words):
+    Failing test for yanked in WikiWord.
+
 2025-06-05  Mats Lidell  <matsl@gnu.org>
 
 * test/hywiki-tests.el (hywiki-tests--hywiki-face-region-at): Get overlay

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -1606,6 +1606,25 @@ Insert test in the middle of other text."
         (hy-delete-file-and-buffer wikiHi)
         (hy-delete-dir-and-buffer hywiki-directory)))))
 
+(ert-deftest hywiki-tests--wikiword-yanked-with-extra-words ()
+  "Verify that a WikiWord that is yanked in highlights properly."
+  :expected-result :failed
+  (hywiki-tests--preserve-hywiki-mode
+    (let* ((hywiki-directory (make-temp-file "hywiki" t))
+           (wikiHi (cdr (hywiki-add-page "Hi")))
+           (hywiki-tests--with-face-test t))
+      (unwind-protect
+          (progn
+            (hywiki-mode 1)
+            (with-temp-buffer
+              (let ((kill-ring (list "Hi#a b c"))
+                    interprogram-paste-function)
+                (yank))
+              (goto-char 2)
+              (should (hywiki-tests--verify-hywiki-word "Hi#a"))))
+        (hy-delete-file-and-buffer wikiHi)
+        (hy-delete-dir-and-buffer hywiki-directory)))))
+
 (provide 'hywiki-tests)
 
 ;; This file can't be byte-compiled without the `el-mock' package

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -1612,17 +1612,53 @@ Insert test in the middle of other text."
   (hywiki-tests--preserve-hywiki-mode
     (let* ((hywiki-directory (make-temp-file "hywiki" t))
            (wikiHi (cdr (hywiki-add-page "Hi")))
+           (wikiHo (cdr (hywiki-add-page "Ho")))
            (hywiki-tests--with-face-test t))
       (unwind-protect
           (progn
             (hywiki-mode 1)
+            ;; Non WikiWords in front of WikiWord.
+            (with-temp-buffer
+              (let ((kill-ring (list "a b Hi#c"))
+                    interprogram-paste-function)
+                (yank))
+              (goto-char 1)
+              (hywiki-tests--verify-hywiki-word nil)
+              (goto-char 6)
+              (hywiki-tests--verify-hywiki-word "Hi#c"))
+            ;; Non WikiWords after WikiWord.
             (with-temp-buffer
               (let ((kill-ring (list "Hi#a b c"))
                     interprogram-paste-function)
                 (yank))
               (goto-char 2)
-              (should (hywiki-tests--verify-hywiki-word "Hi#a"))))
-        (hy-delete-file-and-buffer wikiHi)
+              (hywiki-tests--verify-hywiki-word "Hi#a"))
+            ;; Multiple WikiWords with non WikiWords.
+            (with-temp-buffer
+              (let ((kill-ring (list "a Hi#b c Ho#d e"))
+                    interprogram-paste-function)
+                (yank))
+              (goto-char 4)
+              (hywiki-tests--verify-hywiki-word "Hi#b")
+              (goto-char 11)
+              (hywiki-tests--verify-hywiki-word "Ho#d"))
+            ;; Right part of WikiWord yanked in.
+            (with-temp-buffer
+              (insert "H")
+              (let ((kill-ring (list "i#s"))
+                    interprogram-paste-function)
+                (yank))
+              (goto-char 2)
+              (hywiki-tests--verify-hywiki-word "Hi#s"))
+            ;; Left part of WikiWord yanked in.
+            (with-temp-buffer
+              (insert "i#s")
+              (goto-char 1)
+              (let ((kill-ring (list "H"))
+                    interprogram-paste-function)
+                (yank))
+              (hywiki-tests--verify-hywiki-word "Hi#s")))
+        (hy-delete-files-and-buffers (list wikiHi wikiHo))
         (hy-delete-dir-and-buffer hywiki-directory)))))
 
 (provide 'hywiki-tests)


### PR DESCRIPTION
# What

Add test for WikiWord that is yanked in together with following words.

# Why

The current behavior sets the WikiWord face on the whole yanked
text. It should only set the WikiWord face on the WikiWord. The test
is marked as expected failed.
