### PR TITLE
hib-python-traceback - Fix regex to not fire in place of man-apropos

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,15 @@
-2026-06-01  Bob Weiner  <rsw@gnu.org>
+2026-06-04  Bob Weiner  <rsw@gnu.org>
+
+* hibtypes.el (hib-python-traceback, debugger-source): Fix 2nd regexp in
+    'hib-python-traceback' to not allow any paired delimiters in the file
+    name part of the regexp to prevent matching to a named man-apropos
+    implicit button where the name is split across two lines like so:
+	<[My
+	  Name]> - ls(1)
+
+* hui.el (hui:link-possible-types): Fix klink 'link-to-kcell' return string
+    to include the relative id (cell label) with syntax: relid=idstamp.  This
+    is used when inserting a klink with 'hui:ibut-link-directly'.
 
 2026-05-31  Bob Weiner  <rsw@gnu.org>
 

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:     12-Apr-26 at 12:59:51 by Bob Weiner
+;; Last-Mod:      4-Jun-26 at 10:32:16 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1207,7 +1207,7 @@ in grep and shell buffers."
 (defun hib-python-traceback ()
 "Test for and jump to line referenced in Python pdb, traceback, or pytype error."
   (when (or (looking-at "\\(^\\|.+ \\)File \"\\([^\"\t\f\n\r]+\\S-\\)\", line \\([0-9]+\\)")
-            (looking-at ">?\\(\\s-+\\)\\([^\"()\t\f\n\r]+\\S-\\)(\\([0-9]+\\))\\S-"))
+            (looking-at ">?\\(\\s-+\\)\\([^][\"<>{}()\t\f\n\r]+\\S-\\)(\\([0-9]+\\))\\S-"))
     (let* ((file (match-string-no-properties 2))
            (line-num (match-string-no-properties 3))
            (but-label (concat file ":" line-num)))

--- a/hui.el
+++ b/hui.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 21:42:03
-;; Last-Mod:     16-May-26 at 17:49:30 by Bob Weiner
+;; Last-Mod:      4-Jun-26 at 09:55:07 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -2174,7 +2174,9 @@ Buffer without File      link-to-buffer-tmp"
 					(setq val (hargs:at-p t)))
 				      (list 'link-to-file val))
 				     ((derived-mode-p #'kotl-mode)
-				      (list 'link-to-kcell (hypb:buffer-file-name) (kcell-view:idstamp)))
+				      (list 'link-to-kcell (hypb:buffer-file-name)
+                                            (concat (kcell-view:label) "="
+                                                    (kcell-view:idstamp))))
 				     ;;
 				     ;; If region is active in the target buffer and it is one
 				     ;; line or less, then do a link-to-string-match to the region string.

--- a/kotl/klink.el
+++ b/kotl/klink.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Nov-93 at 12:15:16
-;; Last-Mod:     22-Jun-25 at 10:24:52 by Bob Weiner
+;; Last-Mod:      4-Jun-26 at 11:19:52 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -186,7 +186,7 @@ See documentation for `kcell:ref-to-id' for valid cell-ref formats."
   "Return non-nil iff point is within a klink.
 See documentation for the `actypes::link-to-kotl' function for valid klink
 formats.  Value returned is a list of: link-label, link-start-position, and
-link-end-position, (including delimiters)."
+link-end-position, (positions include delimiters)."
   (let (bol label-and-pos referent path)
     (when (and
 	   ;; Avoid false matches in certain modes.
@@ -391,6 +391,7 @@ Assume point is in klink referent buffer, where the klink points."
 	      (klink:replace-label klink link-buf start new-label)))))
 
 (defun klink:yank-handler (klink)
+  "When yanking a KLINK, make its path relative to `default-directory'."
   (if (string-match "<\\([^,]+\\)?[#,][ \t]*\\(.+\\)" klink)
       (let* ((file (or (match-string 1 klink)
 		       (get-text-property 0 'file-name klink)))
@@ -409,7 +410,7 @@ Assume point is in klink referent buffer, where the klink points."
 		     (insert klink)
 		   (insert (format "<%s#%s" file rest))))))
     (insert klink)))
-				 
+
 (provide 'klink)
 
 ;;; klink.el ends here


### PR DESCRIPTION
- hui:link-possible-types - Fix klink 'link-to-kcell' return string to include the relative id (cell label) with syntax: relid=idstamp.