### PR TITLE
Add an info message link for unsupported referent types

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2025-12-24  Mats Lidell  <matsl@gnu.org>
+
+* hywiki.el (hywiki-reference-to-org-link): Refactor to handle pathname
+    and referent in separate functions.
+    (hywiki--pathname-reference-to-org-link): Original function for
+    pathname links.
+    (hywiki--referent-reference-to-org-link): Creates an info message link
+    that export of the referent type is not supported.
+    (hypb-msg): org-link-type for message links.
+
 2025-12-13  Bob Weiner  <rsw@gnu.org>
 
 * MANIFEST: Add "HY-TALK/HYPERBOLEQA.kotl" from EmacsConf2025 talk.


### PR DESCRIPTION
# What

Add an info message link for unsupported referent types.

# Why

When types of links that we can't export to HTML are present an info
message link is inserted instead to tell reader why.

When hovering over the referent WikiWord (WikiPersonalFile) this message in the black box is shown. 

![Hover](https://github.com/user-attachments/assets/3fca5ba0-7c70-4a2e-bc99-5d17276d6103)



