### PR TITLE
Bump to Emacs 30.2 for CI/CD

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [28.2, 29.4, 30.1, master]
+        version: [28.2, 29.4, 30.2, master]
     container: silex/emacs:${{ matrix.version }}-ci
 
     steps:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:     12-Apr-25 at 13:15:02 by Bob Weiner
+# Last-Mod:     19-Aug-25 at 10:08:26 by Mats Lidell
 #
 # Copyright (C) 1994-2025  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -181,7 +181,7 @@ HYPB_WEB_REPO_LOCATION = ../hyweb/hyperbole/
 HYPB_WEB_REPO_LOCATION_DEVEL = $(HYPB_WEB_REPO_LOCATION)devel/
 
 # CI/CD Emacs versions for local docker based tests
-DOCKER_VERSIONS=28.2 29.4 30.1 master
+DOCKER_VERSIONS=28.2 29.4 30.2 master
 
 ##########################################################################
 #                     NO CHANGES REQUIRED BELOW HERE.                    #


### PR DESCRIPTION
# What

Use Emacs 30.2 for the Emacs 30 tests.

# Why

Emacs 30.2 has been released and we use the latest version on each
Emacs major version in the CI builds.

