### PR TITLE
Verify creating a file for WikiWord highlights WikiWord

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2025-06-24  Mats Lidell  <matsl@gnu.org>
+
+* test/hywiki-tests.el (hywiki-tests--create-wikiword-file-highlights-wikiword):
+    Verify creating a file for WikiWord highlights the instances of
+    WikiWord that already is present in other files.
+
 2025-06-22  Bob Weiner  <rsw@gnu.org>
 
 * hproperty.el (hproperty:but-get-first-in-region): Change from returning a list

--- a/test/hy-test-helpers.el
+++ b/test/hy-test-helpers.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:      1-Jun-25 at 23:22:27 by Mats Lidell
+;; Last-Mod:     24-Jun-25 at 10:21:13 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -20,6 +20,7 @@
 
 (require 'ert)
 (require 'hmouse-drv)                   ; For `action-key'
+(require 'hywiki)                       ; For `hywiki-word-face-at-p'
 (eval-when-compile (require 'cl-lib))
 
 (defun hy-test-helpers:consume-input-events ()

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    18-May-24 at 23:59:48
-;; Last-Mod:     22-Jun-25 at 22:32:29 by Bob Weiner
+;; Last-Mod:     24-Jun-25 at 09:36:49 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1669,6 +1669,25 @@ Insert test in the middle of other text."
                     interprogram-paste-function)
                 (yank))
               (hywiki-tests--verify-hywiki-word "Hi#s")))
+        (hy-delete-files-and-buffers (list wikiHi wikiHo))
+        (hy-delete-dir-and-buffer hywiki-directory)))))
+
+(ert-deftest hywiki-tests--create-wikiword-file-highlights-wikiword ()
+  "Verify creating a WikiWord-file highlights the WikiWord in another file."
+  (hywiki-tests--preserve-hywiki-mode
+    (let* ((hywiki-directory (make-temp-file "hywiki" t))
+           (wikiHi (cdr (hywiki-add-page "Hi")))
+           (hywiki-tests--with-face-test t)
+           wikiHo)
+      (unwind-protect
+          (progn
+            (hywiki-mode 1)
+            (with-current-buffer (find-file wikiHi)
+              (insert "Ho")
+              (save-buffer)
+              (setq wikiHo (cdr (hywiki-add-page "Ho")))
+              (goto-char 2)
+              (hywiki-tests--verify-hywiki-word "Ho")))
         (hy-delete-files-and-buffers (list wikiHi wikiHo))
         (hy-delete-dir-and-buffer hywiki-directory)))))
 


### PR DESCRIPTION
# What

Verify creating a file for WikiWord highlights the instances of the WikiWord
already present in another WikiWord file.

# Why

WikiWords inserted before the WikiWord file is created should be
highlighted at the time the WikiWord file is created.