### PR TITLE
smart-tags-display - Remove tags table check not needed by xref

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2025-09-08  Bob Weiner  <rsw@gnu.org>
+
+* hsys-xref.el (hsys-xref-identifier-at-point): Clarify doc string.
+
+* hmouse-tag.el (smart-tags-display): Remove (or tags-table-list tags-file-name)
+    check since xref is now used and many of its backends don't require a TAGS
+    file.  Fixes issue gh#rswgnu/hyperbole/776.
+                (smart-tags-find-p): Rewrite to optimize and try xref before
+    tags lookup.
+
 2025-09-07  Bob Weiner  <rsw@gnu.org>
 
 * test/hywiki-tests.el (hywiki-tests--published-html-links-to-word-and-section):

--- a/hmouse-tag.el
+++ b/hmouse-tag.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    24-Aug-91
-;; Last-Mod:      7-Sep-25 at 12:37:56 by Bob Weiner
+;; Last-Mod:      8-Sep-25 at 22:11:30 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1295,16 +1295,17 @@ variable or face."
 
 (defun smart-tags-find-p (tag)
   "Return non-nil if TAG is found within a tags table, else nil."
-  (let* ((tags-table-list (smart-entire-tags-table-list))
-	 ;; Identifier searches should almost always be case-sensitive today
-	 (tags-case-fold-search nil)
-	 (func (smart-tags-noselect-function))
-	 (tags-file-name (unless tags-table-list
-			   (when (boundp 'tags-file-name) tags-file-name)))
-	 (tags-add-tables nil))
-    (ignore-errors
-      (cond ((and func tags-table-list (funcall func tag) t))
-	    ((with-no-warnings (and (hsys-xref-definition tag) t)))))))
+  (or (ignore-errors
+	(with-no-warnings (and (hsys-xref-definition tag) t)))
+      (let* ((tags-table-list (smart-entire-tags-table-list))
+	     ;; Identifier searches should almost always be case-sensitive today
+	     (tags-case-fold-search nil)
+	     (func (smart-tags-noselect-function))
+	     (tags-file-name (unless tags-table-list
+			       (when (boundp 'tags-file-name) tags-file-name)))
+	     (tags-add-tables nil))
+	(ignore-errors
+	  (and func tags-table-list (funcall func tag) t)))))
 
 (defun smart-java-cross-reference ()
   "If within a Java @see comment, edit the def and return non-nil, else nil.
@@ -1535,11 +1536,10 @@ backend is used."
 		  ;; many callers of this function.
 		  ;; Find exact identifier matches only.
 		  (with-no-warnings (xref-find-definitions tag)))))
-	  ((or tags-table-list tags-file-name)
-	   ;; Signals an error if tag is not found which is caught by
-	   ;; many callers of this function.
-	   ;; Find exact identifier matches only.
-	   (with-no-warnings (xref-find-definitions tag)))
+	  ;; Signals an error if tag is not found which is caught by
+	  ;; many callers of this function.
+	  ;; Find exact identifier matches only.
+	  ((with-no-warnings (xref-find-definitions tag)))
 	  (t
 	   (error "No existing tag tables in which to find `%s'" tag)))))
 

--- a/hsys-xref.el
+++ b/hsys-xref.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    24-Aug-91
-;; Last-Mod:     14-Apr-25 at 15:51:27 by Mats Lidell
+;; Last-Mod:      8-Sep-25 at 22:03:10 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -50,7 +50,8 @@
   (car (hsys-xref-definitions identifier)))
 
 (defun hsys-xref-identifier-at-point ()
-  "Return nil if xref returns a pathname as an identifier."
+  "Return the identifier at point if not a pathname; otherwise, return nil.
+Identifier is a string."
   (unless (hpath:at-p nil t)
     (xref-backend-identifier-at-point (xref-find-backend))))
 


### PR DESCRIPTION
Fixes issue gh#rswgnu/hyperbole/776.

smart-tags-find-p - Rewrite to optimize and try xref before tags lookup.

hsys-xref-identifier-at-point - Clarify doc string.