### PR TITLE
Use with-locale-environment if defined else use current locale

### DIFF
--- a/man/.dir-locals.el
+++ b/man/.dir-locals.el
@@ -1,20 +1,24 @@
 ((texinfo-mode
   . ((before-save-hook
       . (lambda ()
-          (with-locale-environment "en_US.utf8"
-            (let ((day (string-trim (format-time-string "%e" (current-time))))
-                  (month (capitalize (format-time-string "%B" (current-time))))
-                  (year (format-time-string "%Y" (current-time))))
-              (save-excursion
-                (goto-char (point-min))
-                (when (re-search-forward "\\(@set UPDATED [[:word:]]+ [[:digit:]]+, [[:digit:]]+\\)" nil t)
-                  (replace-match (format "@set UPDATED %s %s, %s" month day year) nil t nil nil))
-                (goto-char (point-min))
-                (when (re-search-forward "\\(@set UPDATED-MONTH [[:word:]]+ [[:digit:]]+\\)" nil t)
-                  (replace-match (format "@set UPDATED-MONTH %s %s" month year) nil t nil nil))
-                (goto-char (point-min))
-                (when (re-search-forward "\\(Printed [[:word:]]+ [[:digit:]]+, [[:digit:]]+\.\\)" nil t)
-                  (replace-match (format "Printed %s %s, %s." month day year) nil t nil nil))
-                (goto-char (point-min))
-                (when (re-search-forward "\\([[:word:]]+ [[:digit:]]+, [[:digit:]]+ @c AUTO-REPLACE-ON-SAVE\\)" nil t)
-                  (replace-match (format "%s %s, %s @c AUTO-REPLACE-ON-SAVE" month day year) nil t nil nil))))))))))
+          (let ((our-set-env
+                 (lambda () (let ((day (string-trim (format-time-string "%e" (current-time))))
+                                  (month (capitalize (format-time-string "%B" (current-time))))
+                                  (year (format-time-string "%Y" (current-time))))
+                              (save-excursion
+                                (goto-char (point-min))
+                                (when (re-search-forward "\\(@set UPDATED [[:word:]]+ [[:digit:]]+, [[:digit:]]+\\)" nil t)
+                                  (replace-match (format "@set UPDATED %s %s, %s" month day year) nil t nil nil))
+                                (goto-char (point-min))
+                                (when (re-search-forward "\\(@set UPDATED-MONTH [[:word:]]+ [[:digit:]]+\\)" nil t)
+                                  (replace-match (format "@set UPDATED-MONTH %s %s" month year) nil t nil nil))
+                                (goto-char (point-min))
+                                (when (re-search-forward "\\(Printed [[:word:]]+ [[:digit:]]+, [[:digit:]]+\.\\)" nil t)
+                                  (replace-match (format "Printed %s %s, %s." month day year) nil t nil nil))
+                                (goto-char (point-min))
+                                (when (re-search-forward "\\([[:word:]]+ [[:digit:]]+, [[:digit:]]+ @c AUTO-REPLACE-ON-SAVE\\)" nil t)
+                                  (replace-match (format "%s %s, %s @c AUTO-REPLACE-ON-SAVE" month day year) nil t nil nil)))))))
+            (if (fboundp 'with-locale-environment)
+                (with-locale-environment "en_US.utf8"
+                  (funcall our-set-env))
+              (funcall our-set-env))))))))


### PR DESCRIPTION
# What

Use with-locale-environment if defined else use current locale.

# Why

For Emacs 28 with-locale-environment is not defined. For that
situation just use the current locale.

# Note

This solution with setting the locale is admittedly not very solid
since it also depend on that the locale en_US.utf8 is defined. So
maybe another approach should be taken for getting the dates updated
in the proper locale.

This PR is, if nothing else, a quick fix for letting Emacs 28 with a
proper locale work fine for editing the Hyperbole texi manual.
