### PR TITLE
hpath:find and ibtype pathname - Fix to ignore # followed by punc; hywiki-cache-save - Suppress save buffer msgs and test file backups

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,15 @@
 2026-04-12  Bob Weiner  <rsw@gnu.org>
 
+* hywiki.el (hywiki-cache-save):
+  test/hy-test-helpers.el (hy-delete-file-and-buffer): Suppress echo area and
+    *Messages* output of 'Wrote <filename' and use 'basic-save-buffer' instead
+    of 'save-buffer' to reduce backup files, etc.
+  hypb.el (hypb:save-buffer-silently): Add and use in 'hywiki-cache-save' and
+    throughout Hyperbole tests.
+
+* test/hywiki-tests.el (hywiki-tests--save-referent-info-node-use-menu): Change
+    match to Info node from "(emacs)" to "(emacs)*" to get it to match.
+
 * hibtypes.el (pathname): Eliminate matches to Elisp quoted symbols like
     #'symbol or any use of quote marks after the leading optional # character.
   hpath.el (hpath:find): Don't match as an anchor unless there are anchor

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 2026-04-12  Bob Weiner  <rsw@gnu.org>
 
+* hibtypes.el (pathname): Eliminate matches to Elisp quoted symbols like
+    #'symbol or any use of quote marks after the leading optional # character.
+  hpath.el (hpath:find): Don't match as an anchor unless there are anchor
+    chars after the opening # char.
+
 * kotl/kotl-mode.el (kotl-mode:split-cell): Fix extra blank line(s)
     remaining after split a cell.  Now removes all whitespace, including
     newlines  around the point where the split occurs.

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:     11-Apr-26 at 19:28:10 by Bob Weiner
+;; Last-Mod:     12-Apr-26 at 12:59:51 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -355,7 +355,7 @@ display options."
           ;; Match PATH-related Environment and Lisp variable names and
 	  ;; Emacs Lisp and Info files without any directory component.
           (when (setq path orig-path)
-            (cond ((string-match "\\`#[^#]+" path)
+            (cond ((string-match "\\`#[^\]\[#+^{}<>\"`'\\\n\t\f\r]+" path)
                    (apply #'ibut:label-set path (hpath:start-end path))
 		   (hact 'link-to-file path))
                   ((and (string-match hpath:path-variable-regexp path)

--- a/hpath.el
+++ b/hpath.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Nov-91 at 00:44:23
-;; Last-Mod:     22-Mar-26 at 18:26:12 by Bob Weiner
+;; Last-Mod:     12-Apr-26 at 12:59:52 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -90,8 +90,10 @@ Group 3 is the 1-based line number.  Group 5 is the 0-based column number.")
 (defconst hpath:markup-link-anchor-regexp
   "\\`\\(#?[^#+]*[^#+.]\\)?\\(#\\)\\([^\]\[#+^{}<>\"`'\\\n\t\f\r]*\\)"
   "Regexp matching a filename followed by a hash (#) and an optional anchor name.
-The anchor is an in-file reference.  # is group 2.  Group 3 is the anchor
-name.")
+The optional filename is group 1, though if it ends with a # then that
+includes group 2.  The anchor is an in-file reference.  Its leading # is
+group 2.  Group 3 is the optional anchor name; if it is empty, then group 2
+is part of the filename.")
 
 (defvar hpath:path-variable-regexp "\\`\\$?[{(]?\\([-_A-Z]*path[-_A-Z]*\\)[)}]?\\'"
   "Regexp that matches exactly to a standalone path variable name reference.
@@ -1590,7 +1592,8 @@ but locational suffixes within the file are utilized."
 			   (string-to-number (match-string 3 path)))
 		 path (substring path 0 (match-beginning 0)))))
     (unless (file-exists-p path) ;; might be #autosave-file#
-      (when (string-match hpath:markup-link-anchor-regexp path)
+      (when (and (string-match hpath:markup-link-anchor-regexp path)
+                 (not (string-empty-p (match-string 3 path))))
 	(setq hash t
 	      anchor (match-string 3 path)
 	      anchor-start-pos (match-beginning 3)

--- a/hypb.el
+++ b/hypb.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     6-Oct-91 at 03:42:38
-;; Last-Mod:     29-Mar-26 at 22:47:54 by Bob Weiner
+;; Last-Mod:     12-Apr-26 at 15:07:51 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1233,6 +1233,17 @@ Removes any trailing newline at the end of the output."
 
 ;;;###autoload
 (defalias 'hypb:rgrep 'hui-select-rgrep)
+
+;;;###autoload
+(defun hypb:save-buffer-silently ()
+  "Silently save the current buffer whether modified or not."
+  (when (buffer-modified-p)
+    (let (
+          ;; Prevent output to the echo area / stdout
+          (inhibit-message t)
+          ;; Prevent writing to the *Messages* buffer
+          (message-log-max nil))
+      (basic-save-buffer))))
 
 (defun hypb:save-lines (regexp)
   "Save only lines containing match for REGEXP.

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Apr-24 at 22:41:13
-;; Last-Mod:     29-Mar-26 at 22:28:44 by Bob Weiner
+;; Last-Mod:     12-Apr-26 at 15:09:20 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -3251,7 +3251,7 @@ save and potentially set `hywiki--directory-mod-time' and
 	(hash-prin1 (hywiki-get-referent-hasht) nil t)
 	(princ ")\n")
 
-	(save-buffer)
+	(hypb:save-buffer-silently)
 	(if (buffer-modified-p)
 	    (error "(hywiki-cache-save): Attempt to kill modified Environment file failed to save, \"%s\"" save-file)
 	  (kill-buffer standard-output))))))

--- a/test/hbut-tests.el
+++ b/test/hbut-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-may-21 at 09:33:00
-;; Last-Mod:      1-May-25 at 23:33:16 by Mats Lidell
+;; Last-Mod:     12-Apr-26 at 15:11:31 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -256,14 +256,14 @@ Create button with link-to-directory using `temporary-file-directory`."
 	  ;; Test with name
           (setq annot-bib-buf (find-file annot-bib-file))
 	  (ibut:program "name" 'annot-bib "arg")
-	  (save-buffer)
+	  (hypb:save-buffer-silently)
 	  (should (string-match (concat (regexp-quote "<[name]> - [arg]")
 					"\\s-*")
 				(buffer-string)))
 	  ;; Test without name
 	  (erase-buffer)
 	  (ibut:program nil 'annot-bib "arg")
-	  (save-buffer)
+	  (hypb:save-buffer-silently)
 	  (should (string-match (concat (regexp-quote "[arg]")
 					"\\s-*")
 				(buffer-string))))
@@ -279,14 +279,14 @@ Create button with link-to-directory using `temporary-file-directory`."
 	  ;; Test with name
           (setq kbd-key-buf (find-file kbd-key-file))
 	  (ibut:program "name" 'kbd-key "{ C-f C-f }")
-	  (save-buffer)
+	  (hypb:save-buffer-silently)
 	  (should (string-match (concat (regexp-quote "<[name]> - { C-f C-f }")
 					"\\s-*")
 				(buffer-string)))
 	  ;; Test without name
 	  (erase-buffer)
 	  (ibut:program nil 'kbd-key "{ C-f C-f }")
-	  (save-buffer)
+	  (hypb:save-buffer-silently)
 	  (should (string-match (concat (regexp-quote "{ C-f C-f }")
 					"\\s-*")
 				(buffer-string))))

--- a/test/hpath-tests.el
+++ b/test/hpath-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    28-Feb-21 at 23:26:00
-;; Last-Mod:      7-Mar-26 at 18:40:46 by Bob Weiner
+;; Last-Mod:     12-Apr-26 at 15:11:31 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -399,7 +399,7 @@
                 (progn
                   (find-file filename)
                   (insert "\"" fn "\"")
-                  (save-buffer)
+                  (hypb:save-buffer-silently)
                   (goto-char 3)
                   (should (string= (hpath:at-p) fn))
                   (should (string= (hpath:is-p fn) fn)))

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     14-Sep-25 at 19:26:09 by Mats Lidell
+;; Last-Mod:     12-Apr-26 at 15:11:31 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -79,7 +79,7 @@
       ;; unsaved buffers are left open
       (save-excursion
 	(set-buffer gbut-file-buffer)
-	(save-buffer))
+	(hypb:save-buffer-silently))
       (hy-delete-file-and-buffer linked-file)
       (when (file-writable-p hbmap:dir-user)
 	(delete-directory hbmap:dir-user t)))))
@@ -546,7 +546,7 @@ of the defun."
         (progn
           (find-file kotl-file)
           (klink:create "1")
-	  (save-buffer)
+	  (hypb:save-buffer-silently)
 
           (kotl-mode:beginning-of-cell)
           (forward-char 1)

--- a/test/hy-test-helpers.el
+++ b/test/hy-test-helpers.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     15-Mar-26 at 23:21:21 by Bob Weiner
+;; Last-Mod:     12-Apr-26 at 15:09:22 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -19,8 +19,8 @@
 ;;; Code:
 
 (require 'ert)
-(require 'hmouse-drv)                   ; For `action-key'
-(require 'hywiki)                       ; For `hywiki-word-face-at-p'
+(require 'hmouse-drv) ;; For `action-key'
+(require 'hywiki)     ;; For `hywiki-word-face-at-p' and (require 'hypb)
 (eval-when-compile (require 'cl-lib))
 
 (defun hy-test-helpers:consume-input-events ()
@@ -93,11 +93,15 @@ Checks ACTYPE, ARGS, LOC, LBL-KEY and NAME."
 
 (defun hy-delete-file-and-buffer (file)
   "Delete FILE and buffer visiting file."
-  (let ((buf (find-buffer-visiting file)))
+  (let ((buf (find-buffer-visiting file))
+        ;; Prevents output to the echo area / stdout
+        (inhibit-message t)
+        ;; Prevents writing to the *Messages* buffer
+        (message-log-max nil))
     (when buf
       (with-current-buffer buf
 	(when (buffer-modified-p)
-	  (save-buffer)
+          (hypb:save-buffer-silently)
 	  ;; If the save failed, ensure it shows non-modified before
 	  ;; trying to kill it.
           (set-buffer-modified-p nil))

--- a/test/hyrolo-tests.el
+++ b/test/hyrolo-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    19-Jun-21 at 22:42:00
-;; Last-Mod:     11-Apr-26 at 19:28:11 by Bob Weiner
+;; Last-Mod:     12-Apr-26 at 15:11:30 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -871,7 +871,7 @@ optional DEPTH the number of sub cells are created to that depth."
         (insert (format "%s %d" heading (1+ d)))
         (kotl-mode:newline 1)
         (insert (format "%s %d" body (1+ d)))))
-    (save-buffer)
+    (hypb:save-buffer-silently)
     kotl-file))
 
 (ert-deftest hyrolo-tests--outline-next-visible-heading-kotl ()

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    18-May-24 at 23:59:48
-;; Last-Mod:     21-Mar-26 at 13:55:18 by Bob Weiner
+;; Last-Mod:     12-Apr-26 at 15:11:29 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -22,7 +22,7 @@
 (require 'el-mock)
 (require 'ert-x)
 (require 'hy-test-helpers)
-(require 'hywiki)
+(require 'hywiki) ;; Requires 'hypb
 (require 'hsys-org)
 (require 'ox-publish)
 (require 'seq) ;; for `seq-take-while' and `seq-uniq'
@@ -395,7 +395,7 @@ around the call.  This is for simulating the command loop."
       (find-file wiki-page)
       (dolist (v sections)
         (hywiki-tests--insert (format "%s\nbody\n" v)))
-      (save-buffer)
+      (hypb:save-buffer-silently)
       (hywiki-mode :all)
       (dolist (v sections)
         (with-temp-buffer
@@ -414,7 +414,7 @@ around the call.  This is for simulating the command loop."
 line 1
 line 2
 ")
-      (save-buffer)
+      (hypb:save-buffer-silently)
       (dolist (l '(1 2))
         (dolist (c '("" ":C0" ":C5"))
           (with-temp-buffer
@@ -890,7 +890,7 @@ body A
 ** Bsection subsection
 body B
 ")
-        (save-buffer))
+        (hypb:save-buffer-silently))
       ;; Create temp buffers with WikiWord links to the target
       ;; WikiWord page and verify they work.
       (with-temp-buffer
@@ -929,7 +929,7 @@ Verify dash in the header matches a target with dash replaced by space."
 * header  three
 * header   four
 ")
-        (save-buffer))
+        (hypb:save-buffer-silently))
       ;; Create temp buffers with WikiWord links to the target
       ;; WikiWord page and verify they work.
       (with-temp-buffer
@@ -984,7 +984,7 @@ body B
 *** Csection subsection
 body C
 ")
-	    (save-buffer)
+	    (hypb:save-buffer-silently)
 	    (find-file wikipage)
 	    (hywiki-tests--insert "\
 WikiWord
@@ -992,7 +992,7 @@ WikiWord#Asection
 \"WikiWord#Bsection subsection\"
 WikiWord#Csection-subsection
 ")
-	    (save-buffer)
+	    (hypb:save-buffer-silently)
 
 	    ;; Export the wiki
 	    (hywiki-publish-to-html t)
@@ -1050,7 +1050,7 @@ WikiWord#Csection-subsection
             (find-file wikiword)
             (erase-buffer)
             (hywiki-tests--insert "Text\n")
-	    (save-buffer)
+	    (hypb:save-buffer-silently)
 
             (should (file-exists-p hywiki-directory))
 	    (should (file-exists-p wikipage))
@@ -1069,7 +1069,7 @@ WikiWord#Csection-subsection
 		(find-file wikipage)
                 (erase-buffer)
                 (hywiki-tests--insert input)
-	        (save-buffer)
+	        (hypb:save-buffer-silently)
 
 		;; Export the wiki
 		(hywiki-publish-to-html t)
@@ -1300,7 +1300,7 @@ Note special meaning of `hywiki-allow-plurals-flag'."
 	   (setq wiki-page-buffer (find-file wiki-page))
 	   (erase-buffer)
 	   (hywiki-tests--insert "WikiWord")
-           (save-buffer)
+           (hypb:save-buffer-silently)
            (goto-char 4)
 	   (should (hact 'kbd-key "C-u C-h hhck {C-e SPC ABC} RET"))
 	   (hy-test-helpers:consume-input-events)
@@ -1368,7 +1368,7 @@ Note special meaning of `hywiki-allow-plurals-flag'."
       (let ((vertico-mode 0))
         (find-file wiki-page)
         (hywiki-tests--insert "\nWikiReferent\n")
-        (save-buffer)
+        (hypb:save-buffer-silently)
         (goto-char (point-min))
         (should (hact 'kbd-key "C-u C-h hhc WikiReferent RET f RET"))
         (hy-test-helpers:consume-input-events)))))
@@ -1447,7 +1447,7 @@ Note special meaning of `hywiki-allow-plurals-flag'."
   (hywiki-tests--referent-test
     (progn
       (sit-for 0.2)
-      (cons 'info-node "(emacs)"))
+      (cons 'info-node "(emacs)*"))
     (save-excursion
       (unwind-protect
           (progn
@@ -1918,7 +1918,7 @@ face is verified during the change."
           (progn
             (with-current-buffer (find-file wikiHi)
               (hywiki-tests--insert "Ho")
-              (save-buffer)
+              (hypb:save-buffer-silently)
               (setq wikiHo (cdr (hywiki-add-page "Ho")))
               (goto-char 2)
               (hywiki-tests--verify-hywiki-word "Ho" "Ho")))
@@ -2202,7 +2202,7 @@ expected result."
 ** SubHeader
 *** SubSubHeader
 ")
-      (save-buffer))
+      (hypb:save-buffer-silently))
     (should (set:equal '("Header" "SubHeader" "SubSubHeader")
                        (hywiki-get-page-headings wiki-page)))))
 
@@ -2251,7 +2251,7 @@ expected result."
 ** SubHeader
 *** SubSubHeader
 ")
-        (save-buffer)))
+        (hypb:save-buffer-silently)))
     (ert-info ("Word 'Wixx' can't be completed, no headers are returned")
       (should-not (hywiki-completion-at-point)))
     (ert-info ("Word 'Wiki' can be completed so headers are returned")

--- a/test/kotl-mode-tests.el
+++ b/test/kotl-mode-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    18-May-21 at 22:14:10
-;; Last-Mod:     12-Apr-26 at 11:24:18 by Bob Weiner
+;; Last-Mod:     12-Apr-26 at 15:11:30 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -123,7 +123,7 @@
 
           ;; Verify idstamp view is active when file is visited next time.
           (set-buffer-modified-p t)
-          (save-buffer)
+          (hypb:save-buffer-silently)
           (kill-buffer)
           (find-file kotl-file)
           (should (eq (kview:label-type kotl-kview) 'id))
@@ -155,7 +155,7 @@
 
           ;; Verify kvspec is kept when saving and opening
           (set-buffer-modified-p t)
-          (save-buffer)
+          (hypb:save-buffer-silently)
           (kill-buffer)
           (find-file kotl-file)
           (should (equal kvspec:current "en."))
@@ -409,7 +409,7 @@
           (kotl-mode:beginning-of-buffer)
           (kotl-mode:kill-tree)
           (should (string= (kcell-view:idstamp) "02"))
-          (save-buffer)
+          (hypb:save-buffer-silently)
           (kill-buffer)
           (find-file kotl-file)
           (should (looking-at-p "second"))
@@ -658,7 +658,7 @@
         (progn
           (find-file kotl-file)
           (insert "a cell")
-          (save-buffer)
+          (hypb:save-buffer-silently)
           (should (string= (kcell:get-attr (kcell-view:cell-from-ref 0) 'level-indent) indent))
 
           (copy-file kotl-file new-name)
@@ -1006,7 +1006,7 @@ optional DEPTH the number of sub cells are created to that depth."
         (insert (format "%s %d" heading (1+ d)))
         (kotl-mode:newline 1)
         (insert (format "%s %d" body (1+ d)))))
-    (save-buffer)
+    (hypb:save-buffer-silently)
     kotl-file))
 
 (cl-defstruct kotl-mode-tests--func


### PR DESCRIPTION
- [hpath:find and ibtype pathname - Fix to ignore # followed by punc](https://github.com/rswgnu/hyperbole/commit/9fe51ee47d9bcf09831eafd1f7e13cd5b8584917)

- [hywiki-cache-save - Suppress save buffer msgs and test file backups](https://github.com/rswgnu/hyperbole/commit/1b3dde90335b6cd3bd303162cd18007b0fd6d9e6)