### PR TITLE
kill behavior depend on last-command so make it nil before yank test

### DIFF
--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     20-Jun-25 at 19:37:43 by Bob Weiner
+;; Last-Mod:     23-Jun-25 at 00:16:35 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -401,8 +401,8 @@ Ensure modifying the button but keeping the label does not create a double label
 
 (ert-deftest hui--kill-ring-save--yank-in-same-kotl ()
   "Yank saved klink into same kotl file."
-  (skip-unless (not noninteractive))
-  (let ((kotl-file (make-temp-file "hypb" nil ".kotl")))
+  (let ((kotl-file (make-temp-file "hypb" nil ".kotl"))
+        last-command)
     (unwind-protect
         (progn
           (find-file kotl-file)
@@ -422,9 +422,9 @@ Ensure modifying the button but keeping the label does not create a double label
 
 (ert-deftest hui--kill-ring-save--yank-in-other-kotl ()
   "Yank saved klink into other kotl file."
-  (skip-unless (not noninteractive))
   (let ((kotl-file (make-temp-file "hypb" nil ".kotl"))
-        (other-file (make-temp-file "hypb" nil ".kotl")))
+        (other-file (make-temp-file "hypb" nil ".kotl"))
+        last-command)
     (unwind-protect
         (progn
           (find-file kotl-file)
@@ -445,9 +445,9 @@ Ensure modifying the button but keeping the label does not create a double label
 
 (ert-deftest hui--kill-ring-save--yank-in-other-file ()
   "Yank saved klink into other file."
-  (skip-unless (not noninteractive))
   (let ((kotl-file (make-temp-file "hypb" nil ".kotl"))
-        (other-file (make-temp-file "hypb" nil ".txt")))
+        (other-file (make-temp-file "hypb" nil ".txt"))
+        last-command)
     (unwind-protect
         (progn
           (find-file kotl-file)
@@ -468,10 +468,10 @@ Ensure modifying the button but keeping the label does not create a double label
 
 (ert-deftest hui--kill-ring-save--yank-in-other-file-other-dir ()
   "Yank saved klink into other file in other dir."
-  (skip-unless (not noninteractive))
   (let* ((kotl-file (make-temp-file "hypb" nil ".kotl"))
          (other-dir (make-temp-file "hypb" t))
-         (other-file (expand-file-name "other-file" other-dir)))
+         (other-file (expand-file-name "other-file" other-dir))
+         last-command)
     (unwind-protect
         (progn
           (find-file kotl-file)


### PR DESCRIPTION
# What

 - Set last-command to nil in yank tests to avoid the kill in the test case
   kill to be combined with kills in other tests.
 - Remove guard for only executing in interactive mode since that is not
   actually required.

# Why

The tests fail when running make test-all but then works when running
them individually. The suspicion is that previous test cases kills text that
is concatenated with the current test case kill and thus undermines the
verification.

# Comment

To be honest I have not really verified the connection with last-command
and our kill-region functionality. I just got a hunch that there could
be some interference with kill picking up more than expected due to the
multiple kill functionality. If a kill is preceded by another kill the result is
concatenated. 

So I tried to see if setting last-command to nil could fix this and it
does. 

I have verified though that the contents of the kill-ring is
completely different after running test-all for the "hui--*" tests on
either this branch or master.

An alternative could possibly be to empty the kill-ring with the
potential to not touch the users kill-ring when running in a live
Emacs session.

I also removed the run-in-interactive-mode-only check since these tests
works fine in batch mode.
