### PR TITLE
Do not copy elc files to hyperbole docker folder

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2026-03-04  Mats Lidell  <matsl@gnu.org>
+
+* Makefile (docker): Remove all elc files in the docker container.
+
 2026-03-03  Mats Lidell  <matsl@gnu.org>
 
 * hload-path.el (hload-path--make-directory-autoloads): Use Emacs provided

--- a/Makefile
+++ b/Makefile
@@ -651,7 +651,8 @@ recompile-docker-elpa:
 
 docker: docker-update
 	docker run --mount type=volume,src=elpa-local,dst=/root/.emacs.d/elpa \
-	-v $$(pwd):/hypb -v /tmp:/hypb-tmp -it --rm silex/emacs:${DOCKER_VERSION} bash -c "cp -a /hypb /hyperbole && make -C hyperbole recompile-docker-elpa ${DOCKER_TARGETS}"
+	-v $$(pwd):/hypb -v /tmp:/hypb-tmp -it --rm silex/emacs:${DOCKER_VERSION} \
+	bash -c "cp -a /hypb /hyperbole && find /hyperbole -name '*.elc' -delete && make -C hyperbole recompile-docker-elpa ${DOCKER_TARGETS}"
 
 docker-run: docker-update
 	docker run --mount type=volume,src=elpa-local,dst=/root/.emacs.d/elpa \


### PR DESCRIPTION
# What

Do not copy elc files to hyperbole docker folder.

# Why

When using the docker target, elc files from the local workspace would be
brought over which caused subtle errors due to elc files not being backwards
compatible.

* Makefile (docker): Remove all elc files in the docker container.
