### PR TITLE
add kotl mode add cell tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,8 @@
-2025-07-29  Mats Lidell  <matsl@gnu.org>
+2025-07-31  Mats Lidell  <matsl@gnu.org>
 
-* test/kotl-mode-tests.el (kotl-mode--add-cell): Add test.
+* test/kotl-mode-tests.el (kotl-mode--add-cell)
+    (kotl-mode--add-after-parent, kotl-mode--add-before-parent)
+    (kotl-mode--add-below-parent, kotl-mode--add-child): Add tests.
 
 2025-07-27  Bob Weiner  <rsw@gnu.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2025-07-29  Mats Lidell  <matsl@gnu.org>
+
+* test/kotl-mode-tests.el (kotl-mode--add-cell): Add test.
+
 2025-07-27  Bob Weiner  <rsw@gnu.org>
 
 *  hpath.el (hpath:external-file-suffixes): Remove old Sun Raster image format

--- a/test/kotl-mode-tests.el
+++ b/test/kotl-mode-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    18-May-21 at 22:14:10
-;; Last-Mod:     29-Jul-25 at 16:05:57 by Mats Lidell
+;; Last-Mod:     30-Jul-25 at 23:55:27 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1177,6 +1177,38 @@ marked with :ignore t")
         (kotl-mode:add-cell 2 "following siblings")
         (should (equal (kcell-view:level) 2))
         (should (string= (kcell-view:label (point)) "1c"))))))
+
+(ert-deftest kotl-mode--add-after-parent ()
+  "Verify `kotl-mode:add-after-parent'."
+  (cl-flet ((init ()
+              (progn (erase-buffer)
+                     (kotl-mode)
+                     (insert "first")
+                     (kotl-mode:add-cell '(4) "child"))))
+    (with-temp-buffer
+      (ert-info ("After init point at beginning of child cell")
+        (init)
+        (should (looking-at-p "child"))
+        (should (= (kcell-view:level) 2)))
+      (ert-info ("Error: Called with non positive argument")
+        (init)
+        (should-error (kotl-mode:add-after-parent 0)))
+      (ert-info ("If on the first level of the outline, insert cells at the start of the outline.")
+        (init)
+        (kotl-mode:beginning-of-buffer)
+        (kotl-mode:add-after-parent 1 "first child cell")
+        (should (string= "first child cell" (kcell-view:contents)))
+        (should (kotl-mode:first-cell-p)))
+      (ert-info ("Add succeeding sibling cells to the current cell’s parent" :prefix "1: ")
+        (init)
+        (kotl-mode:add-after-parent 1 "succeeding sibling")
+        (should (= (kcell-view:level) 1))
+        (should (string= (kcell-view:label (point)) "2")))
+      (ert-info ("Add succeeding sibling cells to the current cell’s parent" :prefix "2: ")
+        (init)
+        (kotl-mode:add-after-parent 2 "succeeding sibling")
+        (should (= (kcell-view:level) 1))
+        (should (string= (kcell-view:label (point)) "3"))))))
 
 (provide 'kotl-mode-tests)
 

--- a/test/kotl-mode-tests.el
+++ b/test/kotl-mode-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    18-May-21 at 22:14:10
-;; Last-Mod:     31-Jul-25 at 12:53:10 by Mats Lidell
+;; Last-Mod:     31-Jul-25 at 13:20:37 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1131,7 +1131,7 @@ marked with :ignore t")
                      (insert "first")
                      (kotl-mode:add-cell '(4) "child"))))
     (with-temp-buffer
-      (ert-info ("After init point at beginning of child cell")
+      (ert-info ("After init. Point at beginning of child cell")
         (init)
         (should (looking-at-p "child"))
         (should (= (kcell-view:level) 2)))
@@ -1176,7 +1176,7 @@ marked with :ignore t")
                      (insert "first")
                      (kotl-mode:add-cell '(4) "child"))))
     (with-temp-buffer
-      (ert-info ("After init point at beginning of child cell")
+      (ert-info ("After init. Point at beginning of child cell")
         (init)
         (should (looking-at-p "child"))
         (should (= (kcell-view:level) 2)))
@@ -1200,6 +1200,35 @@ marked with :ignore t")
         (should (= (kcell-view:level) 1))
         (should (string= (kcell-view:label (point)) "3"))))))
 
+(ert-deftest kotl-mode--add-before-parent ()
+  "Verify `kotl-mode:add-before-parent'."
+  (cl-flet ((init ()
+              (progn (erase-buffer)
+                     (kotl-mode)
+                     (insert "first")
+                     (kotl-mode:add-cell '(4) "child")
+                     (kotl-mode:add-cell '(4) "child of child"))))
+    (with-temp-buffer
+      (ert-info ("After init. Point at beginning of child of child cell")
+        (init)
+        (should (looking-at-p "child of child"))
+        (should (= (kcell-view:level) 3)))
+      (ert-info ("Error: Called with non positive argument")
+        (init)
+        (should-error (kotl-mode:add-before-parent 0)))
+      (ert-info ("If on the first level of the outline, insert cells at the start of the outline.")
+        (init)
+        (kotl-mode:beginning-of-buffer)
+        (should (= (kcell-view:level) 1))
+        (kotl-mode:add-before-parent 1 "start of outline")
+        ;; (should (kotl-mode:first-cell-p))) ;; <= EXPECTED
+        (should (string= (kcell-view:label (point)) "2"))) ;; FAIL: Actual.
+      (ert-info ("Add prior sibling cells to the current cell’s parent")
+        (init)
+        (kotl-mode:add-before-parent 1 "add prior sibling to current cells parent")
+        (should (= (kcell-view:level) 2))
+        (should (string= (kcell-view:label (point)) "1a"))))))
+      
 (provide 'kotl-mode-tests)
 
 ;; This file can't be byte-compiled without the `el-mock' package

--- a/test/kotl-mode-tests.el
+++ b/test/kotl-mode-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    18-May-21 at 22:14:10
-;; Last-Mod:     30-Jul-25 at 23:55:27 by Mats Lidell
+;; Last-Mod:     31-Jul-25 at 12:53:10 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1141,17 +1141,7 @@ marked with :ignore t")
       (ert-info ("when = 0, add as the parent’s first child cell")
         (init)
         (kotl-mode:add-cell 0 "first child cell")
-        (should (kotl-mode:first-cell-p)) ;; FAIL!? Goes to beginning of kotl, not first cell of parent!
-        ;; Expected:
-        ;;  (should (= (kcell-view:level) 2))
-        ;;  (should (looking-at-p "first child cell"))
-        ;;  (should (string= (kcell-view:label (point)) "1a")))
-        )
-      ;; FAIL for same reason as above. Adds as first cell even if at level 1.
-      ;; (ert-info ("when = 0, add as the parent’s first child cell" :prefix "Error case. No parent: ")
-      ;;   (init)
-      ;;   (kotl-mode:beginning-of-buffer)
-      ;;   (should-error (kotl-mode:add-cell 0 "first child cell")))
+        (should (kotl-mode:first-cell-p)))
       (ert-info ("when < 0, add that number of cells as preceding siblings" :prefix "1: ")
         (init)
         (kotl-mode:add-cell -1 "preceding sibling")

--- a/test/kotl-mode-tests.el
+++ b/test/kotl-mode-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    18-May-21 at 22:14:10
-;; Last-Mod:     29-Jul-25 at 15:45:03 by Mats Lidell
+;; Last-Mod:     29-Jul-25 at 16:05:57 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1135,6 +1135,9 @@ marked with :ignore t")
         (init)
         (should (looking-at-p "child"))
         (should (= (kcell-view:level) 2)))
+      (ert-info ("Error: Called with non numeric level")
+        (init)
+        (should-error (kotl-mode:add-cell "not numeric")))
       (ert-info ("when = 0, add as the parent’s first child cell")
         (init)
         (kotl-mode:add-cell 0 "first child cell")
@@ -1144,6 +1147,11 @@ marked with :ignore t")
         ;;  (should (looking-at-p "first child cell"))
         ;;  (should (string= (kcell-view:label (point)) "1a")))
         )
+      ;; FAIL for same reason as above. Adds as first cell even if at level 1.
+      ;; (ert-info ("when = 0, add as the parent’s first child cell" :prefix "Error case. No parent: ")
+      ;;   (init)
+      ;;   (kotl-mode:beginning-of-buffer)
+      ;;   (should-error (kotl-mode:add-cell 0 "first child cell")))
       (ert-info ("when < 0, add that number of cells as preceding siblings" :prefix "1: ")
         (init)
         (kotl-mode:add-cell -1 "preceding sibling")


### PR DESCRIPTION
# What

Add: 
 * kotl-mode--add-cell
 * kotl-mode--add-after-parent
 * kotl-mode--add-before-parent
 * kotl-mode--add-below-parent
 * kotl-mode--add-child

# Why

Functions are lacking tests.

# Note

## Using a temp buffer

These tests uses a new way of testing kotl-mode by combining `erase-buffer`
and `cl-flet` with `with-temp-buffer`. A local function is used that erases the
buffer and then calls `kotl-mode` which initializes the buffer. That way one
temp buffer can be used over and over again with greater speed and less
file creation and deletion. 

If there are no problems with using a temp buffer with `kotl-mode`
then I think that can be applied for more of the kotl-mode tests and
maybe even for more of our tests. 