### PR TITLE
make tests work again

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,17 @@
+2025-09-20  Mats Lidell  <matsl@gnu.org>
+
+* test/hui-mouse-tests.el (hui-mouse-tests--hkey-alist):
+  test/hycontrol-tests.el (hycontrol-tests--framemove-direction-error-message):
+    Use cl-letf to mock functions that requires mocks that can act on
+    multiple calls with with different parameters or different responses
+    or both.
+
+* test/hywiki-tests.el (hywiki-tests--save-referent-command-use-menu)
+    (hywiki-tests--save-referent-global-button-use-menu)
+    (hywiki-tests--save-referent-info-node-use-menu)
+    (hywiki-tests--save-referent-org-roam-node-use-menu): Add a delay before
+    verifying referent.
+
 2025-09-15  Mats Lidell  <matsl@gnu.org>
 
 * hib-debbugs.el (debbugs-gnu-rescan): Declare to silence byte compile

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2025-09-20  Mats Lidell  <matsl@gnu.org>
 
+* test/hy-test-helpers.el (hy-test-helpers:consume-input-events): Wait
+    longer before terminating consumption of input events.
+
 * test/hui-mouse-tests.el (hui-mouse-tests--hkey-alist):
   test/hycontrol-tests.el (hycontrol-tests--framemove-direction-error-message):
     Use cl-letf to mock functions that requires mocks that can act on

--- a/test/hy-test-helpers.el
+++ b/test/hy-test-helpers.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     15-Sep-25 at 17:39:59 by Mats Lidell
+;; Last-Mod:     20-Sep-25 at 11:26:21 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -25,7 +25,7 @@
 
 (defun hy-test-helpers:consume-input-events ()
   "Use `recursive-edit' to consume the events kbd-key generates."
-  (run-with-timer 0.1 nil (lambda () (if (> (recursion-depth) 0) (exit-recursive-edit))))
+  (run-with-timer 0.5 nil (lambda () (if (> (recursion-depth) 0) (exit-recursive-edit))))
   (recursive-edit))
 
 (defun hy-test-helpers:ensure-link-possible-type (type)

--- a/test/hycontrol-tests.el
+++ b/test/hycontrol-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:     8-Jan-25 at 22:52:00
-;; Last-Mod:      4-Mar-25 at 17:06:26 by Mats Lidell
+;; Last-Mod:     19-Sep-25 at 16:43:05 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -24,10 +24,10 @@
 
 (ert-deftest hycontrol-tests--framemove-direction-error-message ()
   "Verify `hycontrol-framemove-direction' shows message when `framemove' is not available."
-  (mocklet (((featurep 'framemove) => nil)
-            ((hycontrol-quit) => t))
-    (let ((err (should-error (hycontrol-framemove-direction 'up) :type 'error)))
-      (should (string-match "Requires manual installation" (cadr err))))))
+  (cl-letf (((symbol-function 'featurep) (lambda (feature &optional _) nil)))
+    (mocklet (((hycontrol-quit) => t))
+      (let ((err (should-error (hycontrol-framemove-direction 'up) :type 'error)))
+        (should (string-match "Requires manual installation" (cadr err)))))))
 
 (provide 'hycontrol-tests)
 

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -1264,9 +1264,9 @@ named WikiReferent with a non-page referent type."
 (ert-deftest hywiki-tests--save-referent-keyseries ()
   "Verify saving and loading a referent keyseries works ."
   (hywiki-tests--referent-test
-   (cons 'key-series "{ABC}")
-   (hy-test-helpers:ert-simulate-keys "ABC\r"
-     (hywiki-add-key-series wiki-word-non-page))))
+    (cons 'key-series "{ABC}")
+    (hy-test-helpers:ert-simulate-keys "ABC\r"
+      (hywiki-add-key-series wiki-word-non-page))))
 
 (ert-deftest hywiki-tests--save-referent-keyseries-use-menu ()
   "Verify saving and loading a referent keyseries works using Hyperbole's menu."
@@ -1324,7 +1324,9 @@ named WikiReferent with a non-page referent type."
   "Verify saving and loading a referent command works using Hyperbole's menu.."
   (skip-unless (not noninteractive))
   (hywiki-tests--referent-test
-    (cons 'command #'hywiki-tests--command)
+    (progn
+      (sit-for 0.2)
+      (cons 'command #'hywiki-tests--command))
     (let ((vertico-mode 0))
       (should (hact 'kbd-key "C-u C-h hhc WikiReferent RET c hywiki-tests--command RET"))
       (hy-test-helpers:consume-input-events))))
@@ -1359,45 +1361,46 @@ named WikiReferent with a non-page referent type."
 (ert-deftest hywiki-tests--save-referent-global-button ()
   "Verify saving and loading a referent global-button works."
   (hywiki-tests--referent-test
-   (cons 'global-button "gbtn")
-   (mocklet ((hargs:read-match => "gbtn"))
-     (hywiki-add-global-button wiki-word-non-page))))
+    (cons 'global-button "gbtn")
+    (mocklet ((hargs:read-match => "gbtn"))
+      (hywiki-add-global-button wiki-word-non-page))))
 
 (ert-deftest hywiki-tests--save-referent-global-button-use-menu ()
   "Verify saving and loading a referent global-button works using Hyperbole's menu."
   (skip-unless (not noninteractive))
   (hywiki-tests--referent-test
-   (cons 'global-button "global")
-
-   (defvar test-buffer)
-   (let* ((test-file (make-temp-file "gbut" nil ".txt"))
-          (test-buffer (find-file-noselect test-file)))
-     (unwind-protect
-         (with-mock
-           (mock (hpath:find-noselect (expand-file-name hbmap:filename hbmap:dir-user)) => test-buffer)
-           (stub gbut:label-list => (list "global"))
-           (mock (gbut:act "global") => t)
-           (gbut:ebut-program "global" 'link-to-file test-file)
-           (should (hact 'kbd-key "C-u C-h hhc WikiReferent RET g global RET"))
-           (hy-test-helpers:consume-input-events))
-       (hy-delete-file-and-buffer test-file)))))
+    (progn
+      (sit-for 0.2)
+      (cons 'global-button "global"))
+    (defvar test-buffer)
+    (let* ((test-file (make-temp-file "gbut" nil ".txt"))
+           (test-buffer (find-file-noselect test-file)))
+      (unwind-protect
+          (with-mock
+            (mock (hpath:find-noselect (expand-file-name hbmap:filename hbmap:dir-user)) => test-buffer)
+            (stub gbut:label-list => (list "global"))
+            (mock (gbut:act "global") => t)
+            (gbut:ebut-program "global" 'link-to-file test-file)
+            (should (hact 'kbd-key "C-u C-h hhc WikiReferent RET g global RET"))
+            (hy-test-helpers:consume-input-events))
+        (hy-delete-file-and-buffer test-file)))))
 
 ;; HyRolo
 (ert-deftest hywiki-tests--save-referent-hyrolo ()
   "Verify saving and loading a referent hyrolo works."
   (hywiki-tests--referent-test
-   (cons 'hyrolo #'hyrolo-fgrep)
-   (hywiki-add-hyrolo wiki-word-non-page)))
+    (cons 'hyrolo #'hyrolo-fgrep)
+    (hywiki-add-hyrolo wiki-word-non-page)))
 
 ;; Info index
 (ert-deftest hywiki-tests--save-referent-info-index ()
   "Verify saving and loading a referent info index works."
   (hywiki-tests--referent-test
-   (cons 'info-index "(emacs)files")
-   (save-excursion
-     (hy-test-helpers:ert-simulate-keys "files\r"
-       (info "emacs")
-       (hywiki-add-info-index wiki-word-non-page)))))
+    (cons 'info-index "(emacs)files")
+    (save-excursion
+      (hy-test-helpers:ert-simulate-keys "files\r"
+        (info "emacs")
+        (hywiki-add-info-index wiki-word-non-page)))))
 
 (ert-deftest hywiki-tests--save-referent-info-index-use-menu ()
   "Verify saving and loading a referent info index works using Hyperbole's menu."
@@ -1416,47 +1419,49 @@ named WikiReferent with a non-page referent type."
 (ert-deftest hywiki-tests--save-referent-info-node ()
   "Verify saving and loading a referent info node works."
   (hywiki-tests--referent-test
-   (cons 'info-node "(emacs)")
-   (save-excursion
-     (unwind-protect
-         (hy-test-helpers:ert-simulate-keys "(emacs)\r"
-           (hywiki-add-info-node wiki-word-non-page))
-       (kill-buffer "*info*")))))
+    (cons 'info-node "(emacs)")
+    (save-excursion
+      (unwind-protect
+          (hy-test-helpers:ert-simulate-keys "(emacs)\r"
+            (hywiki-add-info-node wiki-word-non-page))
+        (kill-buffer "*info*")))))
 
 (ert-deftest hywiki-tests--save-referent-info-node-use-menu ()
   "Verify saving and loading a referent info node works using Hyperbole's menu."
   (skip-unless (not noninteractive))
   (hywiki-tests--referent-test
-   (cons 'info-node "(emacs)")
-   (save-excursion
-     (unwind-protect
-         (progn
-           (should (hact 'kbd-key "C-u C-h hhc WikiReferent RET n (emacs) RET"))
-           (hy-test-helpers:consume-input-events))
-       (kill-buffer "*info*")))))
+    (progn
+      (sit-for 0.2)
+      (cons 'info-node "(emacs)"))
+    (save-excursion
+      (unwind-protect
+          (progn
+            (should (hact 'kbd-key "C-u C-h hhc WikiReferent RET n (emacs) RET"))
+            (hy-test-helpers:consume-input-events))
+        (kill-buffer "*info*")))))
 
 ;; Path link
 (ert-deftest hywiki-tests--save-referent-path-link ()
   "Verify saving and loading a referent path link works."
   (hywiki-tests--referent-test
-   (cons 'path-link "file:L1")
-   (hywiki-add-path-link wiki-word-non-page "file" 1)))
+    (cons 'path-link "file:L1")
+    (hywiki-add-path-link wiki-word-non-page "file" 1)))
 
 ;; Org id
 (ert-deftest hywiki-tests--save-referent-org-id ()
   "Verify saving and loading a referent org id works."
   (hywiki-tests--referent-test
-   (cons 'org-id "ID: generated-org-id")
-   (save-excursion
-     (let ((filea (make-temp-file "hypb" nil ".org")))
-      (unwind-protect
-          (with-current-buffer (find-file filea)
-            (insert "* header\n")
-            (mocklet (((hmouse-choose-link-and-referent-windows) => (list nil (get-buffer-window)))
-                      ((org-id-get-create) => "generated-org-id"))
-              (goto-char (point-max))
-	      (hywiki-add-org-id wiki-word-non-page)))
-	(hy-delete-file-and-buffer filea))))))
+    (cons 'org-id "ID: generated-org-id")
+    (save-excursion
+      (let ((filea (make-temp-file "hypb" nil ".org")))
+        (unwind-protect
+            (with-current-buffer (find-file filea)
+              (insert "* header\n")
+              (mocklet (((hmouse-choose-link-and-referent-windows) => (list nil (get-buffer-window)))
+                        ((org-id-get-create) => "generated-org-id"))
+                (goto-char (point-max))
+	        (hywiki-add-org-id wiki-word-non-page)))
+	  (hy-delete-file-and-buffer filea))))))
 
 ;; FIXME: Add Org-id links tests.
 
@@ -1464,23 +1469,25 @@ named WikiReferent with a non-page referent type."
 (ert-deftest hywiki-tests--save-referent-org-roam-node ()
   "Verify saving and loading a referent org roam node works."
   (hywiki-tests--referent-test
-   (cons 'org-roam-node "node-title")
-   (mocklet (((hypb:require-package 'org-roam) => t)
-	     ((org-roam-node-read) => "node")
-	     ((org-roam-node-title "node") => "node-title"))
-     (hywiki-add-org-roam-node wiki-word-non-page))))
+    (cons 'org-roam-node "node-title")
+    (mocklet (((hypb:require-package 'org-roam) => t)
+	      ((org-roam-node-read) => "node")
+	      ((org-roam-node-title "node") => "node-title"))
+      (hywiki-add-org-roam-node wiki-word-non-page))))
 
 (ert-deftest hywiki-tests--save-referent-org-roam-node-use-menu ()
   "Verify saving and loading a referent org roam node works using Hyperbole's menu."
   (skip-unless (not noninteractive))
   (hywiki-tests--referent-test
-   (cons 'org-roam-node "node-title")
-   (mocklet (((hypb:require-package 'org-roam) => t)
-	     ((org-roam-node-read) => "node")
-	     ((org-roam-node-title "node") => "node-title")
-             ((hywiki-display-org-roam-node "WikiReferent" "node-title") => t))
-     (should (hact 'kbd-key "C-u C-h hhc WikiReferent RET r"))
-     (hy-test-helpers:consume-input-events))))
+    (progn
+      (sit-for 0.2)
+      (cons 'org-roam-node "node-title"))
+    (mocklet (((hypb:require-package 'org-roam) => t)
+	      ((org-roam-node-read) => "node")
+	      ((org-roam-node-title "node") => "node-title")
+              ((hywiki-display-org-roam-node "WikiReferent" "node-title") => t))
+      (should (hact 'kbd-key "C-u C-h hhc WikiReferent RET r"))
+      (hy-test-helpers:consume-input-events))))
 
 (ert-deftest hywiki-tests--delete-parenthesised-char ()
   "Verify removing a char between parentheses only removes the char.


### PR DESCRIPTION
# What

- **Add delay before verification in save referent with menu tests**
- **Use cl-letf to handle featurep**
- **Use cl-letf for mocks that needs to be more intelligent**
- **Add ChangeLog**
- **Wait longer for input events to be processed**

# Why

Tests should work in both docker and native environment.

This PR makes the above work for me in native execution but without
any personalizing, i.e. it works when run from command line using
"make test-all" (which it did not before.)

Some of these changes look strange in the perspective of that the
tests works unchanged in docker but not native. But there are probably
many things that differ between running on your machine and running in
a more limited docker environment. It can be what software is
installed, networking, etc.

The reason for the "big" blocker in the hkey-alist test can be
somewhat explained in that with the changes of xref code the tests
drills deep down into the xref code. The mocks causes some odd
behavior in that code. By instead using cl-letf the calls to
looking-at with other parameters than the one needed for the mock can
be set up to return a valid response. But it is a delicate matter.

There still remains issues for running the tests in a customized
environment. That will have to be addressed separately. I believe this
PR is a step forward anyway to make the tests work under more
circumstances.
