### PR TITLE
Remove leading asterix from defcustom docstrings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2025-12-31  Mats Lidell  <matsl@gnu.org>
+
+* Remove starting asterix from defcustom variable docstrings.
+
 2025-12-25  Mats Lidell  <matsl@gnu.org>
 
 * hywiki.el (hywiki--preparation-function, hywiki--completion-function)

--- a/hmail.el
+++ b/hmail.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     9-Oct-91 at 18:38:05
-;; Last-Mod:      5-Jan-25 at 12:01:15 by Bob Weiner
+;; Last-Mod:     31-Dec-25 at 16:02:19 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -56,7 +56,7 @@
  "Major mode for reading USENET news with Hyperbole buttons.")
 
 (defcustom hmail:init-function nil
-  "*Function (a symbol) to initialize Hyperbole support for a mail reader/composer.
+  "Function (a symbol) to initialize Hyperbole support for a mail reader/composer.
 Valid values are: nil, Mh-init or Rmail-init."
   :type '(choice (const nil)
 		 (const Mh-init)

--- a/hmouse-tag.el
+++ b/hmouse-tag.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    24-Aug-91
-;; Last-Mod:      7-Dec-25 at 20:25:10 by Bob Weiner
+;; Last-Mod:     31-Dec-25 at 16:02:19 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -111,7 +111,7 @@ should insert the implicit link type definition name.")
 (define-obsolete-variable-alias 'smart-asm-include-dirs
   'smart-asm-include-path "06.00")
 (defcustom smart-asm-include-path nil
-  "*Ordered list of directories to search for assembly language include files.
+  "Ordered list of directories to search for assembly language include files.
 Each directory must end with a directory separator."
   :type '(repeat directory)
   :group 'hyperbole-commands)
@@ -130,7 +130,7 @@ Examples include:
 (define-obsolete-variable-alias 'smart-c-cpp-include-dirs
   'smart-c-cpp-include-path "06.00")
 (defcustom smart-c-cpp-include-path '("/usr/include/")
-  "*Ordered list of include directories by default searched by C/C++ preprocessor.
+  "Ordered list of include directories by default searched by C/C++ preprocessor.
 Each directory must end with a directory separator.  See also
 `smart-c-include-path'."
   :type '(repeat directory)
@@ -139,7 +139,7 @@ Each directory must end with a directory separator.  See also
 (define-obsolete-variable-alias 'smart-c-include-dirs
   'smart-c-include-path "06.00")
 (defcustom smart-c-include-path nil
-  "*Ordered list of directories to search for C/C++ include files.
+  "Ordered list of directories to search for C/C++ include files.
 Each directory must end with a directory separator.  Directories normally
 searched by the C/C++ pre-processor should be set instead in
 `smart-c-cpp-include-path'."
@@ -173,7 +173,7 @@ File name is grouping 3.")
 (defcustom smart-java-package-path
   (and (fboundp 'getenv) (getenv "JAVA_HOME")
        (list (expand-file-name "src/" (file-name-as-directory (getenv "JAVA_HOME")))))
-  "*Ordered list of directories to search for imported Java packages.
+  "Ordered list of directories to search for imported Java packages.
 Each directory must end with a directory separator."
   :type '(repeat directory)
   :group 'hyperbole-commands)
@@ -186,12 +186,12 @@ Each directory must end with a directory separator."
 Keyword matched is grouping 1.  Referent is grouping 2.")
 
 (defcustom smart-emacs-tags-file nil
-  "*Full path name of etags file for GNU Emacs source."
+  "Full path name of etags file for GNU Emacs source."
   :type '(file :must-match t)
   :group 'hyperbole-commands)
 
 (defcustom smart-tags-mode-list '(fundamental-mode prog-mode text-mode)
-  "*Major modes where programming symbols are recognized by the Smart Keys."
+  "Major modes where programming symbols are recognized by the Smart Keys."
   :type '(repeat symbol)
   :group 'hyperbole-commands)
 

--- a/hpath.el
+++ b/hpath.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Nov-91 at 00:44:23
-;; Last-Mod:      7-Dec-25 at 21:12:14 by Bob Weiner
+;; Last-Mod:     31-Dec-25 at 16:08:46 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -43,7 +43,7 @@
 					      icomplete-mode ivy-mode
 					      org-roam-mode vertico-mode
                                               selectrum-mode)
-  "*List of boolean mode variables whose modes automatically list completions.
+  "List of boolean mode variables whose modes automatically list completions.
 These are modes where completions are listed without the need for
 pressing the ? key."
   :type '(repeat variable)
@@ -355,7 +355,7 @@ Call this function manually if mount points change after Hyperbole is loaded."
 ;;; ************************************************************************
 
 (defcustom hpath:external-open-office-suffixes "doc[mx]?\\|od[st]\\|ppsx?\\|ppt[mx]?\\|v[dst][s]?[tx]\\|vsd[x]?\\|xls[mx]?"
-  "*Regexp of Open Office document suffix alternatives.
+  "Regexp of Open Office document suffix alternatives.
 These are to be display externally with the Action Key
 Do not include an initial period or enclosing grouping parentheses;
 these will be added automatically.
@@ -366,7 +366,7 @@ possible suffixes."
   :group 'hyperbole-commands)
 
 (defcustom hpath:external-file-suffixes "e?ps\\|dvi\\|pdf\\|ps\\.g?[zZ]\\|gif\\|tiff?\\|xpm\\|xbm\\|xwd\\|pm\\|pbm\\|jpe?g\\|xcf"
-  "*Non-operating system dependent regexp of file suffixes to open outside Emacs.
+  "Non-operating system dependent regexp of file suffixes to open outside Emacs.
 These are opened with the Action Key when not handled by
 `hpath:native-image-suffixes'.  Do not include an initial period
 or enclosing grouping parentheses; these will be added
@@ -378,7 +378,7 @@ automatically."
 								  hpath:external-open-office-suffixes
 								  hpath:external-file-suffixes)
 							  "open"))
-  "*An alist of (FILENAME-REGEXP . DISPLAY-PROGRAM-STRING-OR-LIST) for the macOS.
+  "An alist of (FILENAME-REGEXP . DISPLAY-PROGRAM-STRING-OR-LIST) for the macOS.
 See the function `hpath:get-external-display-alist' for detailed
 format documentation."
   :type '(alist :key-type regexp :value-type string)
@@ -388,7 +388,7 @@ format documentation."
 							      "openoffice.exe")
 							(cons (format "\\.\\(%s\\|vba\\)$" hpath:external-file-suffixes)
 							      "/c/Windows/System32/cmd.exe //c start \"${@//&/^&}\""))
-  "*An alist of (FILENAME-REGEXP . DISPLAY-PROGRAM-STRING-OR-LIST) for MS Windows.
+  "An alist of (FILENAME-REGEXP . DISPLAY-PROGRAM-STRING-OR-LIST) for MS Windows.
 See the function `hpath:get-external-display-alist' for detailed
 format documentation."
   :type '(alist :key-type regexp :value-type string)
@@ -408,7 +408,7 @@ format documentation."
 							      hpath:external-open-office-suffixes
 							      hpath:external-file-suffixes)
 						      "setsid -w xdg-open"))
-  "*An alist of (FILENAME-REGEXP . DISPLAY-PROGRAM-STRING-OR-LIST) for X.
+  "An alist of (FILENAME-REGEXP . DISPLAY-PROGRAM-STRING-OR-LIST) for X.
 See the function `hpath:get-external-display-alist' for detailed
 format documentation."
   :type '(alist :key-type regexp :value-type string)
@@ -456,7 +456,7 @@ format documentation."
 		  (error "Invalid file"))))))
 
     '("\\.rdb\\'" . rdb:initialize)))
-  "*Alist for calling special functions to display file types in Emacs.
+  "Alist for calling special functions to display file types in Emacs.
 The alist consists of (FILENAME-REGEXP . EDIT-FUNCTION) elements.
 See also the function (hpath:get-external-display-alist) for
 external display program settings."
@@ -558,7 +558,7 @@ Used only if the function `image-mode' is defined."
 ;;
 (defcustom hpath:variables
   '(hyperb:dir hywiki-directory load-path exec-path Info-directory-list sm-directory)
-  "*List of Emacs Lisp variable symbols to substitute within matching link paths.
+  "List of Emacs Lisp variable symbols to substitute within matching link paths.
 Each variable value, if bound, must be either a pathname or a list of pathnames.
 When embedded within a path, the format is ${variable}."
   :type '(repeat variable)
@@ -572,7 +572,7 @@ When embedded within a path, the format is ${variable}."
   "*Url pattern for (hpath:rfc rfc-num) to get the RFC document for `rfc-num'.")
 
 (defcustom hpath:suffixes '(".gz" ".Z")
-  "*List of filename suffixes to add or remove within hpath calls.
+  "List of filename suffixes to add or remove within hpath calls.
 Used by `hpath:exists-p' and `hpath:substitute-dir'."
   :type '(repeat string)
   :group 'hyperbole-commands)

--- a/hproperty.el
+++ b/hproperty.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Aug-92
-;; Last-Mod:      5-Oct-25 at 16:41:34 by Mats Lidell
+;; Last-Mod:     31-Dec-25 at 16:02:19 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -41,24 +41,24 @@
 ;;; ************************************************************************
 
 (defcustom hproperty:but-highlight-flag t
-  "*Non-nil means highlight named Hyperbole buttons with `hproperty:but-face'."
+  "Non-nil means highlight named Hyperbole buttons with `hproperty:but-face'."
   :type 'boolean
   :group 'hyperbole-buttons)
 
 (defcustom hproperty:but-emphasize-flag nil
-  "*Non-nil means emphasize selectability of Hyperbole button labels.
+  "Non-nil means emphasize selectability of Hyperbole button labels.
 This is shown when hovering over the button with the mouse."
   :type 'boolean
   :group 'hyperbole-buttons)
 
 (defcustom hproperty:but-flash-time 1000
-  "*Emacs button flash delay."
+  "Emacs button flash delay."
   :type '(integer :match (lambda (_widget value) (and (integerp value) (> value 0))))
   :group 'hyperbole-buttons)
 (make-obsolete-variable 'hproperty:but-flash-time "Use `hproperty:but-flash-time-seconds' instead" "8.0")
 
 (defcustom hproperty:but-flash-time-seconds 0.05
-  "*Emacs button flash delay."
+  "Emacs button flash delay."
   :type 'float
   :group 'hyperbole-buttons)
 

--- a/hsettings.el
+++ b/hsettings.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Apr-91 at 00:48:49
-;; Last-Mod:     29-Jun-24 at 18:57:18 by Bob Weiner
+;; Last-Mod:     31-Dec-25 at 16:06:23 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -101,12 +101,12 @@ The Smart Menu system must have already been loaded.  If a Smart
 Menu is already displayed, perform another Action or Assist Key function.")
 
 (defcustom hmouse-middle-flag (and (boundp 'infodock-version) infodock-version t)
-  "*Non-nil means additionally bind the middle mouse button as an Action Key."
+  "Non-nil means additionally bind the middle mouse button as an Action Key."
   :type 'boolean
   :group 'hyperbole-keys)
 
 (defcustom smart-scroll-proportional t
-  "*Non-nil means Smart Key scroll behavior is relative to current line.
+  "Non-nil means Smart Key scroll behavior is relative to current line.
 Smart Keys will scroll relative to current line when pressed at
 the end of a line.  Action Key moves current line to top of the
 window.  Assist Key moves current line to bottom of the window.
@@ -233,7 +233,7 @@ disable/inhibit support."
 	       (if inhibit-hyperbole-messaging "disabled" "enabled"))))
 
 (defcustom inhibit-hyperbole-messaging t
-  "*Determine whether Hyperbole supports explicit buttons in mail and news buffers.
+  "Determine whether Hyperbole supports explicit buttons in mail and news buffers.
 The default of t means disable such support (work remains to
 modernize these features).  When t, Hyperbole will not alter
 messaging mode hooks nor overload functions from these packages,
@@ -251,7 +251,7 @@ Hyperbole, and then restart Emacs."
   :group 'hyperbole-buttons)
 
 (defcustom hyperbole-web-search-browser-function browse-url-browser-function
-  "*Function of one url argument called by any Hyperbole Find/Web search."
+  "Function of one url argument called by any Hyperbole Find/Web search."
   :type 'function
   :group 'hyperbole-commands)
 
@@ -275,7 +275,7 @@ Hyperbole, and then restart Emacs."
     ("Wikipedia" . "https://en.wikipedia.org/wiki/%s")
     ("X" . "https://x.com/search?q=%s")
     ("Youtube" . "https://www.youtube.com/results?search_query=%s"))
-  "*Alist of (web-service-name . emacs-cmd-or-url-with-%s-parameter) elements.
+  "Alist of (web-service-name . emacs-cmd-or-url-with-%s-parameter) elements.
 The first capitalized character of each web-service-name must be unique.
 This custom option is used in the Hyperbole Find/Web menu where
 the %s in the url-with-%s-parameter is replaced with an interactively

--- a/hui-mini.el
+++ b/hui-mini.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Oct-91 at 20:13:17
-;; Last-Mod:     30-Nov-25 at 17:51:11 by Bob Weiner
+;; Last-Mod:     31-Dec-25 at 16:08:46 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1039,7 +1039,7 @@ command instead.  Typically prevents clashes over {\\`C-c' /}."
 ;;; ************************************************************************
 
 (defcustom hui:menu-highlight-flag t
-  "*If non-nil, highlight the first capitalized character of each menu item.
+  "If non-nil, highlight the first capitalized character of each menu item.
 Highlight with `read-multiple-choice-face'.  The display must
 support underlined faces as well."
   :type 'boolean
@@ -1081,7 +1081,7 @@ support underlined faces as well."
 	 (when (fboundp 'consult-grep) ;; allow for autoloading
 	   '("WikiWordConsult" hywiki-word-consult-grep
 	     "Use `hywiki-consult-grep' to show occurrences of a prompted for HyWikiWord."))))
-  "*Hyperbole minibuffer HyWiki menu items of the form:
+  "Hyperbole minibuffer HyWiki menu items of the form:
 \(LABEL-STRING ACTION-SEXP DOC-STR)."
   :set  (lambda (var value)
 	  (if (fboundp #'hyperbole-minibuffer-menu)
@@ -1112,7 +1112,7 @@ support underlined faces as well."
 	 '("TagFind"          hyrolo-tags-view              "Find HyRolo Org tags.")
 	 '("WordFind"         hyrolo-word                   "Find entries containing words.")
 	 '("Yank"             hyrolo-yank                   "Find an entry containing a string and insert it at point.")))
-  "*Hyperbole minibuffer Rolo menu items of the form:
+  "Hyperbole minibuffer Rolo menu items of the form:
 \(LABEL-STRING ACTION-SEXP DOC-STR)."
   :set  (lambda (var value)
 	  (if (fboundp #'hyperbole-minibuffer-menu)

--- a/hui-mouse.el
+++ b/hui-mouse.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-89
-;; Last-Mod:      7-Dec-25 at 20:15:46 by Bob Weiner
+;; Last-Mod:     31-Dec-25 at 16:02:19 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -130,34 +130,34 @@ In any other context, signal an error."
     (hypb:error "(Hyperbole Assist Key): No action defined for this context; try another location")))
 
 (defcustom action-key-default-function #'action-key-error
-  "*Function run by the Action Key in an unspecified context.
+  "Function run by the Action Key in an unspecified context.
 Set it to `hyperbole' if you want it to display the Hyperbole minibuffer menu."
   :type 'function
   :group 'hyperbole-keys)
 
 (defcustom assist-key-default-function #'assist-key-error
-  "*Function run by the Assist Key in an unspecified context.
+  "Function run by the Assist Key in an unspecified context.
 Set it to `hkey-summarize' if you want it to display a summary of
 Smart Key behavior."
   :type 'function
   :group 'hyperbole-keys)
 
 (defcustom action-key-modeline-buffer-id-function #'dired-jump
-  "*Function to call for Action Key clicks on the buf id portion of a modeline.
+  "Function to call for Action Key clicks on the buf id portion of a modeline.
 Its default value is `dired-jump'; set it to `smart-treemacs-modeline'
 to use the Treemacs file manager package instead."
   :type 'function
   :group 'hyperbole-keys)
 
 (defcustom action-key-eol-function #'smart-scroll-up
-  "*Function run by the Action Key at the end of a line.
+  "Function run by the Action Key at the end of a line.
 Its default value is `smart-scroll-up'.  To disable it, set it to
 #\\='ignore."
   :type 'function
   :group 'hyperbole-keys)
 
 (defcustom assist-key-eol-function #'smart-scroll-down
-  "*Function run by the Assist Key at the end of a line.
+  "Function run by the Assist Key at the end of a line.
 Its default value is `smart-scroll-down'.  To disable it, set it to
 #\\='ignore."
   :type 'function

--- a/hui-select.el
+++ b/hui-select.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Oct-96 at 02:25:27
-;; Last-Mod:     29-Aug-25 at 21:52:32 by Bob Weiner
+;; Last-Mod:     31-Dec-25 at 16:07:18 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -125,7 +125,7 @@
   (format "%sgrep -insIHr" (if (and (executable-find "zgrep")
                                     (string-match-p "bsd" (shell-command-to-string "zgrep --version | head -1")))
                                "z" ""))
-  "*Grep command string and initial arguments sent to `hui-select-rgrep' command.
+  "Grep command string and initial arguments sent to `hui-select-rgrep' command.
 It must end with a space."
   :type 'string
   :group 'hyperbole-commands)
@@ -133,19 +133,19 @@ It must end with a space."
 (defcustom hui-select-brace-modes
   '(c++-mode c++-ts-mode c-mode c-ts-mode java-mode java-ts-mode objc-mode
              perl-mode tcl-mode)
-  "*List of language major modes which define things with brace delimiters."
+  "List of language major modes which define things with brace delimiters."
   :type '(repeat (function :tag "Mode"))
   :group 'hyperbole-commands)
 
 (defcustom hui-select-markup-modes
   '(html-mode mhtml-mode nxml-mode sgml-mode web-mode)
-  "*List of markup language modes that use SGML-style <tag> </tag> pairs."
+  "List of markup language modes that use SGML-style <tag> </tag> pairs."
   :type '(repeat (function :tag "Mode"))
   :group 'hyperbole-commands)
 
 (defcustom hui-select-text-modes
   '(fundamental-mode kotl-mode indented-text-mode Info-mode outline-mode text-mode)
-  "*List of textual modes where paragraphs may be outdented or indented."
+  "List of textual modes where paragraphs may be outdented or indented."
   :type '(repeat (function :tag "Mode"))
   :group 'hyperbole-commands)
 
@@ -153,14 +153,14 @@ It must end with a space."
   (append '(altmath-mode asm-mode csh-mode eiffel-mode ksh-mode math-mode miranda-mode
                          pascal-mode python-mode python-ts-mode sather-mode)
 	  hui-select-text-modes)
-  "*List of modes that use indentation mostly to define syntactic structure.
+  "List of modes that use indentation mostly to define syntactic structure.
 Use for language major modes."
   :type '(repeat (function :tag "Mode"))
   :group 'hyperbole-commands)
 
 (defcustom hui-select-ignore-quoted-sexp-modes
   '(debugger-mode emacs-lisp-mode lisp-mode lisp-interaction-mode slime-mode cider-mode)
-  "*List of modes in which to ignore quoted sexpressions for syntactic matches.
+  "List of modes in which to ignore quoted sexpressions for syntactic matches.
 Use for language major modes."
   :type '(repeat (function :tag "Mode"))
   :group 'hyperbole-commands)
@@ -202,17 +202,17 @@ Used to avoid early dropoff when marking indented code.")
 Used to include a final line when marking indented code.")
 
 (defcustom hui-select-char-p nil
-  "*If t, return single character boundaries when all else fails."
+  "If t, return single character boundaries when all else fails."
   :type 'boolean
   :group 'hyperbole-commands)
 
 (defcustom hui-select-display-type t
-  "*If t, display the thing selected with each mouse click."
+  "If t, display the thing selected with each mouse click."
   :type 'boolean
   :group 'hyperbole-commands)
 
 (defcustom hui-select-whitespace t
-  "*If t, groups of whitespace are considered as things."
+  "If t, groups of whitespace are considered as things."
   :type 'boolean
   :group 'hyperbole-commands)
 
@@ -419,7 +419,7 @@ The function `hui-select-set-region' updates and returns it.")
     (?   . hui-select-whitespace)
     (?\< . hui-select-comment)
     (?\. . hui-select-punctuation))
-  "*Unordered list of pairs of the form (<syntax-char> <function>).
+  "Unordered list of pairs of the form (<syntax-char> <function>).
 Used by the function `hui-select-syntactical-region'.
 Each <function> takes a single position argument and returns a
 region (start . end) defining the boundaries of the thing at that position."

--- a/hui-window.el
+++ b/hui-window.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Sep-92
-;; Last-Mod:     19-Jun-25 at 11:44:26 by Bob Weiner
+;; Last-Mod:     31-Dec-25 at 16:02:19 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -71,13 +71,13 @@
 ;;; ************************************************************************
 
 (defcustom action-key-minibuffer-function #'hyperbole
-  "*Function run by the Action Key after a click in an inactive minibuffer.
+  "Function run by the Action Key after a click in an inactive minibuffer.
 Its default value is `hyperbole', which displays the Hyperbole minibuffer menu."
   :type 'function
   :group 'hyperbole-keys)
 
 (defcustom assist-key-minibuffer-function #'hui-menu-screen-commands
-  "*Function run by the Assist Key after a click in an inactive minibuffer.
+  "Function run by the Assist Key after a click in an inactive minibuffer.
 Its default value is `hui-menu-screen-commands', which displays a popup menu
 of screen control commands."
   :type 'function
@@ -95,25 +95,25 @@ of screen control commands."
   :group 'hyperbole-keys)
 
 (defcustom action-key-modeline-left-edge-function #'action-key-modeline-click-left-edge
-  "*Function run on an Action Mouse Key click at a modeline left edge.
+  "Function run on an Action Mouse Key click at a modeline left edge.
 To disable it, set it to #\\='ignore."
   :type 'function
   :group 'hyperbole-keys)
 
 (defcustom assist-key-modeline-left-edge-function #'assist-key-modeline-click-left-edge
-  "*Function run on an Assist Mouse Key click at a modeline left edge.
+  "Function run on an Assist Mouse Key click at a modeline left edge.
 To disable it, set it to #\\='ignore."
   :type 'function
   :group 'hyperbole-keys)
 
 (defcustom action-key-modeline-right-edge-function #'action-key-modeline-click-right-edge
-  "*Function run on an Action Mouse Key click at a modeline right edge.
+  "Function run on an Action Mouse Key click at a modeline right edge.
 To disable it, set it to #\\='ignore."
   :type 'function
   :group 'hyperbole-keys)
 
 (defcustom assist-key-modeline-right-edge-function #'assist-key-modeline-click-right-edge
-  "*Function run on an Assist Mouse Key click at a modeline right edge.
+  "Function run on an Assist Mouse Key click at a modeline right edge.
 To disable it, set it to #\\='ignore."
   :type 'function
   :group 'hyperbole-keys)

--- a/hui.el
+++ b/hui.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 21:42:03
-;; Last-Mod:     23-Nov-25 at 12:44:22 by Bob Weiner
+;; Last-Mod:     31-Dec-25 at 16:02:19 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -51,12 +51,12 @@
 ;;; ************************************************************************
 
 (defcustom hui:ebut-prompt-for-action nil
-  "*Non-nil prompts for a button-specific action on explicit button creation."
+  "Non-nil prompts for a button-specific action on explicit button creation."
   :type 'boolean
   :group 'hyperbole-buttons)
 
 (defcustom hui:hbut-delete-confirm-flag t
-  "*Non-nil means prompt before interactively deleting explicit buttons."
+  "Non-nil means prompt before interactively deleting explicit buttons."
   :type 'boolean
   :group 'hyperbole-buttons)
 

--- a/hycontrol.el
+++ b/hycontrol.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Jun-16 at 15:35:36
-;; Last-Mod:     26-Oct-25 at 16:04:51 by Bob Weiner
+;; Last-Mod:     31-Dec-25 at 16:02:19 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -164,22 +164,22 @@ evaluated with the buffer argument as the current buffer, e.g. (eq
 major-mode \\='c-mode).")
 
 (defcustom hycontrol-help-flag t
-  "*Non-nil means show key binding help in the minibuffer when in a HyControl mode."
+  "Non-nil means show key binding help in the minibuffer when in a HyControl mode."
   :type 'boolean
   :group 'hyperbole-screen)
 
 (defcustom hycontrol-invert-mode-line-flag t
-  "*Non-nil means invert mode-line to emphasize the special key bindings in effect."
+  "Non-nil means invert mode-line to emphasize the special key bindings in effect."
   :type 'boolean
   :group 'hyperbole-screen)
 
 (defcustom hycontrol-keep-window-flag nil
-  "*Non-nil means leave original window when tear off window to another frame."
+  "Non-nil means leave original window when tear off window to another frame."
   :type 'boolean
   :group 'hyperbole-screen)
 
 (defcustom hycontrol-maximum-units 1000
-  "*Maximum units setting allowed for hycontrol commands.
+  "Maximum units setting allowed for hycontrol commands.
 The unit counter resets to the last digit entered whenever this
 value is exceeded."
   :type '(integer :match (lambda (_widget value)
@@ -188,7 +188,7 @@ value is exceeded."
   :group 'hyperbole-screen)
 
 (defcustom hycontrol-frame-offset '(13 . 23)
-  "*Increase in offset for new hycontrol frames relative to the selected frame.
+  "Increase in offset for new hycontrol frames relative to the selected frame.
 Its value is an (x-offset . y-offset) pair in pixels."
   :type '(cons integer integer)
   :group 'hyperbole-screen)
@@ -211,25 +211,25 @@ Lisp boolean form to evaluate.
 The final predicate should always be t, for default values, typically of zero.")
 
 (defcustom hycontrol-screen-top-offset    0
-  "*Pixel offset from top used when placing a frame at a top corner."
+  "Pixel offset from top used when placing a frame at a top corner."
   :type '(integer :match (lambda (_widget value)
 			   (and (integerp value) (>= value 0)
 				(< value (display-pixel-height)))))
   :group 'hyperbole-screen)
 (defcustom hycontrol-screen-right-offset  0
-  "*Pixel offset from right used when placing a frame at a right corner."
+  "Pixel offset from right used when placing a frame at a right corner."
   :type '(integer :match (lambda (_widget value)
 			   (and (integerp value) (>= value 0)
 				(< value (display-pixel-width)))))
   :group 'hyperbole-screen)
 (defcustom hycontrol-screen-bottom-offset 0
-  "*Pixel offset from bottom used when placing a frame at a bottom corner."
+  "Pixel offset from bottom used when placing a frame at a bottom corner."
   :type '(integer :match (lambda (_widget value)
 			   (and (integerp value) (>= value 0)
 				(< value (display-pixel-height)))))
   :group 'hyperbole-screen)
 (defcustom hycontrol-screen-left-offset   0
-  "*Pixel offset from left used when placing a frame at a left corner."
+  "Pixel offset from left used when placing a frame at a left corner."
   :type '(integer :match (lambda (_widget value)
 			   (and (integerp value) (>= value 0)
 				(< value (display-pixel-width)))))

--- a/hyperbole.el
+++ b/hyperbole.el
@@ -9,7 +9,7 @@
 ;; Maintainer:   Robert Weiner <rsw@gnu.org>
 ;; Maintainers:  Robert Weiner <rsw@gnu.org>, Mats Lidell <matsl@gnu.org>
 ;; Created:      06-Oct-92 at 11:52:51
-;; Last-Mod:      2-Oct-25 at 14:28:52 by Mats Lidell
+;; Last-Mod:     31-Dec-25 at 16:02:19 by Mats Lidell
 ;; Released:     10-Mar-24
 ;; Version:      9.0.2pre
 ;; Keywords:     comm, convenience, files, frames, hypermedia, languages, mail, matching, mouse, multimedia, outlines, tools, wp
@@ -186,7 +186,7 @@ Info documentation at \"(hyperbole)Top\".
 ;;; ************************************************************************
 
 (defcustom hkey-init t
-  "*A non-nil value (default) at system load time binds Hyperbole keys.
+  "A non-nil value (default) at system load time binds Hyperbole keys.
 Keys bound are the Action and Assist Keyboard Keys, as well as
 other keys.  {\\[hkey-either]} invokes the Action Key and
 {\\`C-u' \\[hkey-either]} invokes the Assist Key.  Additionally,

--- a/hywconfig.el
+++ b/hywconfig.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Mar-89
-;; Last-Mod:     20-Jan-24 at 20:20:58 by Mats Lidell
+;; Last-Mod:     31-Dec-25 at 16:02:19 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -59,7 +59,7 @@
 
 (define-obsolete-variable-alias 'wconfig-ring-max 'hywconfig-ring-max "06.00")
 (defcustom hywconfig-ring-max 10
-  "*Max length of Hyperbole window config ring before oldest elements are deleted."
+  "Max length of Hyperbole window config ring before oldest elements are deleted."
   :type `(integer
           :match ,(lambda (_widget value) (and (integerp value) (> value 0))))
   :group 'hyperbole-screen)

--- a/hywiki.el
+++ b/hywiki.el
@@ -969,7 +969,7 @@ After successfully finding a referent, run `hywiki-display-referent-hook'."
 	   "Add a HyWikiWord that displays an Org Roam node given its title.")
 	 '("Sexp"         (hywiki-add-sexpression hkey-value)
 	   "Add a HyWikiWord that evaluates an Elisp sexpression.")))
-  "*Menu of HyWikiWord custom referent types of the form:
+  "Menu of HyWikiWord custom referent types of the form:
 \(LABEL-STRING ACTION-SEXP DOC-STR)."
   :set  (lambda (var value) (set-default var value))
   :type '(cons (list string) (repeat (list string sexp string)))

--- a/kotl/kexport.el
+++ b/kotl/kexport.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    26-Feb-98
-;; Last-Mod:      5-Nov-23 at 11:45:00 by Bob Weiner
+;; Last-Mod:     31-Dec-25 at 16:10:47 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -45,13 +45,13 @@
 
 (defcustom kexport:html-description
   "Created by Hyperbole's outliner.\nSee &quot;(hyperbole)Koutliner&quot; for more information."
-  "*String to insert as the HTML-exported document's description, or nil for none."
+  "String to insert as the HTML-exported document's description, or nil for none."
   :type '(choice (const nil)
 		 (string))
   :group 'hyperbole-koutliner)
 
 (defcustom kexport:html-keywords nil
-  "*String of comma separated keywords to include with an HTML-exported document.
+  "String of comma separated keywords to include with an HTML-exported document.
 If nil, use no keywords."
   :type '(choice (const nil)
 		 (string))

--- a/kotl/kotl-mode.el
+++ b/kotl/kotl-mode.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:      6-Oct-25 at 00:16:41 by Mats Lidell
+;; Last-Mod:     31-Dec-25 at 16:10:26 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -39,7 +39,7 @@
 ;;; ************************************************************************
 
 (defcustom kotl-mode:indent-tabs-mode t
-  "*Non-nil means {\\[kotl-mode:tab-command]} may insert literal tab characters.
+  "Non-nil means {\\[kotl-mode:tab-command]} may insert literal tab characters.
 Tab characters are inserted rather than space characters when
 `kotl-mode:tab-flag' is non-nil.  Default value is t.  The value
 of this variable is local to each Koutline buffer."
@@ -47,7 +47,7 @@ of this variable is local to each Koutline buffer."
   :group 'hyperbole-koutliner)
 
 (defcustom kotl-mode:refill-flag nil
-  "*Non-nil means automatically refill cells during operations.
+  "Non-nil means automatically refill cells during operations.
 Operations are move, copy, promotion and demotion.  Default value
 is nil.  Cells with a `no-fill' attribute are never refilled
 during such operations, regardless of the value of this flag."
@@ -55,7 +55,7 @@ during such operations, regardless of the value of this flag."
   :group 'hyperbole-koutliner)
 
 (defcustom kotl-mode:shrink-region-flag nil
-  "*Non-nil means Koutliner commands automatically shrink the region.
+  "Non-nil means Koutliner commands automatically shrink the region.
 The region is shrinked within the visible bounds of a single cell
 before editing it.  The region then falls within the first
 visible cell that was part of the region or that followed it.
@@ -64,7 +64,7 @@ Default value is nil."
   :group 'hyperbole-koutliner)
 
 (defcustom kotl-mode:tab-flag nil
-  "*Non-nil means {\\[kotl-mode:tab-command]} inserts a literal tab character and {\\[kotl-mode:untab-command]} deletes backward.
+  "Non-nil means {\\[kotl-mode:tab-command]} inserts a literal tab character and {\\[kotl-mode:untab-command]} deletes backward.
 Nil means {\\[kotl-mode:tab-command]} demotes the current tree and
 {\\[kotl-mode:untab-command]} promotes the tree.  The default is nil."
   :type 'boolean

--- a/kotl/kview.el
+++ b/kotl/kview.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    6/30/93
-;; Last-Mod:     20-Jun-25 at 00:40:40 by Bob Weiner
+;; Last-Mod:     31-Dec-25 at 16:10:26 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -66,7 +66,7 @@
 (defvar-local kotl-kview nil "Buffer local kview object.")
 
 (defcustom kview:default-blank-lines t
-  "*Default setting of whether to show blank lines between koutline cells.
+  "Default setting of whether to show blank lines between koutline cells.
 A value of t means show them, nil means don't show them.  Default
 value is t."
   :type 'boolean
@@ -79,14 +79,14 @@ value is t."
   "Default number of lines per cell to show.  0, the default, means all lines.")
 
 (defcustom kview:default-label-min-width 4
-  "*Minimum width to which to pad labels in a kotl view.
+  "Minimum width to which to pad labels in a kotl view.
 Labels are padded with spaces on the left.  Default value is 4."
   :type '(integer :match (lambda (_widget value)
 			   (and (integerp value) (> value 1) (<= value 99))))
   :group 'hyperbole-koutliner)
 
 (defcustom kview:default-label-separator ". "
-  "*Default string to insert between label and contents of a kcell.
+  "Default string to insert between label and contents of a kcell.
 Default value is \". \"."
   :type 'string
   :group 'hyperbole-koutliner)
@@ -97,7 +97,7 @@ Default value is \". \"."
   "Koutline view `outline-regexp' value that handles all label formats.")
 
 (defcustom kview:default-label-type 'alpha
-  "*Default label-type to use for new koutlines.  Default value is \\='alpha.
+  "Default label-type to use for new koutlines.  Default value is \\='alpha.
 It must be one of the following symbols:
   alpha           for `1b3' full alphanumeric labels
   id              for `027' permanent idstamp labels
@@ -111,7 +111,7 @@ It must be one of the following symbols:
 ;;  star            for multi-star labeling, e.g. `***'.
 
 (defcustom kview:default-level-indent 3
-  "*Default number of spaces to indent each succeeding level in koutlines.
+  "Default number of spaces to indent each succeeding level in koutlines.
 Default value is 3."
   :type '(integer :match (lambda (_widget value)
 			   (and (integerp value) (> value 0) (<= value 60))))


### PR DESCRIPTION
# What

Remove leading asterix from defcustom docstrings.

# Why

Asterix in docstring has been dropped since Emacs 24.3.

See:
 - https://www.emacswiki.org/emacs/VariableDefinition
 - https://www.gnu.org/software/emacs/manual/html_node/eintr/defvar-and-asterisk.html
 - bug#23392 (https://debbugs.gnu.org/cgi/bugreport.cgi?bug=23392)
