### PR TITLE
Activate skipped test that can run in batch mode

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,18 @@
+2026-02-16  Mats Lidell  <matsl@gnu.org>
+
+* test/demo-tests.el:
+* test/hmouse-drv-tests.el:
+* test/hui-select-tests.el:
+* test/hui-tests.el:
+* test/hyrolo-tests.el:
+* test/kotl-mode-tests.el: Activate skipped test that can run in batch mode.
+  * In addition to activating the tests some use of
+    hy-test-helpers:consume-input-events has been removed where it is not
+    needed.
+  * A few tests were blocked by checking quoted strings where the quotes
+    differ between batch and interactive. They have been modified to not verify
+    the part of the message that contains the quotes.
+
 2026-02-15  Mats Lidell  <matsl@gnu.org>
 
 * hywiki.el (hywiki--org-link-html-format): Use

--- a/test/demo-tests.el
+++ b/test/demo-tests.el
@@ -74,7 +74,6 @@
 
 ;; Smart scrolling
 (ert-deftest demo-smart-scrolling-proportional-test ()
-  (skip-unless (not noninteractive))
   (unwind-protect
       (let ((enable-local-variables nil))
         (hypb:display-file-with-logo "DEMO")
@@ -148,12 +147,10 @@
 
 ;; HyRolo
 (ert-deftest demo-hyrolo-test ()
-  (skip-unless (not noninteractive))
   (unwind-protect
       (with-temp-buffer
         (load (expand-file-name "hyrolo-demo.el" hyperb:dir))
         (should (hact 'kbd-key "C-x 4 r work RET"))
-        (hy-test-helpers:consume-input-events)
         (should (string= (buffer-name) hyrolo-display-buffer))
         (should (search-forward "Dunn, John")))
     (hyrolo-demo-quit)))
@@ -414,7 +411,6 @@
     (hy-test-helpers:kill-buffer "DEMO")))
 
 (ert-deftest demo-factorial-ebutton-test ()
-  (skip-unless (not noninteractive))
   (unwind-protect
       (let ((enable-local-variables nil))
         (hypb:display-file-with-logo "DEMO")
@@ -508,37 +504,31 @@
 
 (ert-deftest fast-demo-key-series-dired-other-window ()
   "Action key on `dired-other-window' brings up Dired in the other window."
-  (skip-unless (not noninteractive))
   (with-temp-buffer
     (insert "{M-x dired-other-window RET ${hyperb:dir}/*.el RET}")
     (goto-char 5)
     (action-key)
-    (hy-test-helpers:consume-input-events)
     (should (equal 'dired-mode major-mode))
     (should (equal hyperb:dir (expand-file-name default-directory)))))
 
 (ert-deftest fast-demo-key-series-window-grid-22 ()
   "Action key on window grid key series creates a grid."
-  (skip-unless (not noninteractive))
   (with-temp-buffer
     (insert "{C-c @ 22 RET}")
     (goto-char 3)
     (action-key)
-    (hy-test-helpers:consume-input-events)
     (should (= 4 (length (window-list))))))
 
 (ert-deftest fast-demo-key-series-kotl-files ()
   "Action key brings up kotl files in a grid.
 Note: Depends on key series in FAST-DEMO and how many files in
 hyberbole folder that starts with kotl."
-  (skip-unless (not noninteractive))
   (unwind-protect
       (let ((enable-local-variables nil))
         (hypb:display-file-with-logo "FAST-DEMO")
 	(goto-char (point-min))
         (search-forward "{C--1 C-c @")
         (action-key)
-        (hy-test-helpers:consume-input-events)
         (should (= 4 (length (window-list)))))
     (hy-test-helpers:kill-buffer "FAST-DEMO")))
 
@@ -546,28 +536,23 @@ hyberbole folder that starts with kotl."
   "Action key brings up `emacs-lisp-mode' files in a grid.
 Note: Relies on that empty windows are created when there are not
 enough files with matching mode loaded."
-  (skip-unless (not noninteractive))
   (with-temp-buffer
     (insert "{C-u 0 C-c @ emacs-lisp-mode RET 33 RET}")
     (goto-char 3)
     (action-key)
-    (hy-test-helpers:consume-input-events)
     (should (= 9 (length (window-list))))))
 
 (ert-deftest fast-demo-key-series-hyperbole-dir ()
   "Action key on hyperb:dir brings up hyperbole folder."
-  (skip-unless (not noninteractive))
   (with-temp-buffer
     (insert "{C-x 4 d ${hyperb:dir} RET}")
     (goto-char 5)
     (action-key)
-    (hy-test-helpers:consume-input-events)
     (should (equal 'dired-mode major-mode))
     (should (equal hyperb:dir (expand-file-name default-directory)))))
 
 (ert-deftest fast-demo-key-series-keep-lines-ext ()
   "Action key opens Ibuffer and keep lines with extension."
-  (skip-unless (not noninteractive))
   (let ((buff "*Ibuffer*")
         (old (global-key-binding (kbd "C-x C-b")))
         (tmp (make-temp-file "hypb" nil ".hypb-test")))
@@ -578,7 +563,6 @@ enough files with matching mode loaded."
           (insert "{C-x C-b C-x C-q M-x keep-lines RET .hypb-test$ RET C-x C-q}")
           (goto-char 5)
           (action-key)
-          (hy-test-helpers:consume-input-events)
           (with-current-buffer buff
             (should (looking-at-p (concat ".*" tmp)))))
       (hy-test-helpers:kill-buffer buff)
@@ -588,7 +572,6 @@ enough files with matching mode loaded."
 
 (ert-deftest fast-demo-key-series-keep-lines-slash ()
   "Action key opens Ibuffer and keep lines that contains a slash."
-  (skip-unless (not noninteractive))
   (let ((buff "*Ibuffer*")
         (old (global-key-binding (kbd "C-x C-b")))
         (dir (dired hyperb:dir)))
@@ -598,7 +581,6 @@ enough files with matching mode loaded."
           (insert "{C-x C-b C-x C-q M-x keep-lines RET [\\/]$ RET C-x C-q}")
           (goto-char 5)
           (action-key)
-          (hy-test-helpers:consume-input-events)
           (with-current-buffer buff
             (should (looking-at-p (concat ".*[\\/]")))))
       (hy-test-helpers:kill-buffer buff)
@@ -617,7 +599,6 @@ enough files with matching mode loaded."
           (insert "{C-x C-b / RET dired-mode RET}")
           (goto-char 5)
           (action-key)
-          (hy-test-helpers:consume-input-events)
           (with-current-buffer buff
             (should (looking-at-p (concat ".*Dired by name")))))
       (hy-test-helpers:kill-buffer buff)
@@ -637,7 +618,6 @@ enough files with matching mode loaded."
           (insert "{ M-x shell RET M-> (cd ${hyperb:dir} && echo && echo \"PWD=$(pwd)\") RET }")
           (goto-char 5)
           (action-key)
-          (hy-test-helpers:consume-input-events)
           (with-current-buffer shell-buffer-name
             (goto-char (point-max))
             (accept-process-output (get-buffer-process shell-buffer-name) 1)
@@ -650,7 +630,6 @@ enough files with matching mode loaded."
 
 (ert-deftest fast-demo-key-series-shell-grep ()
   "Action key executes grep shell command."
-  (skip-unless (not noninteractive))
   (let* ((shell-file-name (executable-find "sh"))
          (shell-buffer-name "*shell*")
 	 (existing-shell-flag (get-buffer-process shell-buffer-name)))
@@ -659,7 +638,6 @@ enough files with matching mode loaded."
           (insert "{M-x shell RET M-> (export HYPERBOLE_DIR=${hyperb:dir} && cd $HYPERBOLE_DIR && grep -n gbut:label-list *.el) RET}")
           (goto-char 5)
           (action-key)
-          (hy-test-helpers:consume-input-events)
           (with-current-buffer shell-buffer-name
             (with-timeout (5 (ert-fail "Test timed out"))
               (while (not (string-match-p "\n.*\\.el:[0-9]+:.*defun.*gbut:label-list ()" (buffer-substring-no-properties (point-min) (point-max))))
@@ -707,7 +685,6 @@ enough files with matching mode loaded."
           (goto-char 5)
           (view-mode)
           (action-key)
-          (hy-test-helpers:consume-input-events)
           (with-current-buffer shell-buffer-name
             (goto-char (point-max))
             (accept-process-output (get-buffer-process shell-buffer-name) 1)
@@ -720,7 +697,6 @@ enough files with matching mode loaded."
 
 (ert-deftest fast-demo-key-series-shell-grep-view-mode ()
   "Action key executes grep shell command from buffer in `view-mode`."
-  (skip-unless (not noninteractive))
   (let* ((shell-file-name (executable-find "sh"))
          (shell-buffer-name "*shell*")
 	 (existing-shell-flag (get-buffer-process shell-buffer-name)))
@@ -730,7 +706,6 @@ enough files with matching mode loaded."
           (goto-char 5)
           (view-mode)
           (action-key)
-          (hy-test-helpers:consume-input-events)
           (with-current-buffer shell-buffer-name
             (with-timeout (5 (ert-fail "Test timed out"))
               (while (not (string-match-p "\n.*\\.el:[0-9]+:.*defun.*gbut:label-list ()"

--- a/test/hmouse-drv-tests.el
+++ b/test/hmouse-drv-tests.el
@@ -63,7 +63,6 @@
     (ibtype:delete 'ibtypes::defal-url)))
 
 (ert-deftest hbut-defal-key-sequence ()
-  (skip-unless (not noninteractive))
   (defal defal-key "{C-h v \\1 RET}")
   (unwind-protect
       (with-temp-buffer
@@ -137,7 +136,6 @@
     (ibtype:delete 'ibtypes::defil-url)))
 
 (ert-deftest hbut-defil-key-sequence ()
-  (skip-unless (not noninteractive))
   (defil defil-key "<<<" ">>>" ".*" "{C-h v \\& RET}")
   (unwind-protect
       (with-temp-buffer

--- a/test/hui-select-tests.el
+++ b/test/hui-select-tests.el
@@ -81,7 +81,6 @@
 
 (ert-deftest hui-select--thing ()
   "`hui-select-thing' selects bigger sections of text when called repeatedly."
-  (skip-unless (not noninteractive))
   (hui-select-reset)
   (with-temp-buffer
     (insert "Buffer\n\nParagraph\nline.  One word.")
@@ -120,12 +119,11 @@
     ;; error
     (ert-with-message-capture cap
       (should-not (hui-select-thing))
-      (hy-test-helpers:should-last-message "(hui-select-boundaries): ‘buffer’ is the largest selectable region" cap))))
+      (hy-test-helpers:should-last-message "the largest selectable region" cap))))
 
 (ert-deftest hui-select--thing-interactive-prints-type-of-match ()
   "`hui-select-thing' selects bigger sections of text when called repeatedly.
 Verifies right type of match is printed when `hui-select-display-type' is set to t."
-  (skip-unless (not noninteractive))
   (let ((hui-select-display-type t))
     (hui-select-reset)
     (with-temp-buffer
@@ -167,7 +165,7 @@ Verifies right type of match is printed when `hui-select-display-type' is set to
 
       (ert-with-message-capture cap
         (should-not (call-interactively 'hui-select-thing))
-        (hy-test-helpers:should-last-message "(hui-select-boundaries): ‘buffer’ is the largest selectable region" cap)))))
+        (hy-test-helpers:should-last-message "the largest selectable region" cap)))))
 
 (provide 'hui-select-tests)
 ;;; hui-select-tests.el ends here

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -518,7 +518,6 @@ of the defun."
 
 (ert-deftest hui--copy-to-register--yank-in-same-kotl ()
   "Yank klink in register into same kotl file."
-  (skip-unless (not noninteractive))
   (let ((kotl-file (make-temp-file "hypb" nil ".kotl")))
     (unwind-protect
         (progn
@@ -541,7 +540,6 @@ of the defun."
 
 (ert-deftest hui--copy-to-register--yank-in-other-kotl ()
   "Yank klink in register into other kotl file."
-  (skip-unless (not noninteractive))
   (let ((kotl-file (make-temp-file "hypb" nil ".kotl"))
         (other-file (make-temp-file "hypb" nil ".kotl")))
     (unwind-protect
@@ -567,7 +565,6 @@ of the defun."
 
 (ert-deftest hui--copy-to-register--yank-in-other-file ()
   "Yank klink in regiuster into other file."
-  (skip-unless (not noninteractive))
   (let ((kotl-file (make-temp-file "hypb" nil ".kotl"))
         (other-file (make-temp-file "hypb" nil ".txt")))
     (unwind-protect
@@ -592,7 +589,6 @@ of the defun."
 
 (ert-deftest hui--copy-to-register--yank-in-other-file-other-dir ()
   "Yank klink in register into other file in other dir."
-  (skip-unless (not noninteractive))
   (let* ((kotl-file (make-temp-file "hypb" nil ".kotl"))
          (other-dir (make-temp-file "hypb" t))
          (other-file (expand-file-name "other-file" other-dir)))

--- a/test/hyrolo-tests.el
+++ b/test/hyrolo-tests.el
@@ -47,12 +47,10 @@
 
 (ert-deftest hyrolo-demo-search-work ()
   "Use demo example and search for work should match work."
-  (skip-unless (not noninteractive))
   (unwind-protect
       (progn
         (load "../hyrolo-demo")
         (should (hact 'kbd-key "C-x 4r work RET"))
-        (hy-test-helpers:consume-input-events)
         (should (string= (buffer-name) hyrolo-display-buffer))
         (should (looking-at "======"))
         (forward-line 5)
@@ -61,24 +59,20 @@
 
 (ert-deftest hyrolo-demo-tab-jump-to-first-match ()
   "{TAB} shall jump to first match."
-  (skip-unless (not noninteractive))
   (unwind-protect
       (progn
         (load "../hyrolo-demo")
         (should (hact 'kbd-key "C-x 4r work RET TAB"))
-        (hy-test-helpers:consume-input-events)
         (should (string= (buffer-name) hyrolo-display-buffer))
         (should (looking-at "Work")))
     (hyrolo-demo-quit)))
 
 (ert-deftest hyrolo-demo-toggle-visibility ()
   "Keys {h} and {a} shall toggle visibility."
-  (skip-unless (not noninteractive))
   (unwind-protect
       (progn
         (load "../hyrolo-demo")
         (should (hact 'kbd-key "C-x 4r work RET TAB"))
-        (hy-test-helpers:consume-input-events)
         (should (string= (buffer-name) hyrolo-display-buffer))
         (should (looking-at "Work"))
 
@@ -99,17 +93,14 @@
 
 (ert-deftest hyrolo-demo-show-overview ()
   "Key {o} shall show overview."
-  (skip-unless (not noninteractive))
   (unwind-protect
       (progn
         (load "../hyrolo-demo")
         (should (hact 'kbd-key "C-x 4r work RET TAB"))
-        (hy-test-helpers:consume-input-events)
         (should (string= (buffer-name) hyrolo-display-buffer))
         (should (looking-at "work"))
 
         (should (hact 'kbd-key "o"))
-        (hy-test-helpers:consume-input-events)
 	(forward-line 1)
         (end-of-line)
         (should (get-char-property (point) 'invisible))
@@ -122,12 +113,10 @@
 
 (ert-deftest hyrolo-demo-move-to-beginning-and-end-of-file ()
   "*HyRolo* keys {<} and {>} move to begin and end of file, respectively."
-  (skip-unless (not noninteractive))
   (unwind-protect
       (progn
         (load "../hyrolo-demo")
         (should (hact 'kbd-key "C-x 4r work RET TAB"))
-        (hy-test-helpers:consume-input-events)
         (should (string= (buffer-name) hyrolo-display-buffer))
         (should (looking-at "work"))
 
@@ -140,32 +129,26 @@
 
 (ert-deftest hyrolo-demo-move-to-beginning-and-end-of-entry ()
   "*HyRolo* keys {,} and {.} move to begin and end of an entry, respectively."
-  (skip-unless (not noninteractive))
   (unwind-protect
       (progn
         (load "../hyrolo-demo")
         (should (hact 'kbd-key "C-x 4r work RET TAB"))
-        (hy-test-helpers:consume-input-events)
         (should (string= (buffer-name) hyrolo-display-buffer))
 
         (should (hact 'kbd-key "\C-u,n"))
-        (hy-test-helpers:consume-input-events)
 	(should (looking-at "\\*\\*\\s-+Hansen"))
 
         (should (hact 'kbd-key "."))
-        (hy-test-helpers:consume-input-events)
 	(should (looking-at "\\s-?\\*\\*\\*\\s-+Dunn")))
     (hyrolo-demo-quit)))
 
 (ert-deftest hyrolo-demo-move-between-entries-on-same-level ()
   "Key {n} shall move to the next cell, {f} the next same level cell,
 and {b} the previous same level cell."
-  (skip-unless (not noninteractive))
   (unwind-protect
       (progn
         (load "../hyrolo-demo")
         (should (hact 'kbd-key "C-x 4r com RET TAB"))
-        (hy-test-helpers:consume-input-events)
         (should (string= (buffer-name) hyrolo-display-buffer))
         (should (hact 'kbd-key "<"))
         (should (equal (point) (point-min)))
@@ -182,12 +165,10 @@ and {b} the previous same level cell."
 
 (ert-deftest hyrolo-demo-no-following-same-level-heading ()
   "Error when trying to move to non existing next level heading."
-  (skip-unless (not noninteractive))
   (unwind-protect
       (progn
         (load "../hyrolo-demo")
         (should (hact 'kbd-key "C-x 4r com RET TAB"))
-        (hy-test-helpers:consume-input-events)
 
         (should (string= (buffer-name) hyrolo-display-buffer))
         (should (hact 'kbd-key "<"))
@@ -1349,8 +1330,6 @@ body
                    (hyrolo-tests--outline-as-string)))
 
           (should (hact 'kbd-key "TAB"))
-	  (hy-test-helpers:consume-input-events)
-	  (hy-test-helpers:consume-input-events)
           (should (string=
                    (concat (hyrolo-tests--hyrolo-section-header org-file1)
                            "* h-org 1\nbody\n** h-org 1.1\nbody\n** h-org 1.2\nbody\n*** h-org 1.2.1\nbody\n* h-org 2...\n")
@@ -1385,7 +1364,6 @@ body
           ;;          (hyrolo-tests--outline-as-string)))
 
           (should (hact 'kbd-key "f TAB"))
-          (hy-test-helpers:consume-input-events)
           (should (string=
                    (concat (hyrolo-tests--hyrolo-section-header org-file1)
                            "* h-org 1\nbody\n** h-org 1.1\nbody\n** h-org 1.2\nbody\n*** h-org 1.2.1\nbody\n* h-org 2\nbody\n** h-org 2.1\nbody\n")

--- a/test/kotl-mode-tests.el
+++ b/test/kotl-mode-tests.el
@@ -71,7 +71,6 @@
 
 (ert-deftest kotl-mode-indent-cell-changes-level ()
   "Loading kotl-mode example file works."
-  (skip-unless (not noninteractive))
   (setup-kotl-mode-example-test
    (kotl-mode:example temporary-file-directory t)
    (kotl-mode:beginning-of-buffer)
@@ -95,7 +94,6 @@
 
 (ert-deftest kotl-mode-set-view-with-kbd ()
   "When the view mode is changed the label is changed too."
-  (skip-unless (not noninteractive))
   (let ((kotl-file (make-temp-file "hypb" nil ".kotl")))
     (unwind-protect
         (progn
@@ -525,7 +523,6 @@
 
 (ert-deftest kotl-mode-backward-cell-from-invalid-pos-leave-point-in-valid-pos ()
   "From invalid pos backward cell leaves point in valid pos on error."
-  (skip-unless (not noninteractive))
   (let ((kotl-file (make-temp-file "hypb" nil ".kotl")))
     (unwind-protect
         (progn
@@ -831,7 +828,6 @@ In non interactive mode there shall be no beep (nor message)"
 
 (ert-deftest kotl-mode-move-up-to-first-line ()
   "Move up to first line shall succeed with no beep nor message."
-  (skip-unless (not noninteractive))
   (let ((kotl-file (make-temp-file "hypb" nil ".kotl")))
     (unwind-protect
         (progn
@@ -877,7 +873,6 @@ In non-interactive mode there shall be no beep nor message."
 
 (ert-deftest kotl-mode-move-down-to-last-line-shall-not-beep ()
   "Moving down to last line shall not beep."
-  (skip-unless (not noninteractive))
   (let ((kotl-file (make-temp-file "hypb" nil ".kotl")))
     (unwind-protect
         (progn


### PR DESCRIPTION
# What

Activate skipped test that can run in batch mode.

* test/demo-tests.el:
* test/hmouse-drv-tests.el:
* test/hui-select-tests.el:
* test/hui-tests.el:
* test/hyrolo-tests.el:
* test/kotl-mode-tests.el: Activate skipped test that can run in batch mode.
  * In addition to activating the tests some use of
    hy-test-helpers:consume-input-events has been removed where it is not
    needed.
  * A few tests were blocked by checking quoted strings where the quotes
    differ between batch and interactive. They have been modified to not verify
    the part of the message that contains the quotes.

# Why

While cleanup some tests I noticed that I could get them to run in
batch mode by just activating them. Not sure why and when they started
to work in batch mode but they do now. We'll see what CI/CD says!

And having more tests work in batch mode is a good thing.
