### PR TITLE
Add test for edit of WikiWord in an Emacs Lisp docstring

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2025-09-28  Mats Lidell  <matsl@gnu.org>
+
+* test/hywiki-tests.el
+    (hywiki-tests--wikiword-step-check-edit-wikiword-in-emacs-lisp-mode):
+    Add test.
+    (hywiki-tests--wikiword-identified-in-emacs-lisp-mode): Update test to
+    verify WikiWord face.
+
 2025-09-27  Bob Weiner  <rsw@gnu.org>
 
 * hpath.el (hpath:to-markup-anchor): Move 'fundamental-mode' support near

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -1704,11 +1704,39 @@ Insert test in the middle of other text."
                  (p1 . t) (p4) (-1 . "Hiho")))))
         (hy-delete-dir-and-buffer hywiki-directory)))))
 
+(ert-deftest hywiki-tests--wikiword-step-check-edit-wikiword-in-emacs-lisp-mode ()
+  "Run the step check to verify WikiWord is identified under change in a docstring.
+A WikiWord is completed, then last char is deleted and reinserted.  The
+face is verified during the change."
+  (hywiki-tests--preserve-hywiki-mode
+    (let* ((hywiki-directory (make-temp-file "hywiki" t))
+           (wiki-page (cdr (hywiki-add-page "WikiWord"))))
+      (unwind-protect
+          (progn
+            (hywiki-mode 1)
+            (with-temp-buffer
+              (emacs-lisp-mode)
+              (insert "\
+(defun func ()
+  \"WikiWor
+t)
+")
+              ;; Set point after WikiWor
+              (goto-char 1)
+              (should (search-forward "WikiWor"))
+
+              ;; Complete WikiWord and verify highlighting
+              (hywiki-tests--run-test-case
+               '(("d\"" . "WikiWord") (p2 . t) (-1) ("d" . "WikiWord")))))
+        (hy-delete-file-and-buffer wiki-page)
+        (hy-delete-dir-and-buffer hywiki-directory)))))
+
 (ert-deftest hywiki-tests--wikiword-identified-in-emacs-lisp-mode ()
   "Verify WikiWord is identified when surrounded by delimiters in `emacs-lisp-mode'."
   (hywiki-tests--preserve-hywiki-mode
-    (let ((hsys-org-enable-smart-keys t)
-          (hywiki-directory (make-temp-file "hywiki" t)))
+    (let* ((hsys-org-enable-smart-keys t)
+           (hywiki-directory (make-temp-file "hywiki" t))
+           (wiki-page (cdr (hywiki-add-page "WikiWord"))))
       (unwind-protect
           (progn
             (hywiki-mode 1)
@@ -1723,14 +1751,14 @@ Insert test in the middle of other text."
                 (insert (format ";; %s" v))
                 (hywiki-tests--command-execute #'newline 1 'interactive)
                 (goto-char 9)
-                (should (string= "WikiWord" (hywiki-word-at))))
+                (should (string= "WikiWord" (hywiki-tests--word-at))))
 
               (with-temp-buffer
                 (emacs-lisp-mode)
                 (insert (format  "(setq var \"%s\")" v))
                 (hywiki-tests--command-execute #'newline 1 'interactive)
                 (goto-char 16)
-                (should (string= "WikiWord" (hywiki-word-at)))))
+                (should (string= "WikiWord" (hywiki-tests--word-at)))))
 
             ;; Does not match as a WikiWord
             (dolist (v '("WikiWord#"))
@@ -1739,14 +1767,15 @@ Insert test in the middle of other text."
                 (insert (format ";; %s" v))
                 (hywiki-tests--command-execute #'newline 1 'interactive)
                 (goto-char 9)
-                (should-not (hywiki-word-at)))
+                (should-not (hywiki-tests--word-at)))
 
               (with-temp-buffer
                 (emacs-lisp-mode)
                 (insert (format  "(setq var \"%s\")" v))
                 (hywiki-tests--command-execute #'newline 1 'interactive)
                 (goto-char 16)
-                (should-not (hywiki-word-at)))))
+                (should-not (hywiki-tests--word-at)))))
+        (hy-delete-file-and-buffer wiki-page)
         (hy-delete-dir-and-buffer hywiki-directory)))))
 
 (ert-deftest hywiki-tests--wikiword-identified-in-strings-in-emacs-lisp-mode ()


### PR DESCRIPTION
# What

Verifies face changes when editing a WikiWord in a docstring.  Also
update old test to verify WikiWord face as well as WikiWord.

# Why

Docstring highlighting has issues.

# Notes

This test case works but doing the same operations interactively
fails. This could be due to the test code calls the pre and post hooks
to simulate what the interactive code does. See
hywiki-tests--command-execute for the details.

Submitting this test as it covers the case we want to test and uses
the same mechanisms as the other face tests does.

I guess the issue now is to figure out why the pre and post command
hooks are not called when testing this manually. Or if they are why it
differs.

