### PR TITLE
Use delimiters for links with space in HyWiki

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,14 @@
+2026-01-05  Mats Lidell  <matsl@gnu.org>
+
+* test/hywiki-tests.el
+    (hywiki-tests--action-key-moves-to-word-and-section): Adopt to changed
+    linked behavior.
+
+* hywiki.el (hywiki-section-to-headline-reference): Remove unused.
+
+* hpath.el (hpath:dashes-to-spaces-markup-anchor): Do not convert in
+    hywiki pages.
+
 2025-12-31  Mats Lidell  <matsl@gnu.org>
 
 * Remove starting asterix from defcustom variable docstrings.

--- a/hpath.el
+++ b/hpath.el
@@ -3,11 +3,11 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Nov-91 at 00:44:23
-;; Last-Mod:     31-Dec-25 at 16:08:46 by Mats Lidell
+;; Last-Mod:      5-Jan-26 at 22:36:32 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
-;; Copyright (C) 1991-2025  Free Software Foundation, Inc.
+;; Copyright (C) 1991-2026  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.
@@ -147,6 +147,8 @@ The format is ${variable}.  Match grouping 1 is the name of the variable.")
 (declare-function kcell-view:indent "kcell-view")
 (declare-function klink:act "klink")
 (declare-function mm-mailcap-command "mm-decode")
+
+(declare-function hywiki-in-page-p "hywiki")
 
 ;;; ************************************************************************
 ;;; MS WINDOWS PATH CONVERSIONS
@@ -1654,7 +1656,8 @@ but locational suffixes within the file are utilized."
 (defun hpath:dashes-to-spaces-markup-anchor (anchor)
   "Replace dashes with spaces in ANCHOR if not a prog mode and no existing spaces."
   (if (or (derived-mode-p 'prog-mode)
-	  (string-match-p "-.* \\| .*-" anchor))
+	  (string-match-p "-.* \\| .*-" anchor)
+          (hywiki-in-page-p))
       anchor
     ;; In Markdown or outline modes '-' characters in `anchor' are
     ;; converted to spaces at the point of definition unless anchor

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,11 +3,11 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Apr-24 at 22:41:13
-;; Last-Mod:     30-Nov-25 at 18:06:52 by Bob Weiner
+;; Last-Mod:      5-Jan-26 at 20:09:54 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
-;; Copyright (C) 2024-2025  Free Software Foundation, Inc.
+;; Copyright (C) 2024-2026  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.
@@ -2997,7 +2997,6 @@ variables."
                            :complete #'hywiki-org-link-complete
 			   :export #'hywiki-org-link-export
 			   :follow #'hywiki-find-referent
-			   :htmlize-link #'hywiki-section-to-headline-reference
 			   :store #'hywiki-org-link-store)
   (org-link-set-parameters "hypb-msg"
                            :follow (lambda (path) (message "Message: %s" path))
@@ -3064,17 +3063,6 @@ at point must return non-nil or this function will return nil."
     (if (eq save-input-word :range)
 	(list word start end)
       word)))
-
-(defun hywiki-section-to-headline-reference ()
-  "Replace file#section dashes with spaces to match to an Org headline.
-Does replacement only when not in a programming mode and section
-contains no spaces."
- (let ((link (get-text-property (point) 'org-link)))
-   (if (and link (string-match "#" link))
-       (let* ((file (substring link 0 (match-beginning 0)))
-              (section (substring link (match-beginning 0))))
-	 (concat file (hpath:dashes-to-spaces-markup-anchor section)))
-     link)))
 
 (defun hywiki-strip-org-link (link-str)
   "Return the hy:HyWikiWord#section part of an Org link string.

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -3,11 +3,11 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    18-May-24 at 23:59:48
-;; Last-Mod:     22-Nov-25 at 13:35:42 by Bob Weiner
+;; Last-Mod:      5-Jan-26 at 21:38:04 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
-;; Copyright (C) 2024-2025  Free Software Foundation, Inc.
+;; Copyright (C) 2024-2026  Free Software Foundation, Inc.
 ;; See the "HY-COPY" file for license information.
 ;;
 ;; This file is part of GNU Hyperbole.
@@ -964,10 +964,10 @@ Both mod-time and checksum must be changed for a test to return true."
                     ("WikiWord#Asection:L1" . "* Asection")
                     ("WikiWord#Asection:L2" . "body A")
                     ("WikiWord#Asection:L2:C2" . "dy A")
-                    ("WikiWord#Bsection-subsection" . "** Bsection subsection")
+                    ("WikiWord#Bsection-subsection" . "** Bsection-subsection")
                     ("WikiWord#Bsection-subsection:L2" . "body B")
                     ("WikiWord#Bsection-subsection:L2:C2" . "dy B")
-                    ("(WikiWord#Bsection subsection)" . "** Bsection subsection")
+                    ("(WikiWord#Csection subsection)" . "*** Csection subsection")
                     ("(WikiWord#Asection)" . "* Asection")
                     )))
       (unwind-protect
@@ -978,8 +978,10 @@ Both mod-time and checksum must be changed for a test to return true."
 First line
 * Asection
 body A
-** Bsection subsection
+** Bsection-subsection
 body B
+*** Csection subsection
+body C
 ")
               (save-buffer))
             ;; Create temp buffers with WikiWord links to the target


### PR DESCRIPTION
# What

Use delimiters for links with space in HyWiki.

# Why

Do no convert links containing dashes to space. Use links as they are
written just like org does. Publishing is thus close to what org
supports and close to how org links are written (without the org link
delimiters.).

# Note

HyWiki links will thus be different from Hyperboles path links where
links can be given either as a delimited string with spaces or a
string where dashes represent space in the linked header. So old
behavior remains there.

Docstrings that mentions dash to space conversion has not been updated
yet. Will do that if we choose this solution.
