### PR TITLE
Modify test to include search string in path name

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2026-04-16  Mats Lidell  <matsl@gnu.org>
+
+* test/hyrolo-tests.el (hyrolo-tests--tab-through-matches): Verifies
+    that the path name is not selected when tabbing through matches.
+
 2026-04-13  Bob Weiner  <rsw@gnu.org>
 
 * hyrolo.el (hyrolo-next-match, hyrolo-next-regexp-match,

--- a/test/hyrolo-tests.el
+++ b/test/hyrolo-tests.el
@@ -1009,8 +1009,10 @@ optional DEPTH the number of sub cells are created to that depth."
       (hy-delete-files-and-buffers hyrolo-file-list))))
 
 (ert-deftest hyrolo-tests--tab-through-matches ()
-  "Verify tabbing through search matches."
-  (let* ((org-file (make-temp-file "hypb" nil ".org"
+  "Verify tabbing through search matches.
+File name contains the search string to verify it is not selected while
+tabbing though the matches."
+  (let* ((org-file (make-temp-file "hypb_body_" nil ".org"
                                    (hyrolo-tests--gen-outline ?* "heading" 2 "body" 2)))
          (hyrolo-file-list (list org-file)))
     (unwind-protect


### PR DESCRIPTION
# What

Modify test to include search string in path name.

* test/hyrolo-tests.el (hyrolo-tests--tab-through-matches): Verifies
that the path name is not selected when tabbing through matches.

# Why

Fixed in recent commits.

