### PR TITLE
Add more hyrolo movement tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2026-04-10  Mats Lidell  <matsl@gnu.org>
+
+* test/hyrolo-tests.el (hyrolo-tests--fgrep-move-test): Add more tests for
+    movement when a section is hidden.
+
 2026-04-08  Bob Weiner  <rsw@gnu.org>
 
 * test/hyrolo-tests.el (hyrolo-tests--fgrep-move-test): Move tests more

--- a/test/hyrolo-tests.el
+++ b/test/hyrolo-tests.el
@@ -461,6 +461,7 @@ Match a string in the second cell."
 
 (ert-deftest hyrolo-tests--fgrep-move-test ()
   "Verify different move commands after `hyrolo-fgrep'."
+  :expected-result :failed
   (let* ((kotl-file1 (hyrolo-tests--gen-kotl-outline "heading" "foo bar" 1))
          (kotl-file2 (hyrolo-tests--gen-kotl-outline "heading" "foo bar" 1))
          (hyrolo-file-list (list kotl-file1 kotl-file2))
@@ -483,8 +484,37 @@ Match a string in the second cell."
             (execute-kbd-macro (kbd "n"))
             (should (eobp)))
 
+          (ert-info ("With hidden first header move up using ?p")
+            (execute-kbd-macro (kbd "p"))
+            (should (looking-at-p h1a_str))
+            (execute-kbd-macro (kbd "p"))
+            (should (looking-at-p h1_str))
+            (execute-kbd-macro (kbd "p"))
+            (should (looking-at-p "==="))
+            (execute-kbd-macro (kbd "p"))
+            (should (looking-at-p "==="))
+            (should (bobp)))
+
+          (ert-info ("With hidden first header move down using ?f")
+            (should (looking-at-p "==="))
+            (execute-kbd-macro (kbd "f"))
+            (should (looking-at-p "==="))
+            (execute-kbd-macro (kbd "f"))
+            (should (looking-at-p h1_str))
+            (let ((err (should-error (execute-kbd-macro (kbd "f")))))
+              (should (string-match-p "No following same-level heading/header" (cadr err)))))
+
+          (ert-info ("With hidden first header move up using ?b")
+            (execute-kbd-macro (kbd "b"))
+            (should (looking-at-p "==="))
+            (execute-kbd-macro (kbd "b"))
+            (should (looking-at-p "==="))
+            (should (bobp))
+            (let ((err (should-error (execute-kbd-macro (kbd "b")))))
+              (should-not (equal '(void-function nil) err)))) ;FIXME: No error message but void-function!?
+
           (outline-show-all)
-          (goto-char (point-min))
+
           (ert-info ("Move down using ?n")
             (should (looking-at-p "==="))
             (execute-kbd-macro (kbd "n"))


### PR DESCRIPTION
# What

Add more hyrolo movement tests.

* test/hyrolo-tests.el (hyrolo-tests--fgrep-move-test): Add more tests
for movement when a section is hidden.

# Why

Adding more movement cases. 

One error case is added so the test is marked as expected failed. On
moving up using {b} from the first line gives an error message
(void-function nil) which seems wrong. Should be an error message such
as for {f} moving down or just don't move and not error as is the case
for {n} and {p}.

The test is designed to work when that error is changed but should be
checking the proper error message is shown of course when it is
finalized.
