### PR TITLE
 hypb:fgrep-git-log - Walk up dir tree to find if has a .git dir; hypb:remove-from-in-string-cache - use in kill-buffer-hook

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,16 @@
+2026-05-27  Bob Weiner  <rsw@gnu.org>
+
+* hypb.el (hypb:remove-from-in-string-cache): Add and use to remove the
+    current buffer as part of 'kill-buffer-hook'.
+
+* hmouse-tag.el (smart-ancestor-tag-files): Fix to ensure all 'dirs' given
+    are normalized and then 'hpath:expand'ed.  This fixes handling of "."
+    and ".." as dir args.
+  hypb.el (hypb:fgrep-git-log): Walk up directory tree to find if within
+    a git archive for selecting default dir.  If none found, default to
+    'hyperb:dir'.  Default directory to 'hyperb:dir' if current  dir does
+    not contain a ".git" directory.
+
 2026-05-24  Bob Weiner  <rsw@gnu.org>
 
 * hyrolo.el (hyrolo-hdr-to-first-line-p, hyrolo-hdr-move-after-p):

--- a/hmouse-tag.el
+++ b/hmouse-tag.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    24-Aug-91
-;; Last-Mod:     31-Dec-25 at 16:02:19 by Mats Lidell
+;; Last-Mod:     27-May-26 at 09:54:20 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1150,7 +1150,8 @@ list the found tags tables from furthest to nearest."
 		       (if (file-readable-p tags-file)
 			   (setq tags-table-list (cons tags-file tags-table-list))))
 		     tags-table-list)
-		   (if (listp dirs) dirs (list dirs))))))
+                   (mapcar (lambda (dir) (hpath:expand (file-name-as-directory dir)))
+		           (if (listp dirs) dirs (list dirs)))))))
 
 (defun smart-asm-include-file ()
   "If point is on an include file line, try to display file.

--- a/hypb.el
+++ b/hypb.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     6-Oct-91 at 03:42:38
-;; Last-Mod:     27-May-26 at 14:33:45 by Bob Weiner
+;; Last-Mod:     28-May-26 at 12:18:39 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -20,7 +20,7 @@
 ;;; ************************************************************************
 
 ;; Load Org here for `org-fold-show-all'.
-(eval-and-compile (mapc #'require '(compile hversion hact hmouse-tag locate
+(eval-and-compile (mapc #'require '(compile hversion hact locate
 				    cl-lib org package seq)))
 
 ;;; ************************************************************************

--- a/hypb.el
+++ b/hypb.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     6-Oct-91 at 03:42:38
-;; Last-Mod:     11-May-26 at 10:56:26 by Bob Weiner
+;; Last-Mod:     27-May-26 at 14:33:45 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -20,7 +20,7 @@
 ;;; ************************************************************************
 
 ;; Load Org here for `org-fold-show-all'.
-(eval-and-compile (mapc #'require '(compile hversion hact locate
+(eval-and-compile (mapc #'require '(compile hversion hact hmouse-tag locate
 				    cl-lib org package seq)))
 
 ;;; ************************************************************************
@@ -566,8 +566,10 @@ the `format' function."
 Listing is asynchronous.  A press of RET, the Action Key or the
 Assist Key on any log line will display its committed changes."
   (interactive "sFgrep git commits containing: ")
-  (compile (format "git log -S'%s' --line-prefix='commit ' --oneline" string)
-	   #'hypb:fgrep-git-log-mode))
+  (let ((default-directory (or (car (smart-ancestor-tag-files "./" ".git"))
+                               hyperb:dir)))
+    (compile (format "git log -S'%s' --line-prefix='commit ' --oneline" string)
+	     #'hypb:fgrep-git-log-mode)))
 
 (defun hypb:fgrep-git-log-activate (_ignore1 &optional _ignore2)
   "Display git commit for the current line when `compile-goto-error' {RET} is used.
@@ -1551,6 +1553,17 @@ Without file, the banner is prepended to the current buffer."
 			       (- o ?0)))))
 	  oct-str)
     dec-num))
+
+(defun hypb:remove-from-in-string-cache ()
+  "Remove current buffer from `hypb:in-string-cache'.
+Use this as a `kill-buffer-hook'."
+  (remhash (current-buffer) hypb:in-string-cache))
+
+;;; ************************************************************************
+;;; Public initializations
+;;; ************************************************************************
+
+(add-hook 'kill-buffer-hook 'hypb:remove-from-in-string-cache)
 
 (provide 'hypb)
 


### PR DESCRIPTION
- hypb:fgrep-git-log - Walk up dir tree to find if has a .git dir

- hypb:remove-from-in-string-cache): Add and use to remove the
current buffer as part of 'kill-buffer-hook'.

- smart-ancestor-tag-files - Fix to ensure all 'dirs' given
are normalized and then 'hpath:expand'ed.  This fixes handling of "."
and ".." as dir args.