### PR TITLE
Use shorthand for set: to move to hyperbole-set

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,27 @@
+2025-12-21  Mats Lidell  <matsl@gnu.org>
+
+* test/hywiki-tests.el:
+  test/hypb-tests.el:
+  kotl/kotl-mode.el:
+  hyrolo.el:
+  hyperbole.el:
+  hycontrol.el:
+  hvar.el:
+  hui.el:
+  hui-mini.el:
+  hsys-org.el:
+  hibtypes.el:
+  hbut.el:
+  hargs.el:
+  hact.el: Use shorthand for set:
+
+* test/hyperbole-set-tests.el: Rename set-test.el.
+
+* Makefile (EL_COMPILE): Rename set.el to hyperbole-set.el
+
+* hyperbole-set.el: Rename set.el.
+    Use shorthand set: for hyperbole-set- for proper prefixing.
+
 2025-12-13  Bob Weiner  <rsw@gnu.org>
 
 * MANIFEST: Add "HY-TALK/HYPERBOLEQA.kotl" from EmacsConf2025 talk.

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:     11-Dec-25 at 09:51:43 by Mats Lidell
+# Last-Mod:     21-Dec-25 at 16:20:56 by Mats Lidell
 #
 # Copyright (C) 1994-2025  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -221,7 +221,7 @@ EL_COMPILE = hact.el hactypes.el hargs.el hbdata.el hbmap.el hbut.el \
 	     hycontrol.el hui-jmenu.el hui-menu.el hui-mini.el hui-mouse.el hui-select.el \
 	     hui-treemacs.el hui-window.el hui.el hvar.el hversion.el hynote.el hypb.el hyperbole.el \
 	     hyrolo-demo.el hyrolo-logic.el hyrolo-menu.el hyrolo.el hywconfig.el hywiki.el \
-             hasht.el set.el hypb-ert.el hui-dired-sidebar.el hypb-maintenance.el \
+             hasht.el hyperbole-set.el hypb-ert.el hui-dired-sidebar.el hypb-maintenance.el \
              hui-register.el
 
 EL_SRC = $(EL_COMPILE)

--- a/hact.el
+++ b/hact.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:     29-Aug-25 at 14:20:04 by Bob Weiner
+;; Last-Mod:     21-Dec-25 at 16:31:58 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -19,7 +19,7 @@
 ;;; Other required Elisp libraries
 ;;; ************************************************************************
 
-(eval-and-compile (mapc #'require '(hhist set)))
+(eval-and-compile (mapc #'require '(hhist hyperbole-set)))
 
 ;;; ************************************************************************
 ;;; Public declarations
@@ -595,5 +595,9 @@ calling form."
   (action:param-list (actype:action actype)))
 
 (provide 'hact)
+
+;; Local Variables:
+;; read-symbol-shorthands: (("set:" . "hyperbole-set-"))
+;; End:
 
 ;;; hact.el ends here

--- a/hargs.el
+++ b/hargs.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    31-Oct-91 at 23:17:35
-;; Last-Mod:     27-Aug-25 at 23:10:25 by Bob Weiner
+;; Last-Mod:     21-Dec-25 at 17:04:52 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -31,8 +31,7 @@
 (require 'etags)                        ; For `find-tag--default'
 (require 'hpath)
 (require 'hypb)
-;; Avoid any potential library name conflict by giving the load directory.
-(require 'set (expand-file-name "set" hyperb:dir))
+(require 'hyperbole-set)
 (require 'info)
 (require 'hmouse-drv) ;; loads hui-mouse and hmouse-key
 
@@ -1084,5 +1083,9 @@ Hyperbole menu item help when appropriate."
 	  (select-window owind))))))
 
 (provide 'hargs)
+
+;; Local Variables:
+;; read-symbol-shorthands: (("set:" . "hyperbole-set-"))
+;; End:
 
 ;;; hargs.el ends here

--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:      7-Dec-25 at 19:24:08 by Bob Weiner
+;; Last-Mod:     21-Dec-25 at 16:40:32 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -3277,4 +3277,9 @@ Return TYPE's symbol if it existed, else nil."
     (and elisp-sym (funcall elisp-sym) t)))
 
 (provide 'hbut)
+
+;; Local Variables:
+;; read-symbol-shorthands: (("set:" . "hyperbole-set-"))
+;; End:
+
 ;;; hbut.el ends here

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:     22-Nov-25 at 12:40:34 by Bob Weiner
+;; Last-Mod:     21-Dec-25 at 16:50:23 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -78,7 +78,7 @@
 (declare-function markdown-reference-goto-link "ext:markdown")
 (declare-function markdown-wiki-link-p "ext:markdown")
 (declare-function org-roam-id-find "ext:org-roam")
-(declare-function set:member "set")
+(declare-function set:member "hyperbole-set")
 (declare-function symset:add "hact")
 (declare-function symtable:add "hact")
 
@@ -1774,5 +1774,9 @@ version of the conflict."
 
 (run-hooks 'hibtypes-end-load-hook)
 (provide 'hibtypes)
+
+;; Local Variables:
+;; read-symbol-shorthands: (("set:" . "hyperbole-set-"))
+;; End:
 
 ;;; hibtypes.el ends here

--- a/hsys-org.el
+++ b/hsys-org.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Jul-16 at 14:54:14
-;; Last-Mod:     22-Nov-25 at 12:07:13 by Bob Weiner
+;; Last-Mod:     21-Dec-25 at 16:39:18 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -41,8 +41,7 @@
 (require 'org-macs)
 (require 'package)
 (require 'warnings)
-;; Avoid any potential library name conflict by giving the load directory.
-(require 'set (expand-file-name "set" hyperb:dir))
+(require 'hyperbole-set)
 
 ;;; ************************************************************************
 ;;; Public declarations
@@ -780,5 +779,9 @@ This must be called before Org mode is loaded."
   (custom-set-variables '(org-fold-core-style 'overlays)))
 
 (provide 'hsys-org)
+
+;; Local Variables:
+;; read-symbol-shorthands: (("set:" . "hyperbole-set-"))
+;; End:
 
 ;;; hsys-org.el ends here

--- a/hui-mini.el
+++ b/hui-mini.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Oct-91 at 20:13:17
-;; Last-Mod:     30-Nov-25 at 17:51:11 by Bob Weiner
+;; Last-Mod:     21-Dec-25 at 16:40:53 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1209,5 +1209,9 @@ support underlined faces as well."
 (hyperbole-minibuffer-menu)
 
 (provide 'hui-mini)
+
+;; Local Variables:
+;; read-symbol-shorthands: (("set:" . "hyperbole-set-"))
+;; End:
 
 ;;; hui-mini.el ends here

--- a/hui.el
+++ b/hui.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 21:42:03
-;; Last-Mod:     23-Nov-25 at 12:44:22 by Bob Weiner
+;; Last-Mod:     21-Dec-25 at 17:06:17 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -22,8 +22,7 @@
 (require 'cl-macs)  ;; For `cl-do*'
 (require 'hversion)
 (require 'hargs)
-;; Avoid any potential library name conflict by giving the load directory.
-(require 'set (expand-file-name "set" hyperb:dir))
+(require 'hyperbole-set)
 (require 'hmail)
 (require 'hbut)
 (eval-when-compile (require 'hactypes))

--- a/hvar.el
+++ b/hvar.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Oct-91 at 14:00:24
-;; Last-Mod:     29-Sep-25 at 20:23:23 by Mats Lidell
+;; Last-Mod:     21-Dec-25 at 16:34:52 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -19,7 +19,7 @@
 ;;; Other required Elisp libraries
 ;;; ************************************************************************
 
-(require 'set)
+(require 'hyperbole-set)
 
 ;;; ************************************************************************
 ;;; Forward declarations
@@ -117,5 +117,9 @@ existed before the change was made."
 ;; `hsettings' and `hvar' have a cyclic dependency; require this after providing 'hvar
 ;; to avoid an infinite loop.
 (require 'hsettings)
+
+;; Local Variables:
+;; read-symbol-shorthands: (("set:" . "hyperbole-set-"))
+;; End:
 
 ;;; hvar.el ends here

--- a/hycontrol.el
+++ b/hycontrol.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Jun-16 at 15:35:36
-;; Last-Mod:     26-Oct-25 at 16:04:51 by Bob Weiner
+;; Last-Mod:     21-Dec-25 at 16:33:46 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -118,8 +118,7 @@
 (require 'cl-lib)
 (require 'hhist)     ; To store frame-config when hycontrol-windows-grid is used
 (require 'hypb)
-;; Avoid any potential library name conflict by giving the load directory.
-(require 'set (expand-file-name "set" hyperb:dir))
+(require 'hyperbole-set)
 (eval-and-compile
   ;; Get from: https://github.com/emacsmirror/framemove/blob/master/framemove.el
   (require 'framemove nil t)
@@ -2170,5 +2169,9 @@ documentation for more information."
 	     (hycontrol-help-key-description))))
 
 (provide 'hycontrol)
+
+;; Local Variables:
+;; read-symbol-shorthands: (("set:" . "hyperbole-set-"))
+;; End:
 
 ;;; hycontrol.el ends here

--- a/hyperbole-set.el
+++ b/hyperbole-set.el
@@ -1,9 +1,9 @@
-;;; set.el --- General mathematical operators for unordered sets  -*- lexical-binding: t; -*-
+;;; hyperbole-set.el --- General mathematical operators for unordered sets  -*- lexical-binding: t; -*-
 ;;
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    26-Sep-91 at 19:24:19
-;; Last-Mod:     18-Feb-24 at 12:51:49 by Mats Lidell
+;; Last-Mod:     21-Dec-25 at 16:25:30 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -220,6 +220,10 @@ Uses `set:equal-op' for comparison."
 ;; Private variables
 ;; ************************************************************************
 
-(provide 'set)
+(provide 'hyperbole-set)
 
-;;; set.el ends here
+;; Local Variables:
+;; read-symbol-shorthands: (("set:" . "hyperbole-set-"))
+;; End:
+
+;;; hyperbole-set.el ends here

--- a/hyperbole.el
+++ b/hyperbole.el
@@ -9,7 +9,7 @@
 ;; Maintainer:   Robert Weiner <rsw@gnu.org>
 ;; Maintainers:  Robert Weiner <rsw@gnu.org>, Mats Lidell <matsl@gnu.org>
 ;; Created:      06-Oct-92 at 11:52:51
-;; Last-Mod:      2-Oct-25 at 14:28:52 by Mats Lidell
+;; Last-Mod:     21-Dec-25 at 17:07:35 by Mats Lidell
 ;; Released:     10-Mar-24
 ;; Version:      9.0.2pre
 ;; Keywords:     comm, convenience, files, frames, hypermedia, languages, mail, matching, mouse, multimedia, outlines, tools, wp
@@ -176,8 +176,7 @@ Info documentation at \"(hyperbole)Top\".
 ;;; ************************************************************************
 
 (require 'hload-path)
-;; Avoid any potential library name conflict by giving the load directory.
-(require 'set (expand-file-name "set" hyperb:dir))
+(require 'hyperbole-set)
 (require 'hypb)
 (require 'hui-select)  ;; This requires 'hvar which defines the var:append function.
 

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Jun-89 at 22:08:29
-;; Last-Mod:     22-Nov-25 at 07:54:28 by Bob Weiner
+;; Last-Mod:     21-Dec-25 at 16:29:26 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -42,8 +42,7 @@
 (require 'outline)
 (require 'package)
 (require 'reveal)
-;; Avoid any potential library name conflict by giving the load directory.
-(require 'set (expand-file-name "set" hyperb:dir))
+(require 'hyperbole-set)
 (require 'sort)
 (require 'xml)
 (declare-function kotl-mode:to-valid-position "kotl/kotl-mode")

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:      6-Oct-25 at 00:16:41 by Mats Lidell
+;; Last-Mod:     21-Dec-25 at 16:36:33 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -4012,5 +4012,9 @@ See `delete-selection-helper'."
 	(delete-selection-helper deletion-type)))))
 
 (provide 'kotl-mode)
+
+;; Local Variables:
+;; read-symbol-shorthands: (("set:" . "hyperbole-set-"))
+;; End:
 
 ;;; kotl-mode.el ends here

--- a/test/hypb-tests.el
+++ b/test/hypb-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:     5-Apr-21 at 18:53:10
-;; Last-Mod:     14-Sep-25 at 15:53:43 by Mats Lidell
+;; Last-Mod:     21-Dec-25 at 16:45:43 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -155,6 +155,7 @@ See Emacs bug#74042 related to usage of texi2any."
 ;; the use of the `with-mock' macro), which is not a dependency of Hyperbole.
 ;;  Local Variables:
 ;;  no-byte-compile: t
+;;  read-symbol-shorthands: (("set:" . "hyperbole-set-"))
 ;;  End:
 
 (provide 'hypb-tests)

--- a/test/hyperbole-set-tests.el
+++ b/test/hyperbole-set-tests.el
@@ -1,9 +1,9 @@
-;;; set-tests.el --- Hyperbole mathematical set library tests          -*- lexical-binding: t; -*-
+;;; hyperbole-set-tests.el --- Hyperbole mathematical set library tests          -*- lexical-binding: t; -*-
 ;;
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:     5-Feb-23 at 09:12:52
-;; Last-Mod:     29-May-24 at 00:56:52 by Bob Weiner
+;; Last-Mod:     21-Dec-25 at 17:10:33 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -17,7 +17,7 @@
 ;;; Code:
 
 ;; Avoid any potential library name conflict by giving the load directory.
-(require 'set (expand-file-name "set" hyperb:dir))
+(require 'hyperbole-set)
 
 (ert-deftest set-tests--function-tests-equal ()
   "Test Hyperbole set library functions."
@@ -145,6 +145,10 @@
     (should (= (set:size (set:create 'a 'b)) 1))
     (should (= (set:size (set:union (set:create 'a) (set:create 'b))) 1))
     (should (set:equal (set:union (set:create 'a) (set:create 'b)) (set:create 'a)))))
+
+;; Local Variables:
+;; read-symbol-shorthands: (("set:" . "hyperbole-set-"))
+;; End:
 
 (provide 'set-tests)
 ;;; set-tests.el ends here

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    18-May-24 at 23:59:48
-;; Last-Mod:     22-Nov-25 at 13:35:42 by Bob Weiner
+;; Last-Mod:     21-Dec-25 at 16:46:43 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -2196,6 +2196,7 @@ expected result."
 ;;
 ;; Local Variables:
 ;; no-byte-compile: t
+;; read-symbol-shorthands: (("set:" . "hyperbole-set-"))
 ;; End:
 
 ;;; hywiki-tests.el ends here


### PR DESCRIPTION
# What

Use shorthand for set: to move to hypebole-set.

# Why

Experimenting with using shorthands to see if that can help in
transforming code base into using proper naming for files and symbols.
