### PR TITLE
Add test for hui:kill-region and restoring with yank

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2025-06-24  Mats Lidell  <matsl@gnu.org>
 
+* test/hui-tests.el (hui--kill-region-delimited-text-and-yank-back)
+    (hui--select-boundaries): Add tests.
+
 * test/hywiki-tests.el (hywiki-tests--create-wikiword-file-highlights-wikiword):
     Verify creating a file for WikiWord highlights the instances of
     WikiWord that already is present in other files.


### PR DESCRIPTION
# What

 - Add test for hui:kill-region and restoring with yank
 - Add related test for hui-select-boundaries.

# Why

 - This is not covered by test yet.
 - The tests indicates there is a problem with hui-select-boundaries!?
 
# Comment

The last test in hui--kill-region-delimited-text-and-yank-back fails I
think due to hui-select-boundaries not returning a region when there
is no carriage return at the end of the only line in the test buffer.

The test for hui-select-bondaries shows that the carriage return
affects the region that is returned.
