### PR TITLE
Activate all checks and mark test case as expected to fail

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2025-11-17  Mats Lidell  <matsl@gnu.org>
 
+* test/hywiki-tests.el (hywiki-tests--maybe-highlight-page-names): Add
+    test cases that fail and mark test as expected-result failed.
+
 * test/hpath-tests.el
     (hpath:path-at-point-with-unbalanced-quote-on-same-line):
     Rename test. Track current behavior.

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -2049,7 +2049,11 @@ face is verified during the change."
         (hywiki-tests--delete-hywiki-dir-and-buffer hywiki-directory)))))
 
 (ert-deftest hywiki-tests--maybe-highlight-page-names ()
-  "Verify `hywiki-maybe-highlight-page-names'."
+  "Verify `hywiki-maybe-highlight-page-names'.
+Start and stop point of all highlighted regions in the buffer, as
+computed by `hywiki-tests--hywiki-face-regions', are compared to the
+expected result."
+  :expected-result :failed
   (hywiki-tests--preserve-hywiki-mode
     (let* ((hywiki-directory (make-temp-file "hywiki_" t))
 	   (wikiword (cdr (hywiki-add-page "WiWo"))))
@@ -2062,11 +2066,10 @@ face is verified during the change."
                          ("WiWo text WiWo" . ((1 . 5) (11 . 15)))
                          ("\"WiWo\"" . ((2 . 6)))
                          ("\"WiWo text\"" . ((2 . 6)))
-                         ;; FIXME: Failing tests below.
-                         ;; ("\"WiWo WiWo\"" . ((2 . 6) (7 . 11)))
-                         ;; ("\"WiWo text WiWo\"" . ((2 . 6) (12 . 16)))
-                         ;; ("\"WiWo WiWo WiWo\"" . ((2 . 6) (7 . 11) (12 . 16)))
-                         ))
+                         ;; Failing tests below.
+                         ("\"WiWo WiWo\"" . ((2 . 6) (7 . 11)))
+                         ("\"WiWo text WiWo\"" . ((2 . 6) (12 . 16)))
+                         ("\"WiWo WiWo WiWo\"" . ((2 . 6) (7 . 11) (12 . 16)))))
               (let ((input (car v))
                     (overlay-regions (cdr v)))
 	        (with-temp-buffer


### PR DESCRIPTION
# What

Activate all checks and mark test case as expected to fail.

# Why

Try to move away from FIXME comments in test cases related to checks
that does not pass and thus indicates a problem. Instead use
expected-result failed to be more transparent about what test that
triggers a bad behavior.
