### PR TITLE
protect org publish project alist from change by test

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,7 +2,7 @@
 
 * test/hywiki-tests.el
     (hywiki-tests--published-html-links-to-word-and-section): Do no let test
-    change org-publish-project-alist.
+    change org-publish-project-alist and update test.
 
 2025-06-06  Mats Lidell  <matsl@gnu.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2025-06-07  Mats Lidell  <matsl@gnu.org>
+
+* test/hywiki-tests.el
+    (hywiki-tests--published-html-links-to-word-and-section): Do no let test
+    change org-publish-project-alist.
+
 2025-06-06  Mats Lidell  <matsl@gnu.org>
 
 * test/hywiki-tests.el (hywiki-tests--wikiword-yanked-with-extra-words):

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -809,9 +809,9 @@ body B
             (save-buffer))
           (with-current-buffer (find-file-noselect wikipage)
             (insert "\
-* WikiWord
-* WikiWord#Asection
-* WikiWord#Bsection-subsection
+WikiWord
+WikiWord#Asection
+\"WikiWord#Bsection subsection\"
 ")
             (save-buffer))
 
@@ -828,12 +828,12 @@ body B
             ;; (First check we even get the wikipage with sections)
             (should (<= 1 (count-matches (regexp-quote "WikiWord") (point-min) (point-max))))
             (should (= 1 (count-matches (regexp-quote "WikiWord#Asection") (point-min) (point-max))))
-            (should (= 1 (count-matches (regexp-quote "WikiWord#Bsection-subsection") (point-min) (point-max))))
+            (should (= 1 (count-matches (regexp-quote "WikiWord#Bsection subsection") (point-min) (point-max))))
 
             ;; Then verify the href links are generated
             (should (= 1 (count-matches (regexp-quote "<a href=\"WikiWord.html\">WikiWord</a>") (point-min) (point-max))))
-            (should (= 1 (count-matches (regexp-quote "<a href=\"WikiWord.html#Asection\">WikiWord#ASection</a>") (point-min) (point-max))))
-            (should (= 1 (count-matches (regexp-quote "<a href=\"WikiWord.html#Bsection-subsection\">WikiWord#Bsection-subsection</a>") (point-min) (point-max))))))
+            (should (= 1 (count-matches (regexp-quote "<a href=\"WikiWord.html#Asection\">WikiWord#Asection</a>") (point-min) (point-max))))
+            (should (= 1 (count-matches (regexp-quote "<a href=\"WikiWord.html#Bsection-subsection\">WikiWord#Bsection subsection</a>") (point-min) (point-max))))))
       (hy-delete-files-and-buffers (list wikipage wikiword wikipage-html wikiword-html
                                          (expand-file-name "index.org" hywiki-directory)
                                          (expand-file-name "index.html" hywiki-org-publishing-directory)))

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -784,6 +784,7 @@ body B
   "Verify published html links to WikiWord and section."
   :expected-result :failed
   (let* ((hywiki-directory (make-temp-file "hywiki_" t))
+         org-publish-project-alist
          (hywiki-org-publishing-directory (make-temp-file "public_html_" t))
          (wikipage (cdr (hywiki-add-page "WikiPage")))
          (wikipage-html (expand-file-name "WikiPage.html" hywiki-org-publishing-directory))


### PR DESCRIPTION
# What

- **Do no let test change org-publish-project-alist**
- **Simplify target text and use quotes for subsection**

# Why

The test case, if run in an live Emacs, should not alter the users
org-publish-project-alist setting. 

The test data is also updated to be more precis i.e. there is no need
to let the WikiWord-links to be in headers but can rather be plain
body text.
