### PR TITLE
Make autoloads in synchronous subprocess

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2026-05-16  Mats Lidell  <matsl@gnu.org>
+
+* hload-path.el (hload-path--make-directory-autoloads-in-sync-subprocess):
+    Run autoload generation in a synchronous subprocess.
+    (hyperb:generate-autoloads): Use
+    hload-path--make-directory-autoloads-in-sync-subprocess.
+
 2026-05-15  Mats Lidell  <matsl@gnu.org>
 
 * Add declare-function and defvar that replaces the autoload definitions

--- a/hload-path.el
+++ b/hload-path.el
@@ -95,6 +95,21 @@ directory separator character.")
   "Use `loaddefs-generate' if available or fallback to `make-directory-autoloads'.
 `make-directory-autoloads' is defined since Emacs 28.")
 
+(defun hload-path--make-directory-autoloads-in-sync-subprocess (dirs output-file)
+  "Make autoloads in a synchronous subprocess for directories DIRS.
+The autoloads will be written to OUTPUT-FILE.  Use `loaddefs-generate'
+if available or fallback to `make-directory-autoloads', defined since
+Emacs 28."
+  (call-process (expand-file-name invocation-name invocation-directory)
+                nil nil nil
+                "--batch"
+                "--eval" (format "(%S '%S %S)"
+                                 (cond ((fboundp 'loaddefs-generate)
+                                        #'loaddefs-generate)
+                                       (t
+                                        #'make-directory-autoloads))
+                                 dirs output-file)))
+
 ;; Menu items could call this function before Info is loaded.
 (autoload 'Info-goto-node   "info" "Jump to specific Info node."  t)
 
@@ -119,12 +134,12 @@ This is used only when running from git source and not a package release."
 	 (al-buf (find-file-noselect al-file)))
     ;; (make-local-variable 'generated-autoload-file)
     (with-current-buffer al-buf
-      (hload-path--make-directory-autoloads "." al-file))
+      (hload-path--make-directory-autoloads-in-sync-subprocess "." al-file))
     (kill-buffer al-buf)
     (setq al-file (expand-file-name "kotl/kotl-autoloads.el")
 	  al-buf (find-file-noselect al-file))
     (with-current-buffer al-buf
-      (hload-path--make-directory-autoloads "." al-file))
+      (hload-path--make-directory-autoloads-in-sync-subprocess "." al-file))
     (kill-buffer al-buf))
   (unless (hyperb:autoloads-exist-p)
     (error "Hyperbole failed to generate autoload files; try running 'make src' in a shell in %s" hyperb:dir)))


### PR DESCRIPTION
# What

Avoid loading files within current Emacs when generating autoloads
while Hyperbole is being loaded. Dispatch the autoloads generation to
a subprocess to work around eager macro expansion error when loading
Hyperbole.

* hload-path.el (hload-path--make-directory-autoloads-in-sync-subprocess):
Run autoload generation in a synchronous subprocess.
(hyperb:generate-autoloads): Use
hload-path--make-directory-autoloads-in-sync-subprocess.

# Why

The same issue with loaddefs-gen: load error (error "Eager
macro-expansion failure: ...) occurs when the generation is performed
within a running Emacs since the generation is done while Hyperbole is
being loading. That is the same situation as before with the make
autoloads target.

