### PR TITLE
Use with-suppressed-warnings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2025-10-08  Mats Lidell  <matsl@gnu.org>
+
+* kotl/kotl-mode.el (kotl-mode):
+  hywiki.el (hywiki-add-org-id): Use with-suppressed-warnings.
+
+* hload-path.el (hyperb:with-suppressed-warnings): Remove Emacs 26
+    compatibilty macro. Not needed.
+
 2025-10-06  Mats Lidell  <matsl@gnu.org>
 
 * test/hy-test-helpers.el (hy-test-helpers:ert-simulate-keys): Silence

--- a/hload-path.el
+++ b/hload-path.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    29-Jun-16 at 14:39:33
-;; Last-Mod:     29-Jan-25 at 19:07:46 by Mats Lidell
+;; Last-Mod:      6-Oct-25 at 00:16:34 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -87,40 +87,6 @@ directory separator character.")
 ;;; Autoloads
 ;;; ************************************************************************
 
-(defmacro hyperb:with-suppressed-warnings (warnings &rest body)
-  "Like `progn', but prevents compiler WARNINGS in BODY.
-
-Defined here for elpa build compatibility which uses Emacs 26 and
-does not include `with-suppressed-warnings'.
-
-WARNINGS is an associative list where the first element of each
-item is a warning type, and the rest of the elements in each item
-are symbols they apply to.  For instance, if you want to suppress
-byte compilation warnings about the two obsolete functions `foo'
-and `bar', as well as the function `zot' being called with the
-wrong number of parameters, say
-
-\(with-suppressed-warnings ((obsolete foo bar)
-                           (callargs zot))
-  (foo (bar))
-  (zot 1 2))
-
-The warnings that can be suppressed are a subset of the warnings
-in `byte-compile-warning-types'; see the variable
-`byte-compile-warnings' for a fuller explanation of the warning
-types.  The types that can be suppressed with this macro are
-`free-vars', `callargs', `redefine', `obsolete',
-`interactive-only', `lexical', `mapcar', `constants' and
-`suspicious'.
-
-For the `mapcar' case, only the `mapcar' function can be used in
-the symbol list.  For `suspicious', only `set-buffer' can be used."
-
-  (declare (debug (sexp &optional body)) (indent 1))
-  (if (fboundp 'with-suppressed-warnings)
-      `(with-suppressed-warnings ,warnings ,@body)
-    `(with-no-warnings ,@body)))
-
 ;; New autoload generation function defined only as of Emacs 28
 (defalias 'hload-path--make-directory-autoloads
   (cond ((fboundp 'loaddefs-generate)
@@ -143,7 +109,7 @@ The function does NOT recursively descend into subdirectories of the
 directory or directories specified."
   ;; Don't use a 'let' on this next line or it will fail.
   (setq generated-autoload-file output-file)
-  (hyperb:with-suppressed-warnings ((obsolete update-directory-autoloads))
+  (with-suppressed-warnings ((obsolete update-directory-autoloads))
     (update-directory-autoloads dir)))
 
 ;; Menu items could call this function before Info is loaded.

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Apr-24 at 22:41:13
-;; Last-Mod:     14-Sep-25 at 20:58:17 by Bob Weiner
+;; Last-Mod:      6-Oct-25 at 00:16:42 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1232,7 +1232,7 @@ calling this function."
 	(user-error "(hywiki-add-org-id): Referent buffer <%s> must be in org-mode, not %s"
 		    (buffer-name)
 		    major-mode))
-      (let ((org-id (hyperb:with-suppressed-warnings ((callargs org-id-get))
+      (let ((org-id (with-suppressed-warnings ((callargs org-id-get))
                       (if (>= (action:param-count #'org-id-get) 4)
 			(org-id-get nil nil nil t)
 		      (org-id-get)))))

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:     20-Jun-25 at 20:08:20 by Bob Weiner
+;; Last-Mod:      6-Oct-25 at 00:16:41 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -240,7 +240,7 @@ It provides the following keys:
     ;; We have been converting a buffer from a foreign format to a koutline.
     ;; Now that it is converted, ensure that `kotl-previous-mode' is set to
     ;; koutline.
-    (hyperb:with-suppressed-warnings ((free-vars kotl-previous-mode))
+    (with-suppressed-warnings ((free-vars kotl-previous-mode))
       (setq kotl-previous-mode 'kotl-mode))
     (run-mode-hooks 'kotl-mode-hook)
     (unless (string-prefix-p hyrolo-display-buffer (buffer-name))


### PR DESCRIPTION
# What

Use with-suppressed-warnings.

# Why

Drop hypb:with-suppressed-warnings. Not needed now. Our support of
Emacs starts with Emacs 28 that has with-suppressed-warnings.
