### PR TITLE
Add hyrolo-set-date test

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 2026-05-10  Mats Lidell  <matsl@gnu.org>
 
-* test/hyrolo-tests.el (hyrolo-tests--add--error-cases):
+* test/hyrolo-tests.el (hyrolo-tests--set-date):
+    (hyrolo-tests--add--error-cases):
     (hyrolo-tests--add-item-to-new-file): Add tests.
     (hyrolo-tests--add-items-at-multiple-levels):
     (hyrolo-tests--add-items-interactive): Fix quotes in docstring.

--- a/test/hyrolo-tests.el
+++ b/test/hyrolo-tests.el
@@ -2039,6 +2039,51 @@ Dependencies on the consult package are mocked."
                 (hy-test-helpers:should-last-message "not found" cap)))))
       (hy-delete-file-and-buffer hyrolo-file))))
 
+(ert-deftest hyrolo-tests--set-date ()
+  "Verify `hyrolo-set-date' sets and updates an items date."
+  (let ((test-time "2024-12-11"))
+    (cl-letf (((symbol-function 'format-time-string)
+               (lambda (_fmt &optional _time _zone) test-time)))
+      (with-temp-buffer
+        (insert "* item\n")
+
+        (ert-info ("Do not insert date if date format is empty or nil")
+          (dolist (v '("" nil))
+            (let ((hyrolo-date-format v))
+              (goto-char (point-min))
+              (hyrolo-set-date)
+              (should (string= "* item\n" (buffer-string))))))
+
+        (ert-info ("Do not insert date in kotl-mode")
+          (let ((major-mode 'kotl-mode))
+            (goto-char (point-min))
+            (hyrolo-set-date)
+            (should (string= "* item\n" (buffer-string)))))
+
+        (ert-info ("Don't set date if date is not present and request is edit-only")
+          (goto-char (point-min))
+          (hyrolo-set-date t)
+          (should (string= "* item\n" (buffer-string))))
+
+        (ert-info ("Set date if not there")
+          (goto-char (point-min))
+          (hyrolo-set-date)
+          (should (string= "* item\n\t2024-12-11\n" (buffer-string))))
+
+        (ert-info ("Update date if item has a date")
+          (setq test-time "2025-01-01")
+          (goto-char (point-min))
+          (hyrolo-set-date)
+          (should (string= "* item\n\t2025-01-01\n" (buffer-string))))
+
+        (ert-info ("Update date if item has a date, keep trailing newlines")
+          (setq test-time "2025-01-02")
+          (goto-char (point-max))
+          (insert "\n\n")
+          (goto-char (point-min))
+          (hyrolo-set-date)
+          (should (string= "* item\n\t2025-01-02\n\n\n" (buffer-string))))))))
+
 (provide 'hyrolo-tests)
 
 ;; This file can't be byte-compiled without the `el-mock' package

--- a/test/hyrolo-tests.el
+++ b/test/hyrolo-tests.el
@@ -2082,7 +2082,17 @@ Dependencies on the consult package are mocked."
           (insert "\n\n")
           (goto-char (point-min))
           (hyrolo-set-date)
-          (should (string= "* item\n\t2025-01-02\n\n\n" (buffer-string))))))))
+          (should (string= "* item\n\t2025-01-02\n\n\n" (buffer-string))))
+
+        (ert-info ("Update date if item has a date, keep leading whitespace")
+          (goto-char (point-min))
+          (search-forward "2025-01-02")
+          (beginning-of-line)
+          (insert "\t\t")
+          (setq test-time "2025-01-03")
+          (goto-char (point-min))
+          (hyrolo-set-date)
+          (should (string= "* item\n\t\t\t2025-01-03\n\n\n" (buffer-string))))))))
 
 (provide 'hyrolo-tests)
 


### PR DESCRIPTION
# What

Add hyrolo-set-date test

* test/hyrolo-tests.el (hyrolo-tests--set-date): Add test.

# Why

Add coverage for more hyrolo functions.

# Note

This PR needs the recent change to hyrolo-set-date to be merged into master.
