### PR TITLE
hpath:absolute-to - Rewrite to fix when given multiple 'default-dirs'

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2025-12-06  Bob Weiner  <rsw@gnu.org>
+
+* hpath.el (hpath:absolute-to): Rewrite to fix when given multiple 'default-dirs'
+    to test until find the first one that expands to an existing file before
+    dropping out of the loop.
+           (hpath:call): Fix so when 'path' exists (may have already been expanded),
+    it is used rather than the 'expanded-path' variable.
+  test/hpath-tests.el (hpath--absolute-to): Enable this test; fixed by above changes.
+           (hpath:call): Fix one case where 'mode-prefix' was not prepended.
+
 2025-11-30  Mats Lidell  <matsl@gnu.org>
 
 * hpath.el (hpath:find-file-mailcap): Remove unused.

--- a/test/hpath-tests.el
+++ b/test/hpath-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    28-Feb-21 at 23:26:00
-;; Last-Mod:      2-Dec-25 at 12:46:06 by Mats Lidell
+;; Last-Mod:      6-Dec-25 at 22:34:32 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -337,7 +337,6 @@
 
 (ert-deftest hpath--absolute-to ()
   "Verify `hpath:absolute-to'."
-  :expected-result :failed
   ;; Not valid path return unchanged
   (should-not (hpath:absolute-to nil))
   (should (= (hpath:absolute-to 1) 1))


### PR DESCRIPTION
- hpath:call - Fix so when 'path' exists (may have already been expanded), it is used rather than the 'expanded-path' variable.

- hpath:call - Fix one case where 'mode-prefix' was not prepended.