### PR TITLE
hywiki-word-highlight-in-current-buffer - Fix to run in proper bufs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,14 @@
+2026-02-15  Bob Weiner  <rsw@gnu.org>
+
+* hywiki.el (hywiki-word-highlight-in-current-buffer): Fix bug that added
+    highlighting hooks to buffers where HyWikiWords are not highlighted.
+    Previously, this function filtered out only minibuffers.  Now it filters
+    out buffers where hywiki-mode is not active.
+            (hywiki-mode-normalize): Add to normalize 'hywiki-mode' args and
+    handle mode toggling.
+            (hywiki-default-mode): Add this customization which determines
+    the state HyWiki is initialized to when Hyperbole is activated.
+
 2026-02-14  Bob Weiner  <rsw@gnu.org>
 
 * hsys-org.el (hsys-org-fix-version): Ensure 'org-install-dir' is a dir and

--- a/hyperbole.el
+++ b/hyperbole.el
@@ -9,7 +9,7 @@
 ;; Maintainer:   Robert Weiner <rsw@gnu.org>
 ;; Maintainers:  Robert Weiner <rsw@gnu.org>, Mats Lidell <matsl@gnu.org>
 ;; Created:      06-Oct-92 at 11:52:51
-;; Last-Mod:     18-Jan-26 at 08:29:42 by Bob Weiner
+;; Last-Mod:     15-Feb-26 at 20:18:18 by Bob Weiner
 ;; Released:     10-Mar-24
 ;; Version:      9.0.2pre
 ;; Keywords:     comm, convenience, files, frames, hypermedia, languages, mail, matching, mouse, multimedia, outlines, tools, wp
@@ -510,8 +510,9 @@ frame, those functions by default still return the prior frame."
   (when (fboundp #'vertico-mouse-mode)
     (add-hook 'vertico-mode-hook (lambda () (vertico-mouse-mode 1))))
   ;;
-  ;; Set HyWiki page auto-HyWikiWord highlighting and `yank-handled-properties'
-  (hywiki-mode :pages)
+  ;; Initialize HyWiki page auto-HyWikiWord highlighting and `yank-handled-properties'
+  ;; based on the `hywiki-default-mode'.
+  (hywiki-mode hywiki-default-mode)
   ;;
   ;; Hyperbole initialization is complete.
   (message "Initializing Hyperbole...done"))


### PR DESCRIPTION
hywiki-default-mode - Add this customization which determines the initial state of HyWiki when Hyperbole is initialized.

hywiki-mode-normalize - Add to normalize 'hywiki-mode' args and handle mode toggling.