### PR TITLE
Silence byte compile warnings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2026-02-18  Mats Lidell  <matsl@gnu.org>
+
+* hsys-org.el: require 'find-func for find-library--from-load-history.
+
+* hui-mini.el (hywiki-mode):
+* hyrolo.el (hywiki-mode): Defvar.
+
+* hywiki.el (hywiki-potential-buffer-p, hywiki-word-from-reference): Fix
+    quotes.
+
 2026-02-17  Mats Lidell  <matsl@gnu.org>
 
 * test/hywiki-tests.el (hywiki-tests--verify-removal-of-delimiter-updates-face):

--- a/hsys-org.el
+++ b/hsys-org.el
@@ -41,6 +41,7 @@
 (require 'org-macs)
 (require 'package)
 (require 'warnings)
+(require 'find-func)
 ;; Avoid any potential library name conflict by giving the load directory.
 (require 'set (expand-file-name "set" hyperb:dir))
 

--- a/hui-mini.el
+++ b/hui-mini.el
@@ -38,6 +38,7 @@
 (defvar hyrolo-add-hook)                ; "hyrolo.el"
 (defvar hyrolo-edit-hook)               ; "hyrolo.el"
 (defvar hyrolo-file-list)               ; "hyrolo.el"
+(defvar hywiki-mode)                    ; "hywiki.el"
 (defvar org-mode-map)                   ; "org.el"
 
 (declare-function hpath:find "hpath")

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -89,14 +89,15 @@
 (declare-function org-outline-level "org")
 
 (defvar consult-preview-key)            ; "ext:consult.el"
+(defvar google-contacts-buffer-name)    ; "ext:google-contacts.el"
+(defvar hbut:source-prefix)             ; "hbut.el"
+(defvar hywiki-mode)                    ; "hywiki.el"
+(defvar org-agenda-buffer-tmp-name)     ; "org-agenda.el"
 (defvar org-directory)                  ; "org.el"
 (defvar org-mode-map)                   ; "org-keys.el"
 (defvar org-mode-syntax-table)          ; "org.el"
 (defvar org-outline-regexp)             ; "org.el"
 (defvar org-outline-regexp-bol)         ; "org.el"
-(defvar org-agenda-buffer-tmp-name)     ; "org-agenda.el"
-(defvar google-contacts-buffer-name)    ; "ext:google-contacts.el"
-(defvar hbut:source-prefix)             ; "hbut.el"
 
 ;; markdown-mode.el
 (defvar markdown-regex-header)

--- a/hywiki.el
+++ b/hywiki.el
@@ -1103,7 +1103,7 @@ Exclude the minibuffer if selected and return nil."
   "Return non-nil if the current buffer can support HyWikiWords.
 Always exclude minibuffers.
 This does not mean `hywiki-mode' is presently active in that buffer;
-use 'hywiki-active-in-current-buffer-p' for that."
+use `hywiki-active-in-current-buffer-p' for that."
 
   (and (not (minibufferp))
        ;; (not (and (boundp 'edebug-active) edebug-active))
@@ -3710,9 +3710,9 @@ Default to any HyWikiWord at point."
 (defun hywiki-word-from-reference (ref)
   "Return the HyWikiWord part of a reference (part before the #).
 This does not test whether a referent exists for the HyWikiWord; call
-‘hywiki-referent-exists-p’ without an argument for that.  Nor does it
+`hywiki-referent-exists-p' without an argument for that.  Nor does it
 test whether the HyWikiWord reference is within an invalid context;
-call ‘hywiki-non-hook-context-p’ for that."
+call `hywiki-non-hook-context-p' for that."
   (when (and (stringp ref)
 	     (string-match hywiki-word-with-optional-suffix-exact-regexp ref))
     (match-string 1 ref)))


### PR DESCRIPTION
# What

Silence byte compile warnings

* hsys-org.el: require 'find-func for find-library--from-load-history.
* hui-mini.el (hywiki-mode):
* hyrolo.el (hywiki-mode): Defvar.
* hywiki.el (hywiki-potential-buffer-p):
  (hywiki-word-from-reference): Fix quotes.

# Why

We want a clean byte compile with no warnings.
