### PR TITLE
Update hyrolo-tests--expand-path-list

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2026-05-21  Mats Lidell  <matsl@gnu.org>
+
+* test/hyrolo-tests.el (hyrolo-tests--expand-path-list): Add test when
+    bbdb and google-contacts are in use.
+
 2026-05-21  Bob Weiner  <rsw@gnu.org>
 
 * hpath.el (hpath:expand): Don't expand if path is a "*Buffer Name*"

--- a/test/hyrolo-tests.el
+++ b/test/hyrolo-tests.el
@@ -1842,20 +1842,21 @@ match
 
 (ert-deftest hyrolo-tests--expand-path-list ()
   "Verify `hyrolo-expand-path-list'."
-  (should (equal (hyrolo-expand-path-list nil)
-		 (list hyrolo-default-file)))
-  (let ((bbdb-file nil))
-    (mocklet (((hpath:expand-list
-                '("/file1")
-                "\\.\\(kotl?\\|org\\|ou?tl\\|md\\|markdown\\|mkd\\|mdown\\|mkdn\\|mdwn\\)$")
-               => (list "/file1")))
-      (should (equal (hyrolo-expand-path-list '("/file1")) '("/file1")))))
-  (let ((bbdb-file nil))
-    (mocklet (((hpath:expand-list
-                '("/file1")
-                "\\.\\(kotl?\\|org\\|ou?tl\\|md\\|markdown\\|mkd\\|mdown\\|mkdn\\|mdwn\\)$")
-               => (list "/file1")))
-      (should (equal (hyrolo-expand-path-list '("/file1")) '("/file1"))))))
+  (let ((hyrolo-default-file "~/default"))
+    (should (equal (hyrolo-expand-path-list nil)
+		   (list hyrolo-default-file)))
+    (defvar bbdb-file)
+    (defvar google-contacts-buffer-name)
+    (let ((bbdb-file "~/bbdb")
+          (google-contacts-buffer-name "*Google Contacts*"))
+      (mocklet (((hyrolo-google-contacts-p) => t))
+        (should (equal (hyrolo-expand-path-list nil)
+		       (list hyrolo-default-file bbdb-file google-contacts-buffer-name))))))
+  (mocklet (((hpath:expand-list
+              '("/file1")
+              "\\.\\(kotl?\\|org\\|ou?tl\\|md\\|markdown\\|mkd\\|mdown\\|mkdn\\|mdwn\\)$")
+             => (list "/file1")))
+    (should (equal (hyrolo-expand-path-list '("/file1")) '("/file1")))))
 
 (ert-deftest hyrolo-tests--at-tags-p ()
   "Verify `hyrolo-at-tags-p´."


### PR DESCRIPTION
# What

Update hyrolo-tests--expand-path-list

* test/hyrolo-tests.el (hyrolo-tests--expand-path-list): Add test when
bbdb and google-contacts are in use.

# Why

Cover more paths in the hyrolo-expand-path-list.
