### PR TITLE
Add test for hywiki--maybe-highlight-page-names

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2025-11-06  Mats Lidell  <matsl@gnu.org>
+
+* test/hywiki-tests.el (hywiki-tests--hywiki-face-regions): Helper for
+    verifying generated overlays.
+    (hywiki-tests--maybe-highlight-page-names): Verify
+    overlays created by hywiki-maybe-highlight-page-names.
+
 2025-11-02  Mats Lidell  <matsl@gnu.org>
 
 * test/hywiki-tests.el


### PR DESCRIPTION
# What

Verifies the hywiki-word-face overlays are covering the expected
words. Not less and not more.
