### PR TITLE
Silence byte compile warnings in tests in package install

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2025-10-06  Mats Lidell  <matsl@gnu.org>
+
+* test/hy-test-helpers.el (hy-test-helpers:ert-simulate-keys): Silence
+    warnings for not defined vertico-mode.
+
+* test/hmouse-info-tests.el (hmouse-info-build-completions-no-match): Fix
+    unwind-protect with no unwind form.
+    (hy-test-helpers): Require helper functions.
+    (Info-complete-menu-buffer): Define var.
+
 2025-10-05  Bob Weiner  <rsw@gnu.org>
 
 * hsys-www.el (eww-browse-url): Stop overloading this 'eww' function and replace

--- a/test/hmouse-info-tests.el
+++ b/test/hmouse-info-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    29-Dec-21 at 09:02:00
-;; Last-Mod:      6-Jul-25 at 13:02:40 by Bob Weiner
+;; Last-Mod:      5-Oct-25 at 23:02:48 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -21,6 +21,9 @@
 (require 'ert)
 (require 'ert-x)
 (require 'hmouse-info)
+(require 'hy-test-helpers)
+
+(defvar Info-complete-menu-buffer)
 
 (ert-deftest hmouse-info-read-index-with-completion ()
   "Read a completion that completes."
@@ -33,8 +36,8 @@
       (progn
         (info "(emacs)")
         (setq Info-complete-menu-buffer (clone-buffer))
-        (should (eq '() (Info-build-menu-item-completions "nothinglikethis" nil t)))
-    (kill-buffer "*info*"))))
+        (should (eq '() (Info-build-menu-item-completions "nothinglikethis" nil t))))
+    (kill-buffer "*info*")))
 
 (ert-deftest hmouse-info-build-completions-multiple-matches ()
   "Build completions."

--- a/test/hy-test-helpers.el
+++ b/test/hy-test-helpers.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     20-Sep-25 at 11:26:21 by Mats Lidell
+;; Last-Mod:      5-Oct-25 at 23:56:44 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -41,10 +41,11 @@ Disable `vertico-mode' which can get in the way of standard key
 processing."
   (declare (debug t) (indent 1))
   `(if (bound-and-true-p vertico-mode)
-       (unwind-protect
-	   (progn (vertico-mode 0)
-		  (ert-simulate-keys ,keys ,@body))
-	 (vertico-mode 1))
+       (with-no-warnings
+         (unwind-protect
+	     (progn (vertico-mode 0)
+		    (ert-simulate-keys ,keys ,@body))
+	   (vertico-mode 1)))
      (ert-simulate-keys ,keys ,@body)))
 
 (defun hy-test-helpers:should-last-message (msg captured)


### PR DESCRIPTION
# What

Silence byte compile warnings in tests in package install.

# Why

Byte compiling the tests, which the package manager does, reveals some
byte compilation warnings that is not shown in our regular CI since it
does not byte compile tests.
