### PR TITLE
Ensure markdown-mode is preferred

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2026-05-19  Mats Lidell  <matsl@gnu.org>
+
+* test/hy-test-dependencies.el (fboundp): When markdown-ts-mode is defined
+    prefer markdown-mode. This avoids markdown-ts-mode prompting for
+    treesitter grammar.
+
 2026-05-16  Bob Weiner  <rsw@gnu.org>
 
 * man/hyperbole.texi (Default Hyperbole Bindings): Update doc for {M-w} to copy

--- a/test/hy-test-dependencies.el
+++ b/test/hy-test-dependencies.el
@@ -21,8 +21,8 @@
 ;; Force markdown-mode to be selected first to avoid markdown-ts-mode
 ;; for now. It requires Tree-sitter grammars to be installed which
 ;; conflicts with our current CI setup.
-;; (when (fboundp #'markdown-ts-mode)
-;;   (add-to-list 'auto-mode-alist '("\\.md\\'" . markdown-mode)))
+(when (fboundp #'markdown-ts-mode)
+  (add-to-list 'auto-mode-alist '("\\.md\\'" . markdown-mode)))
 
 (add-to-list 'package-archives '("melpa" . "https://melpa.org/packages/"))
 (package-initialize)

--- a/test/hy-test-dependencies.el
+++ b/test/hy-test-dependencies.el
@@ -18,6 +18,12 @@
 
 ;;; Code:
 
+;; Force markdown-mode to be selected first to avoid markdown-ts-mode
+;; for now. It requires Tree-sitter grammars to be installed which
+;; conflicts with our current CI setup.
+;; (when (fboundp #'markdown-ts-mode)
+;;   (add-to-list 'auto-mode-alist '("\\.md\\'" . markdown-mode)))
+
 (add-to-list 'package-archives '("melpa" . "https://melpa.org/packages/"))
 (package-initialize)
 


### PR DESCRIPTION
# What

Ensure markdown-mode is preferred to markdown-ts-mode to avoid issues
with treesitter grammars.

# Why

When markdown-ts-mode is selected it will look for treesitter grammar
for markdown which we have not installed in CI and docker environment.

# Note

This solves the immediate issue with Emacs master build and thus the coming Emacs 31 version. We should probably try to solve the grammar issue for our CI and docker builds but that is saved for later.
