### PR TITLE
Check all caps on filename, reorder mode tests, in anchor search

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2025-09-24  Mats Lidell  <matsl@gnu.org>
+
+* hpath.el (hpath:to-markup-anchor): Match all-caps filenames including
+    dash and underline characters. Check for markdown before checking if
+    buffer is derived by text-mode since that masks markdown.
+
 2025-09-21  Bob Weiner  <rsw@gnu.org>
 
 * hpath.el (hpath:to-markup-anchor): Support 'fundamental-mode' and derived

--- a/hpath.el
+++ b/hpath.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Nov-91 at 00:44:23
-;; Last-Mod:     21-Sep-25 at 09:14:07 by Bob Weiner
+;; Last-Mod:     24-Sep-25 at 19:06:49 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1677,19 +1677,21 @@ of the buffer."
 				    (anchor-name (hpath:dashes-to-spaces-markup-anchor anchor))
 				    (referent-regexp (format
 						      (cond ((or (derived-mode-p 'outline-mode) ;; Includes Org mode
-								 ;; Treat all caps filenames without suffix like outlines, e.g. README, INSTALL.
+								 ;; Treat all caps filenames without suffix like outlines,
+                                                                 ;; e.g. README, INSTALL, HY-NEWS, ...
 								 (and (hypb:buffer-file-name)
-								      (string-match-p "\\`[A-Z][A-Z0-9]+\\'" (hypb:buffer-file-name))))
+								      (string-match-p "\\`[A-Z0-9][A-Z0-9_-]*\\'"
+                                                                                      (file-name-nondirectory (hypb:buffer-file-name)))))
 							     hpath:outline-section-pattern)
-							    ((or prog-mode (null (hypb:buffer-file-name))
-								 (apply #'derived-mode-p '(fundamental-mode text-mode)))
-							     "%s")
 							    ((or (and (hypb:buffer-file-name)
 								      (string-match-p hpath:markdown-suffix-regexp (hypb:buffer-file-name)))
 								 (apply #'derived-mode-p hpath:shell-modes))
 							     hpath:markdown-section-pattern)
 							    ((derived-mode-p 'texinfo-mode)
 							     hpath:texinfo-section-pattern)
+							    ((or prog-mode (null (hypb:buffer-file-name))
+								 (apply #'derived-mode-p '(fundamental-mode text-mode)))
+							     "%s")
 							    (t hpath:outline-section-pattern))
 						      (regexp-quote anchor-name)))
 				    (referent-leading-spaces-regexp


### PR DESCRIPTION
- Change setup referent-regexp to look only on filename part of path for all-caps.
- Extend all-caps to also include dash and underscore so that files like HY-NEWS are expected to have star-outlines.
- Change order of test so that markup is not masked by text-mode.