### PR TITLE
Add test for hyrolo-add

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2026-05-10  Mats Lidell  <matsl@gnu.org>
+
+* test/hyrolo-tests.el (hyrolo-tests--add--error-cases):
+    (hyrolo-tests--add-item-to-new-file): Add tests.
+    (hyrolo-tests--add-items-at-multiple-levels):
+    (hyrolo-tests--add-items-interactive): Fix quotes in docstring.
+
 2026-05-10  Bob Weiner  <rsw@gnu.org>
 
 * hyrolo.el (hyrolo-set-date): Change edit date to replace date without

--- a/test/hyrolo-tests.el
+++ b/test/hyrolo-tests.el
@@ -30,8 +30,39 @@
 
 (declare-function hy-test-helpers:consume-input-events "hy-test-helpers")
 
+(ert-deftest hyrolo-tests--add--error-cases ()
+  "Verify `hyrolo-add' error cases."
+  (defvar hyrolo-file)
+  (let ((hyrolo-file (make-temp-file "hypb" nil ".otl")))
+    (unwind-protect
+        (let ((hyrolo-file-list (list hyrolo-file)))
+          (should-error (hyrolo-add ""))
+          (should-error (hyrolo-add 'symbol))
+          (should-error (hyrolo-add "a" ""))
+          (should-error (hyrolo-add "a" 'symbol))
+          (should-error (hyrolo-add "a/b/c"))
+          ;; File not writable
+          (with-mock
+            (mock (file-writable-p hyrolo-file) => nil)
+            (should-error (hyrolo-add "a")))
+          ;; File not readable
+          (with-mock
+            (mock (file-readable-p hyrolo-file) => nil)
+            (should-error (hyrolo-add "a"))))
+      (hy-delete-file-and-buffer hyrolo-file))))
+
+(ert-deftest hyrolo-tests--add-item-to-new-file ()
+  "Verify `hyrolo-add' creates and visits the file buffer if file does not exist."
+  (let ((new-file (expand-file-name (make-temp-name "hypb") "/tmp")))
+    (unwind-protect
+        (progn
+          (should-not (file-exists-p new-file))
+          (hyrolo-add "a" new-file)
+          (should (equal (current-buffer) (get-file-buffer new-file))))
+      (hy-delete-file-and-buffer new-file))))
+
 (ert-deftest hyrolo-tests--add-items-at-multiple-levels ()
-  "`hyrolo-add` can add items at different levels."
+  "`hyrolo-add' can add items at different levels."
   (let ((hyrolo-file (make-temp-file "hypb" nil ".otl")))
     (unwind-protect
         (let ((hyrolo-file-list (list hyrolo-file)))
@@ -47,7 +78,7 @@
       (hy-delete-file-and-buffer hyrolo-file))))
 
 (ert-deftest hyrolo-tests--add-items-interactive ()
-  "`hyrolo-add` can add items when called interactively."
+  "`hyrolo-add' can add items when called interactively."
   (let ((hyrolo-file (make-temp-file "hypb" nil ".otl")))
     (unwind-protect
         (let ((hyrolo-file-list (list hyrolo-file)))


### PR DESCRIPTION
# What

Add test for hyrolo-add

* test/hyrolo-tests.el (hyrolo-tests--add--error-cases):
    (hyrolo-tests--add-item-to-new-file): Add tests.
    (hyrolo-tests--add-items-at-multiple-levels):
    (hyrolo-tests--add-items-interactive): Fix quotes in docstring.

# Why

More test coverage for hyrolo.

# Note

Testing write and read properties of files using root as user is
problematic since it behaves different for root than for a regular
user. This PR solved it by mocking the checks. 

This shows a bigger problem. In the best of worlds we should be
running the tests as a regular user. That will require some work to
implement in our current setup. 
