### PR TITLE
Use batch-byte+native-compile for eln target

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2026-02-03  Mats Lidell  <matsl@gnu.org>
+
+* Makefile (%.elc): Use batch-byte+native-compile.
+
 2026-02-02  Bob Weiner  <rsw@gnu.org>
 
 * test/hywiki-tests.el (hywiki-tests--edit-string-pairs): Enable two more tests

--- a/Makefile
+++ b/Makefile
@@ -350,7 +350,7 @@ ifeq ($(HYPB_NATIVE_COMP),yes)
 	$(HYPB_ELC_ELN)$(EMACS) --batch --quick \
 	--eval "(progn (add-to-list 'load-path \"$(curr_dir)\") (add-to-list 'load-path \"$(curr_dir)/kotl\"))" \
 	-l bytecomp ${HYPB_BIN_WARN} \
-	-f batch-native-compile $<
+	-f batch-byte+native-compile $<
 else
 %.elc: %.el
 	$(HYPB_ELC)$(EMACS) --batch --quick \


### PR DESCRIPTION
# What

Use batch-byte+native-compile with eln target.

# Why

Without elc files being generated Make does more recompiles than
necessary when the eln target is used.
