### PR TITLE
Use test= with coverage target

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2026-04-21  Mats Lidell  <matsl@gnu.org>
+
+* Makefile (COVERAGE_TESTSPEC): Use test= for specifying the test selector
+    to be used when running coverage check. Defaults to t.
+
 2026-04-16  Mats Lidell  <matsl@gnu.org>
 
 * test/hyrolo-tests.el (hyrolo-tests--tab-through-matches): Verifies

--- a/Makefile
+++ b/Makefile
@@ -728,12 +728,12 @@ docker-clean:
 # coverage for the specified file.
 #
 # Usage:
-#    make coverage file=<file> testspec=<testspec>
+#    make coverage file=<file> test=<testspec>
 
 # Specify file to inspect for coverage while running tests given by testspec
 COVERAGE_FILE = ${file}
-ifeq ($(origin testspec), command line)
-COVERAGE_TESTSPEC = ${testspec}
+ifeq ($(origin test), command line)
+COVERAGE_TESTSPEC = ${test}
 else
 COVERAGE_TESTSPEC = t
 endif


### PR DESCRIPTION
# What

Use test= with coverage target.

* Makefile (COVERAGE_TESTSPEC): Use test= for specifying the test selector
to be used when running coverage check. Defaults to t.

# Why

This harmonizes with the test target where test=<selector> it used to
select what tests to run.
