### PR TITLE
hywiki-word-at - Fix to obey `hywiki-org-link-type-required' setting

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,30 @@
+2025-11-22  Bob Weiner  <rsw@gnu.org>
+
+* test/hywiki-tests.el (hywiki-tests--assist-key-on-hywikiword-displays-help):
+    Fix so always works regardless of where Hyperbole Help window is displayed
+    or whether it is the selected window.
+                       (hywiki-tests--wikiword-identified-with-delimiters): Set
+    'hywiki-org-link-type-required' to nil so WikiWords are recognized in Org
+    links without the hy: prefix.
+
+* hywiki.el (hywiki-word-at): Fix to respect the 'hywiki-org-link-type-required'
+    setting and ignore HyWikiWord Org links without a 'hy:' prefix when that
+    variable is non-nil.
+  test/hsys-org-tests.el (hsys-org:org-link-at-p): Avoid failure by forcing
+    the setting of 'hywiki-org-link-type-required' to t.
+
+* hywiki.el (hywiki-debuttonize-non-character-commands): Elaborate contexts
+    where this hook function fires.  Rename to 'hywiki-word-store-around-point'.
+            (hywiki-buttonize-non-character-commands): Rename to
+    'hywiki-word-highlight-post-command'.
+            (hywiki-buttonize-character-commands): Rename to
+    'hywiki-word-highlight-post-self-insert'.
+            (hywiki--buttonize-characters): Remove, not used.
+
+* hyrolo.el (hyrolo-logical-regexp): Add so regexp can be reused and anchor
+    to start of the search string.  Use in 'hyrolo-fgrep' and
+    'hyrolo-fgrep-logical'.
+
 2025-11-18  Mats Lidell  <matsl@gnu.org>
 
 * test/hmouse-drv-tests.el (hbut-find-exec-shell-cmd-test)
@@ -1746,7 +1773,7 @@
 2025-03-23  Mats Lidell  <matsl@gnu.org>
 
 * test/hywiki-tests.el (hywiki-tests--run-test-case): Run DSL for testing
-    Hywiki words.
+    HywikiWords.
     (hywiki-tests--lorem-ipsum): Surrounding test text.
     (hywiki-tests--verify-hywiki-word): DSL verification helper.
     (hywiki-tests--wikiword-step-check-verification)
@@ -2619,7 +2646,7 @@ value to be [[WikiWord]] not [[file:WikiWord.org][WikiWord]].
 
 * test/hywiki-tests.el (hywiki-tests--a-wikiword-in-hywiki-directory)
     (hywiki-tests--wikiword-identified-with-delimiters): Add tests for
-    hywiki words with delimiters.
+    HyWikiWords with delimiters.
 
 2024-12-23  Bob Weiner  <rsw@gnu.org>
 
@@ -3823,8 +3850,6 @@ value to be [[WikiWord]] not [[file:WikiWord.org][WikiWord]].
 * hywiki.el (hywiki--range): Add to hold (start . end) range values.
             (hywiki-word-at): If word is already highlighted with
     'hywiki-word-face', use that as a shortcut to get the word.
-            (hywiki-buttonize-word): Add.
-	    (hywiki-maybe-highlight-page-name): Rewrite to use above function.
 
 2024-07-12  Mats Lidell  <matsl@gnu.org>
 
@@ -4252,7 +4277,7 @@ value to be [[WikiWord]] not [[file:WikiWord.org][WikiWord]].
             (hywiki-mode): Change all defcustom groups in this library to
     'hyperbole-wiki.
 	    (hywiki-excluded-major-modes): Add to exclude major modes and their
-    descendents from highlighting and activation of HyWiki words.  Default is nil.
+    descendents from highlighting and activation of HyWikiWords.  Default is nil.
             (hywiki-active-in-current-buffer-p): Add and use in 'hywiki' ibtype.
 	    (hywiki-in-page-p): Add and use where buffer's file is tested against
     'hywiki-directory'.
@@ -4320,7 +4345,7 @@ value to be [[WikiWord]] not [[file:WikiWord.org][WikiWord]].
     call of 'hywiki-buttonize'.
             (hywiki-remap-buttonize-characters, hywiki-initialize-mode-map):
     Remove these and move keymap init into 'hywiki-mode' definition.
-            (hywiki-buttonize): Rewrite to highlight hywiki word to the left of
+            (hywiki-buttonize): Rewrite to highlight HyWikiWord to the left of
     point iff last inserted char is in the set of 'hywiki--buttonize-characters'.
     Rename to 'hywiki-buttonize-character-commands'.
            (hywiki-buttonize-non-character-commands): Add.
@@ -4377,7 +4402,7 @@ value to be [[WikiWord]] not [[file:WikiWord.org][WikiWord]].
             (hywiki-remap-org-insertion-punctuation-keys): Rename to
     'hywiki-remap-buttonize-characters'.
             (hywiki--buttonize-characters): Add as a computed string of single
-    characters that each trigger prior hywiki word highlighting when it is enabled.
+    characters that each trigger prior HyWikiWord highlighting when it is enabled.
             (hywiki-highlight-page-name, hywiki-highlight-page-names): Don't skip
      back over symbol chars.
             (hywiki-find-page): Use this function as the 'find-file-hook' instead
@@ -4469,7 +4494,7 @@ value to be [[WikiWord]] not [[file:WikiWord.org][WikiWord]].
              (hywiki-get-page-files): Add missing '+' for multiple chars in file suffix.
              (hywiki-at-wikiword, hywiki-highlight-page-names): Allow for numerics
     in #section references.
-             (hywiki--word-face): Change foreground of HyWiki word to 'orange'
+             (hywiki--word-face): Change foreground of HyWikiWord to 'orange'
     when on a dark background.
 
 2024-04-22  Bob Weiner  <rsw@gnu.org>
@@ -4477,7 +4502,7 @@ value to be [[WikiWord]] not [[file:WikiWord.org][WikiWord]].
 * hywiki.el: Add new auto-wikiword note-taking system with `hywiki' ibtype.
   hasht.el: Temporarily add this for hywiki hash table support.
   hibtypes.el (load "hywiki"): Add at lowest ibtype priority.
-  hsys-org.el (hsys-org-link-at-p): Support HyWiki word handling.
+  hsys-org.el (hsys-org-link-at-p): Support HyWikiWord handling.
   Makefile (EL_COMPILE):
   MANIFEST: Add hywiki.el and hasht.el.
 

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:      9-Nov-25 at 13:52:10 by Bob Weiner
+;; Last-Mod:     22-Nov-25 at 12:40:34 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -108,6 +108,7 @@
 ;;; Creates and displays personal wiki pages and sections with auto-wikiword links
 ;;; ========================================================================
 
+;; Defines `hywiki-word' ibtype
 (load "hywiki" nil t)
 
 ;;; ========================================================================

--- a/hsys-org.el
+++ b/hsys-org.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Jul-16 at 14:54:14
-;; Last-Mod:     30-Aug-25 at 23:19:35 by Bob Weiner
+;; Last-Mod:     22-Nov-25 at 12:07:13 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -510,10 +510,12 @@ Start and end are the buffer positions of the label of the link.  This
 is either the optional description or if none, then the referent, i.e.
 either [[referent][description]] or [[referent]].
 
-Ignore [[hy:HyWiki]] buttons and return nil (handle these as
-implicit buttons).  Assume caller has already checked that the
-current buffer is in `org-mode' or is looking for an Org link in
-a non-Org buffer type."
+If point is on a HyWikiWord within an Org link and HyWikiWords are
+recognized in the current buffer, ignore the Org link and return nil
+(handle these elsewhere as implicit buttons).
+
+Assume caller has already checked that the current buffer is in
+`org-mode' or is looking for an Org link in a non-Org buffer type."
   (unless (or (smart-eolp) (smart-eobp))
     (let (label-start-end)
       (if (derived-mode-p 'org-mode)
@@ -521,15 +523,15 @@ a non-Org buffer type."
 	  (when (org-element-property :raw-link (org-element-context))
 	    ;; At an Org link
 	    (save-match-data
-	      ;; If this Org link matches a potential HyWiki word, ignore it.
+	      ;; If this Org link matches a potential HyWikiWord, ignore it.
 	      (when (and (not (and (fboundp 'hywiki-word-at) (hywiki-word-at)))
 			 (setq label-start-end (hsys-org-link-label-start-end)))
 		(cons (nth 1 label-start-end) (nth 2 label-start-end)))))
-	;; non-Org mode (can't call org-element (which
+	;; Non-Org mode (can't call org-element (which
 	;; hsys-org-thing-at-p calls) outside of Org mode.
-	;; Check if point is inside a link
+	;; Check if point is inside a link.
 	(save-match-data
-	  ;; If any Org link matches a potential HyWiki word, ignore it.
+	  ;; If any Org link matches a potential HyWikiWord, ignore it.
 	  (when (and (not (and (fboundp 'hywiki-word-at) (hywiki-word-at)))
 		     (setq label-start-end (hargs:delimited "[[" "]]" nil nil t)))
 	    (let* ((start (nth 1 label-start-end))

--- a/hyrolo-logic.el
+++ b/hyrolo-logic.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    13-Jun-89 at 22:57:33
-;; Last-Mod:     21-Jun-25 at 22:20:28 by Bob Weiner
+;; Last-Mod:     22-Nov-25 at 07:56:55 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -75,8 +75,8 @@
 ;;; ************************************************************************
 
 ;;;###autoload
-(defun hyrolo-fgrep-logical (expr &optional count-only include-sub-entries no-sub-entries-out
-				  koutline-flag)
+(defun hyrolo-fgrep-logical (expr &optional count-only include-sub-entries
+                             no-sub-entries-out koutline-flag)
   "Display rolo entries matching EXPR.
 EXPR is a string that may contain sexpression logical prefix operators.
 If optional COUNT-ONLY is non-nil, don't display entries, return
@@ -111,16 +111,16 @@ Double quotes may be used to group multiple words as a single argument."
 			      (read expr) count-only include-sub-entries
 			      no-sub-entries-out t))
 	   (setq total-matches (eval (read expr))))
-	  ((string-match-p "\(\\(r-\\)?\\(and\\|or\\|xor\\|not\\)\\>" expr)
-	   (setq expr (replace-regexp-in-string "\(or " "\(| " expr nil t))
-	   (setq expr (replace-regexp-in-string "\(xor " "\(@ " expr nil t))
-	   (setq expr (replace-regexp-in-string "\(not " "\(! " expr nil t))
-	   (setq expr (replace-regexp-in-string "\(and " "\(& " expr nil t))
+	  ((string-match-p hyrolo-logical-regexp expr)
+	   (setq expr (replace-regexp-in-string "(or " "(| " expr nil t))
+	   (setq expr (replace-regexp-in-string "(xor " "(@ " expr nil t))
+	   (setq expr (replace-regexp-in-string "(not " "(! " expr nil t))
+	   (setq expr (replace-regexp-in-string "(and " "(& " expr nil t))
 
-	   (setq expr (replace-regexp-in-string "\(r-or " "\(r-| " expr nil t))
-	   (setq expr (replace-regexp-in-string "\(r-xor " "\(r-@ " expr nil t))
-	   (setq expr (replace-regexp-in-string "\(r-not " "\(r-! " expr nil t))
-	   (setq expr (replace-regexp-in-string "\(r-and " "\(r-& " expr nil t))
+	   (setq expr (replace-regexp-in-string "(r-or " "(r-| " expr nil t))
+	   (setq expr (replace-regexp-in-string "(r-xor " "(r-@ " expr nil t))
+	   (setq expr (replace-regexp-in-string "(r-not " "(r-! " expr nil t))
+	   (setq expr (replace-regexp-in-string "(r-and " "(r-& " expr nil t))
 
 	   (setq expr (replace-regexp-in-string
 		       "\"\\([^\"]*\\)\"" "{\\1}" expr nil nil))
@@ -134,15 +134,15 @@ Double quotes may be used to group multiple words as a single argument."
 	       (setq saved-expr expr)))
 	   (setq expr (replace-regexp-in-string
 		       "{\\([^{}]+\\)}" "\"\\1\"" expr nil nil))
-	   (setq expr (replace-regexp-in-string "\(| " "\(hyrolo-or start end  " expr nil t))
-	   (setq expr (replace-regexp-in-string "\(@ " "\(hyrolo-xor start end " expr nil t))
-	   (setq expr (replace-regexp-in-string "\(! " "\(hyrolo-not start end " expr nil t))
-	   (setq expr (replace-regexp-in-string "\(& " "\(hyrolo-and start end " expr nil t))
+	   (setq expr (replace-regexp-in-string "(| " "(hyrolo-or start end  " expr nil t))
+	   (setq expr (replace-regexp-in-string "(@ " "(hyrolo-xor start end " expr nil t))
+	   (setq expr (replace-regexp-in-string "(! " "(hyrolo-not start end " expr nil t))
+	   (setq expr (replace-regexp-in-string "(& " "(hyrolo-and start end " expr nil t))
 
-	   (setq expr (replace-regexp-in-string "\(r-| " "\(hyrolo-r-or start end  " expr nil t))
-	   (setq expr (replace-regexp-in-string "\(r-@ " "\(hyrolo-r-xor start end " expr nil t))
-	   (setq expr (replace-regexp-in-string "\(r-! " "\(hyrolo-r-not start end " expr nil t))
-	   (setq expr (replace-regexp-in-string "\(r-& " "\(hyrolo-r-and start end " expr nil t))
+	   (setq expr (replace-regexp-in-string "(r-| " "(hyrolo-r-or start end  " expr nil t))
+	   (setq expr (replace-regexp-in-string "(r-@ " "(hyrolo-r-xor start end " expr nil t))
+	   (setq expr (replace-regexp-in-string "(r-! " "(hyrolo-r-not start end " expr nil t))
+	   (setq expr (replace-regexp-in-string "(r-& " "(hyrolo-r-and start end " expr nil t))
 
 	   (setq expr (format "(hyrolo-logic (quote %S) nil %s %s %s %s)"
 			      (read expr) count-only include-sub-entries

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Jun-89 at 22:08:29
-;; Last-Mod:      9-Nov-25 at 13:31:08 by Bob Weiner
+;; Last-Mod:     22-Nov-25 at 07:54:28 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -138,6 +138,10 @@
 ;;; ************************************************************************
 ;;; Public variables
 ;;; ************************************************************************
+
+(defvar hyrolo-logical-regexp
+  "\\`(\\(r-\\)?\\(and\\|or\\|xor\\|not\\)\\>"
+  "Regexp matching the beginning of a HyRolo logical search string.")
 
 (defvar hyrolo-boolean-only-flag nil
   "Set to prevent HyRolo from displaying an error buffer when running tests.
@@ -744,7 +748,7 @@ on the logical sexpression matching."
 			       (cadr input-and-matching-files)))))
   (setq string (string-trim string "\"" "\""))
   (let ((total-matches 0))
-    (if (string-match-p "\(\\(r-\\)?\\(and\\|or\\|xor\\|not\\)\\>" string)
+    (if (string-match-p hyrolo-logical-regexp string)
 	(progn
 	  ;; Search string contains embedded logic operators.
 	  ;; First try to match logical sexpression within a single

--- a/hywiki/HyWiki.org
+++ b/hywiki/HyWiki.org
@@ -44,7 +44,7 @@ buffer by surrounding them with double square brackets and the
 prefix, e.g. [[MyWikiWord]]; existing HyWiki page names then will
 override Org's standard handling of such links.  To prevent Org
 mode's binding of {M-RET} from splitting lines and creating new
-headlines when on a HyWiki word whose page has not yet been
+headlines when on a HyWikiWord whose page has not yet been
 created, set `hsys-org-enable-smart-keys' to `t' so that
 Hyperbole's Action Key does the right thing in this context.
 

--- a/man/hyperbole.texi
+++ b/man/hyperbole.texi
@@ -7,7 +7,7 @@
 @c Author:       Bob Weiner
 @c
 @c Orig-Date:     6-Nov-91 at 11:18:03
-@c Last-Mod:     29-Aug-25 at 03:42:13 by Bob Weiner
+@c Last-Mod:     22-Nov-25 at 10:36:49 by Bob Weiner
 
 @c %**start of header (This is for running Texinfo on a region.)
 @setfilename hyperbole.info
@@ -2527,7 +2527,7 @@ minibuffer or the other window.
 @cindex hywiki existing word
 @anchor{hywiki-existing-word}
 @item hywiki-existing-word
-When on a HyWiki word with an existing page, display its page and
+When on a HyWikiWord with an existing page, display its page and
 optional section.
 
 @findex ibtypes action
@@ -3104,7 +3104,7 @@ source reference line again.
 @cindex hywiki word
 @anchor{hywiki-word}
 @item hywiki-word
-When on a HyWiki word, display its page and optional section.  If the
+When on a HyWikiWord, display its page and optional section.  If the
 associated HyWiki page does not exist, create it automatically.
 
 @findex ibtypes hynote-file

--- a/test/hsys-org-tests.el
+++ b/test/hsys-org-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    23-Apr-21 at 20:55:00
-;; Last-Mod:     15-Sep-25 at 20:07:53 by Mats Lidell
+;; Last-Mod:     22-Nov-25 at 12:07:27 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -66,28 +66,29 @@
 (ert-deftest hsys-org:org-link-at-p ()
   "Should be t if point is within an org-link."
   (with-temp-buffer
-    ;; Org-mode
-    (org-mode)
-    (insert "[[Link]]\n\n")
-    (ert-info ("Within an org link")
+    (let ((hywiki-org-link-type-required t))
+      ;; Org-mode
+      (org-mode)
+      (insert "[[Link]]\n\n")
+      (ert-info ("Within an org link")
+	(goto-char 3)
+	(should (hsys-org-link-at-p)))
+      (ert-info ("At end of line")
+	(end-of-line)
+	(should-not (hsys-org-link-at-p)))
+      (ert-info ("At end of buffer")
+	(end-of-buffer)
+	(should-not (hsys-org-link-at-p)))
+      ;; Out side of org-mode
+      (erase-buffer)
+      (fundamental-mode)
+      (insert "[[hy:HyWiki]]\n\n")
       (goto-char 3)
-      (should (hsys-org-link-at-p)))
-    (ert-info ("At end of line")
-      (end-of-line)
-      (should-not (hsys-org-link-at-p)))
-    (ert-info ("At end of buffer")
-      (end-of-buffer)
-      (should-not (hsys-org-link-at-p)))
-    ;; Out side of org-mode
-    (erase-buffer)
-    (fundamental-mode)
-    (insert "[[hy:HyWiki]]\n\n")
-    (goto-char 3)
-    (ert-info ("Accept link if unknown HyWiki button")
-      (should (hsys-org-link-at-p)))
-    (ert-info ("Ignore link if known HyWiki button")
-      (mocklet (((hywiki-word-at) => t))
-        (should-not (hsys-org-link-at-p))))))
+      (ert-info ("Accept link if unknown HyWiki button")
+	(should (hsys-org-link-at-p)))
+      (ert-info ("Ignore link if known HyWiki button")
+	(mocklet (((hywiki-word-at) => t))
+          (should-not (hsys-org-link-at-p)))))))
 
 (ert-deftest hsys-org:org-target-at-p ()
   "Should be non nil if point is within an org-radio-target."

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    18-May-24 at 23:59:48
-;; Last-Mod:     16-Nov-25 at 11:09:20 by Bob Weiner
+;; Last-Mod:     22-Nov-25 at 13:35:42 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -323,8 +323,10 @@ This is for simulating the command loop."
             (should (string= "WikiWord" (hywiki-word-at)))
             (delete-other-windows)
             (assist-key)
-            (other-window 1)
-            (should (string-prefix-p "*Help: Hyperbole " (buffer-name))))
+            (should (get-window-with-predicate
+		     (lambda (win) (string-prefix-p "*Help: Hyperbole "
+						    (buffer-name
+						     (window-buffer win)))))))
         (hywiki-tests--delete-hywiki-dir-and-buffer hywiki-directory)))))
 
 (ert-deftest hywiki-tests--action-key-on-wikiword-displays-page ()
@@ -441,6 +443,7 @@ line 2
   "Verify WikiWord is identified when surrounded by delimiters."
   (hywiki-tests--preserve-hywiki-mode
     (let ((hsys-org-enable-smart-keys t)
+	  (hywiki-org-link-type-required nil)
           (hywiki-directory (make-temp-file "hywiki" t)))
       (unwind-protect
           (progn
@@ -496,8 +499,8 @@ line 2
               (font-lock-ensure)
               (should (hsys-org-face-at-p 'org-link))
               (if (string= "WikiWord" (hywiki-word-at))
-		  (should-not v)
-		(should t)))))
+		  (should v)
+		(should-not v)))))
       (hywiki-mode 0)
       (hywiki-tests--delete-hywiki-dir-and-buffer hywiki-directory)))))
 
@@ -1958,7 +1961,7 @@ face is verified during the change."
         (hywiki-tests--delete-hywiki-dir-and-buffer hywiki-directory)))))
 
 (ert-deftest hywiki-tests--verify-removal-of-delimiter-updates-face ()
-  "Verify removing a delimiter the face is changed along with the WikiWord."
+  "Verify WikiWord highlight face change when adding/removing a delimiter."
   :expected-result :failed
   (hywiki-tests--preserve-hywiki-mode
     (let* ((hywiki-directory (make-temp-file "hywiki" t))


### PR DESCRIPTION
hywiki-tests--assist-key-on-hywikiword-displays-help - Fix.

hywiki-tests--wikiword-identified-with-delimiters - Handle
 'hywiki-org-link-type-required'.

hsys-org:org-link-at-p - Handle 'hywiki-org-link-type-required'.

Rename HyWiki hook functions.