### PR TITLE
Add run-bash target for use with the docker target

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2025-10-04  Mats Lidell  <matsl@gnu.org>
+
+* Makefile (run-bash): Run bash in docker container for use with the
+    docker target.
+
 2025-10-03  Mats Lidell  <matsl@gnu.org>
 
 * test/kotl-mode-tests.el (kotl-mode--add-cell): Add test for nil

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:     14-Sep-25 at 23:28:46 by Mats Lidell
+# Last-Mod:      2-Oct-25 at 21:59:40 by Mats Lidell
 #
 # Copyright (C) 1994-2025  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -659,6 +659,12 @@ docker-update:
 # Example: make docker version=29.4 targets="clean bin run-emacs"
 run-emacs:
 	emacs --eval "(progn (add-to-list 'load-path \"/hyperbole\") (require 'hyperbole) (hyperbole-mode 1))"
+
+# Similar target for starting bash in the container. Useful for
+# manually doing things before starting Emacs but having Hyperbole
+# available in /hyperbole through the docker target.
+run-bash:
+	bash
 
 docker-clean:
 	docker rm elpa-local


### PR DESCRIPTION
# What

Add run-bash target for use with the docker target.

# Why

When debugging it can be useful to land in bash before starting
Emacs.
