### PR TITLE
Remove byte compile warnings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2025-08-20  Mats Lidell  <matsl@gnu.org>
+
+* hywiki.el (hywiki--extend-region): Fill long docstring.
+    (hywiki--maybe-de/highlight-sexp): Escape character literals.
+
+* hibtypes.el (display-value-and-remove-region): Declare actype as
+    function to silence byte compiler.
+
 2025-08-20  Bob Weiner  <rsw@gnu.org>
 
 * test/hywiki-tests.el (hywiki-tests--edit-string-pairs): Add a few more

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:     17-Aug-25 at 00:28:01 by Bob Weiner
+;; Last-Mod:     20-Aug-25 at 23:46:20 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1569,6 +1569,7 @@ original DEMO file."
 (declare-function display-boolean  "ext:ignore")
 (declare-function display-variable "ext:ignore")
 (declare-function display-value    "ext:ignore")
+(declare-function display-value-and-remove-region "ext:ignore")
 
 (defib action ()
   "The Action Button type.

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Apr-24 at 22:41:13
-;; Last-Mod:     20-Aug-25 at 00:27:54 by Bob Weiner
+;; Last-Mod:     20-Aug-25 at 23:22:46 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -3528,7 +3528,8 @@ invalid.  Appended only if the referent-type supports suffixes."
   "Extend range (START END) to include delimited regions; return the new range.
 Ensure START and END are in increasing order.
 
-Used to extend a region to fully include any strings or balanced pair delimiters."
+Used to extend a region to fully include any strings or balanced pair
+delimiters."
   (unless (integer-or-marker-p start)
     (error "`start' arg must be an integer or marker, not '%s'" start))
   (unless (integer-or-marker-p end)
@@ -3694,7 +3695,7 @@ DIRECTION-NUMBER is 1 for forward scanning and -1 for backward scanning."
       ;; HyWikiWord.  But include any trailing delimiter or regexp
       ;; matching will not work.
       (save-restriction
-	(when (memq (char-after start) '(?( ?) ?< ?> ?{ ?} ?[ ?] ?\"))
+	(when (memq (char-after start) '(?\( ?\) ?< ?> ?{ ?} ?\[ ?\] ?\"))
 	  (setq start (1+ start)))
 	(narrow-to-region start end)
 	(prog1 (funcall func start end)


### PR DESCRIPTION
# What

Remove byte compile warnings.

# Why

Clean builds are nice and show we care about byte compiler info.