### PR TITLE
Fix minor issues reported by flycheck

### DIFF
--- a/hact.el
+++ b/hact.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:     29-Aug-25 at 14:20:04 by Bob Weiner
+;; Last-Mod:     30-Dec-25 at 14:42:06 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -336,7 +336,7 @@ TYPE and TYPE-CATEGORY are both symbols.  TYPE-CATEGORY must be one of
 (defun action:param-count (action)
   "Return the number of args in ACTION's arg list.
 Keywords and special symbols like &optional and &key are excluded."
-  (length (seq-filter (lambda (sym) 
+  (length (seq-filter (lambda (sym)
 			(not (or (keywordp sym)
 				 (string-match "^&" (symbol-name sym)))))
 		      (action:params action))))

--- a/hasht.el
+++ b/hasht.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    16-Mar-90 at 03:38:48
-;; Last-Mod:     29-Aug-25 at 02:16:00 by Bob Weiner
+;; Last-Mod:     30-Dec-25 at 14:42:14 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -136,12 +136,12 @@ in the hash table.  Use `hash-key-p' instead for that function."
 
 (defun hash-make (initializer &optional reverse)
   "Create and return a hash table from INITIALIZER.
-INITIALIZER may be an alist with elements of the form (<value>. <key>)
+INITIALIZER may be an alist with elements of the form (<value> . <key>)
 from which the hash table is built (<key> must be a string).
 Alternatively, it may be a non-negative integer which is used as the
 minimum size of a new, empty hash table.  Optional non-nil second
 argument REVERSE means INITIALIZER has elements of form
-(<key> . <value>).
+\(<key> . <value>).
 
 The resultant value associated with a <key> is the <value> from the last
 entry in INITIALIZER with that <key>.  See `hash-make-prepend' to
@@ -151,7 +151,7 @@ merge all the values for a given <key> instead."
 	     (make-hash-table :size initializer)
 	   (error "(hash-make): Initializer must be >= 0, not `%s'"
 		  initializer)))
-	((numberp initializer) 
+	((numberp initializer)
 	 (error "(hash-make): Initializer must be a positive integer, not `%f'"
 		initializer))
 	(t (let* ((size (length initializer))
@@ -199,8 +199,8 @@ in reverse order of occurrence (they are prepended to the list).  See
 (defun hash-map (func hash-table)
   "Return the list from calling FUNC on (<value> . <string-key>) in HASH-TABLE.
 
-If FUNC is in \\='(cdr key second symbol-name), then return all <key>s
-as strings.  If FUNC is in \\='(car value first symbol-value), then
+If FUNC is in \\='(cdr key second `symbol-name'), then return all <key>s
+as strings.  If FUNC is in \\='(car value first `symbol-value'), then
 return all <value>s."
   (unless (hash-table-p hash-table)
     (error "(hash-map): Invalid hash-table: `%s'" hash-table))
@@ -305,7 +305,7 @@ This is suitable for use as a value of `hash-merge-values-function'."
 If KEY is not found in HASH-TABLE, it is added with a value of (list VALUE).
 
 Trigger an error if an existing VALUE is not a list.  Do nothing and return nil
-if KEY or HASH-TABLE are of the wrong type." 
+if KEY or HASH-TABLE are of the wrong type."
   (when (and (hash-table-p hash-table)
 	     (stringp key))
       (let* ((key-sym (intern key))
@@ -349,7 +349,7 @@ An error will occur if KEY is not found in HASH-TABLE."
     (let ((key-sym (intern-soft key)))
 	(if (gethash key-sym hash-table)
 	    (puthash key-sym value hash-table)
-	  (error "(hash-replace): `%s' key not found in hash table." key)))))
+	  (error "(hash-replace): `%s' key not found in hash table" key)))))
 
 (defun hash-size (hash-table)
   "Return size of HASH-TABLE which is >= number of elements in the table.
@@ -381,3 +381,4 @@ Optional COUNT conses number of duplicates on to front of list before return."
   (if count (cons count sorted-strings) sorted-strings))
 
 (provide 'hasht)
+;;; hasht.el ends here

--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:      7-Dec-25 at 19:24:08 by Bob Weiner
+;; Last-Mod:     30-Dec-25 at 23:55:08 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -963,7 +963,7 @@ The ibut used defaults to \='hbut:current or the optional IBUT-SYMBOL."
 
 (defun hattr:is-p (attr value &optional hbut-symbol)
   "Return t if ATTR has VALUE for \='hbut:current or optional HBUT-SYMBOL."
-  (and (symbolp attr) attr 
+  (and (symbolp attr) attr
        (eq (hattr:get (or (and (symbolp hbut-symbol) hbut-symbol) 'hbut:current)
 		      attr)
 	   value)))
@@ -1553,7 +1553,7 @@ positions at which the button delimiter begins and ends."
 (defun    hbut:map (but-func &optional regexp-match include-delims)
   "Apply BUT-FUNC to a set of hbuttons in the visible part of the current buffer.
 Finds both ebuts and named ibuts that match any optional REGEXP-MATCH
-(may be a partial match but must include delimiters).
+\(may be a partial match but must include delimiters).
 
 Any regexp given must have grouping 1 match the label.
 
@@ -1909,7 +1909,7 @@ excluding delimiters, not just one."
 
 	  (setq lbl-start-end (if (and start-delim end-delim)
 				  (ibut:label-p nil start-delim end-delim t t)
-				(or 
+				(or
 				 ;; <action> buttons can be longer
 				 ;; than two lines, so don't limit
 				 ;; the length.

--- a/hpath.el
+++ b/hpath.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Nov-91 at 00:44:23
-;; Last-Mod:     31-Dec-25 at 16:08:46 by Mats Lidell
+;; Last-Mod:      1-Jan-26 at 18:17:35 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1835,7 +1835,7 @@ the end following a # or , character are temporarily stripped, and path
 variables are expanded with `hpath:substitute-value'.  This normalized path
 form is what is returned for PATH."
   (when (and (stringp path)
-	     (or 
+	     (or
 	      ;; Due to the colons, "hui.el#save-excursion:I2:L2:C30",
 	      ;; will improperly match to a PATH variable. Ensure it doesn't.
 	      (string-match hpath:instance-line-column-regexp path)

--- a/hsys-consult.el
+++ b/hsys-consult.el
@@ -2,7 +2,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     4-Jul-24 at 09:57:18
-;; Last-Mod:     10-Aug-25 at 12:43:19 by Bob Weiner
+;; Last-Mod:     30-Dec-25 at 14:42:23 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -177,10 +177,11 @@ prompt."
 
 (defun hsys-consult-grep-headlines-read-regexp (grep-function prompt
 						&optional regexp)
-  "With `consult', use GREP-FUNCTION and PROMPT to completing read an
-optional REGEXP, the initial pattern for the grep.  Suppress preview
-and return the selected \"file:line:line-contents\".  GREP-FUNCTION
- must take these arguments: regexp max-matches path-list prompt.
+  "With `consult', use GREP-FUNCTION and PROMPT to completing read.
+The optional REGEXP is an initial pattern for the grep.  Suppress
+preview and return the selected \"file:line:line-contents\".
+GREP-FUNCTION must take these arguments: regexp max-matches path-list
+prompt.
 
 Without `consult', just read a REGEXP with PROMPT."
   (if (hsys-consult-active-p)

--- a/hsys-org.el
+++ b/hsys-org.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Jul-16 at 14:54:14
-;; Last-Mod:     22-Nov-25 at 12:07:13 by Bob Weiner
+;; Last-Mod:     31-Dec-25 at 00:03:26 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -512,7 +512,7 @@ either [[referent][description]] or [[referent]].
 
 If point is on a HyWikiWord within an Org link and HyWikiWords are
 recognized in the current buffer, ignore the Org link and return nil
-(handle these elsewhere as implicit buttons).
+\(handle these elsewhere as implicit buttons).
 
 Assume caller has already checked that the current buffer is in
 `org-mode' or is looking for an Org link in a non-Org buffer type."

--- a/hui-mini.el
+++ b/hui-mini.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Oct-91 at 20:13:17
-;; Last-Mod:     31-Dec-25 at 16:08:46 by Mats Lidell
+;; Last-Mod:      1-Jan-26 at 18:18:17 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -817,7 +817,7 @@ command instead.  Typically prevents clashes over {\\`C-c' /}."
 	  ("Proportionally" (setq smart-scroll-proportional t))
 	  ("Windowful"      (setq smart-scroll-proportional nil))))
        '(cust-hywiki-mode .
-	 (("HyWiki Mode>")	  
+	 (("HyWiki Mode>")
 	  ("All-Editable-Buffers" (hywiki-mode :all)
 	   "HyWikiWords are highlighted and active in buffers outside of the HyWiki page directory.")
 	  ("HyWiki-Pages-Only"    (hywiki-mode :pages)
@@ -1039,7 +1039,7 @@ command instead.  Typically prevents clashes over {\\`C-c' /}."
 ;;; ************************************************************************
 
 (defcustom hui:menu-highlight-flag t
-  "If non-nil, highlight the first capitalized character of each menu item.
+  "Non-nil means highlight the first capitalized character of each menu item.
 Highlight with `read-multiple-choice-face'.  The display must
 support underlined faces as well."
   :type 'boolean

--- a/hui-mouse.el
+++ b/hui-mouse.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-89
-;; Last-Mod:     31-Dec-25 at 16:02:19 by Mats Lidell
+;; Last-Mod:      1-Jan-26 at 18:18:24 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1866,7 +1866,7 @@ When the Action Key is pressed and `hsys-org-enable-smart-keys' is t:
   3. On an Org agenda view item, jump to the item for editing.
 
 When the Action Key is pressed and `hsys-org-enable-smart-keys' is
-either `t' or `:buttons':
+either t or `:buttons':
 
   4. Within a radio or internal target or a link to it, jump between
      the target and the first link to it, allowing two-way navigation.

--- a/hynote.el
+++ b/hynote.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    23-Jun-24 at 12:50:37
-;; Last-Mod:      1-Sep-24 at 14:26:02 by Bob Weiner
+;; Last-Mod:      1-Jan-26 at 18:19:13 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -165,3 +165,4 @@ relative to `hynote-directory-list'."
 ;;; ************************************************************************
 
 (provide 'hynote)
+;;; hynote.el ends here

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Jun-89 at 22:08:29
-;; Last-Mod:     22-Nov-25 at 07:54:28 by Bob Weiner
+;; Last-Mod:     30-Dec-25 at 14:42:32 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1590,7 +1590,7 @@ the entry to be inserted.
 
 With optional prefix arg, REGEXP-FLAG, treat NAME as a regular expression
 instead of a string."
-  (interactive (list 
+  (interactive (list
 		(hsys-consult-grep-headlines-read-regexp
 		 #'hyrolo-consult-grep "Yank rolo headline matching")
 		current-prefix-arg))

--- a/hywiki.el
+++ b/hywiki.el
@@ -124,7 +124,7 @@
 ;;
 ;; hywiki-referent-prompt-flag      When nil                   When t
 ;;  -------------------------------------------------------------------------------------
-;;  Action Key              hywiki-word-create-and-display 
+;;  Action Key              hywiki-word-create-and-display
 ;;    or HyWiki/Create      Create Page and Display          Create Referent and Display
 ;;  Assist Key              hywiki-word-create-and-display
 ;;    or C-u HyWiki/Create  Create Referent and Display      Create Page and Display
@@ -255,12 +255,12 @@ Each element is of the form: (wikiword . (referent-type . referent-value)).")
 ;;; ************************************************************************
 
 (defcustom hywiki-word-highlight-flag t
-  "The default, non-nil value treats HyWikiWords in HyWiki pages as hyperlinks.
+  "Non-nil means HyWikiWords in HyWiki pages are treated as hyperlinks.
 A nil value disables HyWikiWord hyperlink buttons in both HyWiki
 pages and all other buffers (since it also disables `hywiki-mode').
 
 Outside of HyWiki pages, the global minor mode `hywiki-mode' must be
-manually enabled for auto-HyWikiWord highlighting. Interactively, {C-h
+manually enabled for auto-HyWikiWord highlighting.  Interactively, {\\`C-h'
 h h m a} does this; programmatically, use `(hywiki-mode :all)' to
 enable it.
 
@@ -357,8 +357,9 @@ nil means no full buffer highlighting has occurred.")
     open-line                         ;; C-o
     quoted-insert                     ;; C-q
     )
-  "Commands that insert characters but whose input events do not
-  arrive as characters or that quote another character for input.")
+  "List of non character commands.
+Commands that insert characters but whose input events do not
+arrive as characters or that quote another character for input.")
 
 ;; Define the keymap for hywiki-mode.
 (defvar hywiki-mode-map nil
@@ -479,7 +480,7 @@ For reference, this is set when `window-buffer-change-functions' calls
 `hywiki-maybe-highlight-page-names' which calls `hywiki-in-page-p'.")
 
 (defcustom hywiki-referent-prompt-flag nil
-  "When t, the Action Key and HyWiki/Create always prompt for referent type.
+  "Non-nil means the Action Key and HyWiki/Create always prompt for referent type.
 Nil by default."
   :type 'boolean
   :initialize #'custom-initialize-default
@@ -2714,7 +2715,7 @@ If deleted, update HyWikiWord highlighting across all frames."
 	   ('prefix (company-grab-word))
 	   ('candidates
 	    (let ((prefix (company-grab-word)))
-	      (when prefix 
+	      (when prefix
 		(cl-loop for key being the hash-keys in (hywiki-get-wikiword-list)
 			 when (string-prefix-p prefix key)
 			 collect key))))
@@ -3027,7 +3028,7 @@ since a prior publish.
 Files are saved in:
     (hywiki-org-get-publish-property :publishing-directory)
 Customize this directory with:
-    {M-x customize-variable RET hywiki-org-publishing-directory RET}."
+    {\\`M-x' `customize-variable' RET hywiki-org-publishing-directory RET}."
   (interactive "P")
   ;; Export Org to html with useful link ids.
   ;; Instead of random ids like "orga1b2c3", use heading titles with
@@ -3497,7 +3498,7 @@ Search across `hywiki-directory'."
 (defun hywiki-word-is-p (word)
   "Return non-nil if WORD is a HyWikiWord and optional #section:Lnum:Cnum.
 WORD may not yet have a referent (non-existent).  Use `hywiki-get-referent'
-to determine whether a HyWikiWord referent exists. 
+to determine whether a HyWikiWord referent exists.
 
 Return nil if WORD is a prefixed, typed hy:HyWikiWord, since
 these are handled by the Org mode link handler."

--- a/kotl/kcell.el
+++ b/kotl/kcell.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-May-93
-;; Last-Mod:     25-Nov-23 at 16:33:20 by Mats Lidell
+;; Last-Mod:     31-Jul-25 at 20:35:20 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -122,7 +122,7 @@ returned.  If CELL-REF is invalid or does not exist, nil is returned.
 
 If optional KVIEWSPEC-FLAG is non-nil and CELL-REF includes a
 viewspec, return the the idstamp concatenated with the viewspec
-(begins with a | character) as a string.
+\(begins with a | character) as a string.
 
 CELL-REF may be a whole number:
 

--- a/kotl/kfile.el
+++ b/kotl/kfile.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    10/31/93
-;; Last-Mod:     19-Oct-24 at 10:30:56 by Bob Weiner
+;; Last-Mod:     31-Jul-25 at 20:35:42 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -69,7 +69,7 @@ Return the new kview."
 ;;;###autoload
 (defun kfile:is-p ()
   "Iff current buffer contains a koutline, return file format version string.
-If not a koutline, return nil. This works both for unformatted
+If not a koutline, return nil.  This works both for unformatted
 and formatted koutlines."
   (let (ver-string)
     (save-excursion

--- a/kotl/kfill.el
+++ b/kotl/kfill.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    23-Jan-94
-;; Last-Mod:     20-Jan-24 at 15:42:54 by Mats Lidell
+;; Last-Mod:     31-Jul-25 at 20:36:46 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -54,9 +54,7 @@
     ;; This keeps normal paragraphs from interacting unpleasantly with
     ;; the types given above.
     ("[^ \t/#%?!~*+-]" . kfill:normal))
-"Value is an alist of the form
-
-   ((REGXP . FUNCTION) ...)
+  "Value is an alist of the form ((REGEXP . FUNCTION) ...).
 
 When `fill-paragraph' is called, the REGEXP of each alist element is compared
 with the beginning of the current line.  If a match is found the corresponding

--- a/kotl/kimport.el
+++ b/kotl/kimport.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Nov-93 at 11:57:05
-;; Last-Mod:     25-Feb-24 at 18:03:16 by Mats Lidell
+;; Last-Mod:     31-Jul-25 at 20:37:32 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -200,7 +200,7 @@ on."
 				 (kcell-view:sibling-p)))))
 
     (when (eq import-from output-to)
-      (error "(kimport:aug-post-outline): Import and output buffers may not be the same."))
+      (error "(kimport:aug-post-outline): Import and output buffers may not be the same"))
 
     (set-buffer import-from)
     (outline-show-all)
@@ -274,7 +274,7 @@ placed.
 				 (kcell-view:sibling-p)))))
 
     (when (eq import-from output-to)
-      (error "(kimport:star-outline): Import and output buffers may not be the same."))
+      (error "(kimport:star-outline): Import and output buffers may not be the same"))
 
     (set-buffer import-from)
     (outline-show-all)
@@ -354,7 +354,7 @@ paragraphs as a sequence of same level cells.  The variable,
 				 (kcell-view:sibling-p)))))
 
     (when (eq import-from output-to)
-      (error "(kimport:text): Import and output buffers may not be the same."))
+      (error "(kimport:text): Import and output buffers may not be the same"))
 
     (set-buffer import-from)
     (let ((kotl-import (derived-mode-p 'kotl-mode))
@@ -604,7 +604,7 @@ will be added as children of the cell where this function leaves point
 		(goto-char (point-max)))
 	      (kotl-mode:to-valid-position))
 	  (error
-	   "(kimport:initialize): Second arg, %s, must be a koutline file."
+	   "(kimport:initialize): Second arg, %s, must be a koutline file"
 	   (buffer-name output-to)))
       (when erase-flag
 	(widen)

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:     31-Dec-25 at 16:10:26 by Mats Lidell
+;; Last-Mod:      1-Jan-26 at 18:18:27 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -2974,7 +2974,7 @@ Prefix ARG selects the cells whose attributes are removed or set:
   "Split the current cell into two cells and move to the new cell.
 The cell contents after point become part of the newly created cell.
 The default is to create the new cell as a sibling of the current cell.
-With optional universal ARG, {C-u}, the new cell is added as the child of
+With optional universal ARG, {\\`C-u'}, the new cell is added as the child of
 the current cell.  Non-read-only attributes from the current cell are
 replicated in the new cell."
   (interactive "*P")
@@ -3117,7 +3117,7 @@ to a specified buffer, otherwise, copy the active region.
 Use 0 to copy the whole outline buffer.  Prompt for whether or not
 to expand and include any hidden/invisible text within the copied text."
   (interactive)
-  (call-interactively 
+  (call-interactively
    (if (use-region-p)
        #'kotl-mode:copy-region-to-buffer
      #'kotl-mode:copy-tree-to-buffer)))
@@ -3409,7 +3409,7 @@ because, in this case the deletion might narrow the column."
    (lambda () (org-force-self-insert n))))
 
 (defun kotl-mode:org-self-insert-command (n)
-  "Like `self-insert-command’, use overwrite-mode for whitespace in tables.
+  "Like `self-insert-command’, use `overwrite-mode' for whitespace in tables.
 If the cursor is in a table looking at whitespace, the whitespace is
 overwritten, and the table is not marked as requiring realignment."
   (interactive "p")
@@ -3433,7 +3433,7 @@ conflicting binding to this key outside orgtbl-mode."
    (lambda () (orgtbl-create-or-convert-from-region arg))))
 
 (defun kotl-mode:orgtbl-self-insert-command (n)
-  "Like `self-insert-command', use overwrite-mode for whitespace in tables.
+  "Like `self-insert-command', use `overwrite-mode' for whitespace in tables.
 If the cursor is in a table looking at whitespace, the whitespace is
 overwritten, and the table is not marked as requiring realignment."
   (interactive "p")

--- a/kotl/kview.el
+++ b/kotl/kview.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:     31-Dec-25 at 16:10:26 by Mats Lidell
+;; Last-Mod:      1-Jan-26 at 18:18:36 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -385,7 +385,7 @@ Return t unless no such cell."
     found))
 
 (defun kcell-view:get-attr (attribute &optional pos)
-  "Return ATTRIBUTE's value for current cell or cell at optional POS
+  "Return ATTRIBUTE's value for current cell or cell at optional POS.
 Use 0 for POS to retrieve top cell's attributes."
   (if (eq pos 0)
       (if (eq attribute 'idstamp)


### PR DESCRIPTION
Includes:
 - Removing trailing white space
 - Insert double space between sentences
 - Conform to "Non-nil means" docstring wording for flag variables
 - Keycode in docstring formatting
 - Error messages should not end in a period
 - Line in docstring should not start with a paren
 - First line in a docstring should be a complete sentence