### PR TITLE
Do not set MAKE variable

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2026-05-12  Mats Lidell  <matsl@gnu.org>
+
+* Makefile (HYPB_NATIVE_COMP): Use MAKE variable in recursive make.
+
 2026-05-11  Mats Lidell  <matsl@gnu.org>
 
 * test/hyrolo-tests.el (hyrolo-tests--mail-to): Test error case.

--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,6 @@ GPG = \gpg
 GZIP = \gzip -c
 INSTALL = \install -m 644 -c
 MKDIR = \mkdir -p
-MAKE = \make
 RM = \rm -f
 TAR = \tar
 ZIP = \zip -qry
@@ -386,7 +385,7 @@ bin: remove-elc src new-bin
 # Native compilation (Requires Emacs built with native compilation support.)
 .PHONY: eln
 eln:
-	HYPB_NATIVE_COMP=yes make new-bin
+	HYPB_NATIVE_COMP=yes $(MAKE) new-bin
 
 .PHONY: tags
 tags: TAGS


### PR DESCRIPTION
# What

The MAKE variable is special to make and should not be changed.

Makefile (HYPB_NATIVE_COMP): Use MAKE variable in recursive make.

# Why

Follow good practices. See [How the MAKE Variable Works](https://www.gnu.org/software/make/manual/html_node/MAKE-Variable.html)
