### PR TITLE
Use hycontrol-global-text-scale-adjust

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 2025-09-25  Mats Lidell  <matsl@gnu.org>
 
+* hycontrol.el (hycontrol-global-text-scale-adjust): Modification of
+    global-text-scale-adjust for use with hycontrol menu.
+    (hycontrol-frame-zoom, hycontrol-frame-zoom-reset): Use
+    hycontrol-global-text-scale-adjust when Emacs has global-text-scale-adjust.
+
 * hycontrol-zmfrm.el (fontset): Require fontset for defining xldf-regexp-* vars.
     (fontset-info, query-fontset, x-list-fonts): Declare functions.
 


### PR DESCRIPTION
# What

Use hycontrol-global-text-scale-adjust.

# Why

global-text-scale-adjust could not be called from hycontrol menu due
to its use of transient key map which did not work with hycontrols key
handling. hycontrol-global-text-scale-adjust is a stripped down
version of global-text-scale-adjust that is suited to be used from a
menu system such as hycontrol. It also blend in well with
global-text-scale-adjust so the functions can be used intermixed on
the Emacsen that has global-text-scale-adjust.

With this we can also remove hycontrol-zmfrm.el when Emacs 28 is not
supported any more.
