### PR TITLE
Test with unbalanced quote on same line as quoted path

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2025-11-11  Mats Lidell  <matsl@gnu.org>
+
+* test/hpath-tests.el (hpath:path-at-point-finds-path-when-unbalanced-quote-on-same-line):
+    Verify that unbalanced quotes on same line as quoted path does not
+    interfere with finding the path.
+
 2025-11-07  Mats Lidell  <matsl@gnu.org>
 
 * hsys-www.el (eww--dwim-expand-url): Declare function to silence warning.

--- a/test/hpath-tests.el
+++ b/test/hpath-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    28-Feb-21 at 23:26:00
-;; Last-Mod:     18-Oct-25 at 12:43:56 by Bob Weiner
+;; Last-Mod:     11-Nov-25 at 16:27:32 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -125,6 +125,17 @@
     (insert "\"foo:bar:lisp\"")
     (goto-char 7)
     (should (not (hpath:at-p)))))
+
+(ert-deftest hpath:path-at-point-finds-path-when-unbalanced-quote-on-same-line ()
+  "Find path at point finds a path even with unbalanced quotes on same line."
+  :expected-result :failed
+  (dolist (v '(("  \"/tmp\"  ")       ; Reference case: no quotes
+               ("  \"/tmp\" \"")      ; Quote after: Works
+               ("\" \"/tmp\"  ")))    ; Quote before: FAILS
+    (with-temp-buffer
+      (insert (format "%s\n" v))
+      (goto-char 6)
+      (should (string= (hpath:at-p nil t) "/tmp")))))
 
 (ert-deftest hpath:find-exec-shell-cmd-test ()
   "Path prefix ! will run pathname as a non windowed program."


### PR DESCRIPTION
# What

Add test for quoted path on same line as single quote.

# Why

The path should be found but currently a single quote before the path
makes hpath:at-p return nil.

# Note

Test is marked as expected-result failed so it can be merged.
