### PR TITLE
Add test for hpath:delimited-possible-path

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2025-11-16  Mats Lidell  <matsl@gnu.org>
+
+* test/hpath-tests.el (hpath--hpath:delimited-possible-path-in-ls-R):
+    Rename test.
+    (hpath--hpath:delimited-possible-path): Add test using the old name.
+
 2025-11-16  Bob Weiner  <rsw@gnu.org>
 
 * test/hywiki-tests.el (hywiki-tests--hkey-help): Rename to


### PR DESCRIPTION
# What

Add test for hpath:delimited-possible-path

# Why

Since we were working on this today I thought some more coverage would
be good. Seems we only had direct test for ls-R listings before.

# Note

I changed name of the old test to better reflect it is about ls-R
listings and reused the name for the new test.
