### PR TITLE
Use default value for face test flag

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2026-02-17  Mats Lidell  <matsl@gnu.org>
+
+* test/hywiki-tests.el (hywiki-tests--verify-removal-of-delimiter-updates-face):
+    (hywiki-tests--wikiword-yanked-with-extra-words):
+    (hywiki-tests--create-wikiword-file-highlights-wikiword): Use
+    hywiki-tests--with-face-test default value.
+* test/hywiki-yki-tests.el (hywiki--verify-get-buffer-text-with-point-and-highlight-compact):
+    Use hywiki-tests--with-face-test default value. Let
+    hywiki-tests--preserve-hywiki-mode handle wikiword file and hywiki-directory.
+
 2026-02-16  Mats Lidell  <matsl@gnu.org>
 
 * test/demo-tests.el:

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -1828,8 +1828,7 @@ face is verified during the change."
 (ert-deftest hywiki-tests--verify-removal-of-delimiter-updates-face ()
   "Verify WikiWord highlight face change when adding/removing a delimiter."
   (hywiki-tests--preserve-hywiki-mode
-    (let ((hywiki-tests--with-face-test t)
-	  (hi-page (cdr (hywiki-add-page "Hi"))))
+    (let ((hi-page (cdr (hywiki-add-page "Hi"))))
       (unwind-protect
 	  (dolist (testcase
 		   '((("\"Hi#a b c\"" . "Hi#a b c") (p3 . "Hi#a b c")
@@ -1843,8 +1842,7 @@ face is verified during the change."
   "Verify that a yanked in WikiWord highlights properly."
   (hywiki-tests--preserve-hywiki-mode
     (let* ((wikiHi (cdr (hywiki-add-page "Hi")))
-           (wikiHo (cdr (hywiki-add-page "Ho")))
-           (hywiki-tests--with-face-test t))
+           (wikiHo (cdr (hywiki-add-page "Ho"))))
       (unwind-protect
           (progn
             ;; Left part of WikiWord yanked in.
@@ -1897,7 +1895,6 @@ face is verified during the change."
   "Verify creating a WikiWord-file highlights the WikiWord in another file."
   (hywiki-tests--preserve-hywiki-mode
     (let* ((wikiHi (cdr (hywiki-add-page "Hi")))
-           (hywiki-tests--with-face-test t)
            wikiHo)
       (unwind-protect
           (progn

--- a/test/hywiki-yki-tests.el
+++ b/test/hywiki-yki-tests.el
@@ -160,13 +160,9 @@ Each test is constructed as three phases:
   `buffer-string' as a string is constructed where chars are used for
   point, and start and stop of the highlighting with angle brackets.
   That is then compared to the expected string."
-  (skip-unless (not noninteractive))    ; Only works in interactive mode for now
   (hywiki-tests--preserve-hywiki-mode
-   (let* ((hywiki-directory (make-temp-file "hywiki" t))
-          (wikiHi (cdr (hywiki-add-page "Hi")))
-          (wikiHo (cdr (hywiki-add-page "Ho")))
-          (wikiWord (cdr (hywiki-add-page "WikiWord")))
-          (hywiki-tests--with-face-test t))
+   (let* ((wikiHi (cdr (hywiki-add-page "Hi")))
+          (wikiHo (cdr (hywiki-add-page "Ho"))))
      (cl-flet* ((pre: (start)
                   (hywiki-test--set-buffer-text-with-point-and-highlight start))
                 (exec: (cmd &rest args)
@@ -267,8 +263,7 @@ Each test is constructed as three phases:
                (del:           "<abc> abc")
                (post: "<WikiWord> ^ <WikiWord>")))
 
-         (hy-delete-files-and-buffers (list wikiHi wikiHo wikiWord))
-         (hywiki-tests--delete-hywiki-dir-and-buffer hywiki-directory))))))
+         (hy-delete-files-and-buffers (list wikiHi wikiHo)))))))
 
 (provide 'hywiki-yki-tests)
 


### PR DESCRIPTION
# What

Use default value for face test flag.

* test/hywiki-tests.el (hywiki-tests--verify-removal-of-delimiter-updates-face):
    (hywiki-tests--wikiword-yanked-with-extra-words):
    (hywiki-tests--create-wikiword-file-highlights-wikiword): Use
    hywiki-tests--with-face-test default value.
* test/hywiki-yki-tests.el (hywiki--verify-get-buffer-text-with-point-and-highlight-compact):
    Use hywiki-tests--with-face-test default value. Let
    hywiki-tests--preserve-hywiki-mode handle wikiword file and hywiki-directory.

# Why

The face test flag is per default t so we should only set it to nil in
the cases where we don't want to verify the face. This is a left over
from the initial test for faces where the highlighting did not work
properly.

The hywiki-tests--preserve-hywiki-mode macro handles the removal of
the hywiki-directory and also creates the first WikiWord for the
tests. Test should just use that when applicable.
