### PR TITLE
 link-to-ibut - Fix infinite loop, in-buffer links and but attr refs; smart-emacs-lisp-mode-p - Add support for comint-mode and complilation-mode

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,39 @@
+2026-06-07  Bob Weiner  <rsw@gnu.org>
+
+* hmouse-tag.el (smart-emacs-lisp-mode-p): Add support for 'comint-mode'
+    used by shell buffers and 'compilation-mode' that contain elisp symbols.
+
+2026-06-06  Bob Weiner  <rsw@gnu.org>
+
+* test/hui-tests.el (hui--ibut-create-interactive)
+(hui--ibut-create-interactive-add-comment-char)
+(hui--ibut-create-interactive-label-using-region):
+
+2026-06-05  Bob Weiner  <rsw@gnu.org>
+
+* hbut.el (ibut:to): Fix to search for 'name-key' surrounded by
+    implicit button name delimiters.  Avoids matching to
+    <ilink:name-key> action buttons.
+          (ibut:to-text): Allow movement to the linked ibut if point
+    is on an ilink.  Fixes bug where in-buffer ilinks did not work.
+    Remove check of any hbut:current attributes prior to moving to the
+    linked to ibut as these refer to the link-to-ibut button.
+          (ibut:insert-text): For 'actypes::link-to-ibut', convert
+    label key to label text.
+  hui.el (hui:link-possible-types): Fix 'link-to-ibut' to use label
+    text rather than label key and don't include the location if
+    the link is to a button within the source buffer.
+          (ibut:insert-text): Use 'actype:def-symbol' and don't expose
+    actypes:: prefix.
+
+* MANIFEST: (hui-register.el): Add missing entry.
+
+* hbut.el (ibut:to-text): Error if 'lbl-key' is an empty string.
+
+* hactypes.el: (link-to-ibut): Fix infinite loop in <ilink:label> links
+    by replacing 'hbut:act' call with a call to 'actype:act' which
+    utilizes the actype computed from the prior 'ibut:at-p' call.
+
 2026-06-04  Bob Weiner  <rsw@gnu.org>
 
 * hibtypes.el (hib-python-traceback, debugger-source): Fix 2nd regexp in

--- a/FAST-DEMO
+++ b/FAST-DEMO
@@ -1,4 +1,6 @@
 
+
+
 * GNU Hyperbole Fast Demo by Bob Weiner
 
   Send an email or a testimonial if you like Hyperbole to <rsw@gnu.org>.
@@ -12,16 +14,19 @@
 * Introductory Videos
 
   If you prefer video introductions, visit the videos linked to in the tables below;
-  otherwise, skip to the next section.  The first table is an overview talk of
-  Hyperbole broken into few minute sections that you can watch individually.  The
-  second table has links to separate videos covering aspects of Hyperbole.
+  otherwise, skip to the next section.  The first table, "#Hyperbole Overview Video",
+  is an overview talk of Hyperbole broken into few minute sections that you can watch
+  individually.  The second table has links to separate videos covering aspects of
+  Hyperbole, including the full <ilink:Overview and Demo>.
 
-  Hyperbole video demos start with 'section 06 - Hyperbole Buttons' in this first
+** Hyperbole Overview Video
+
+  Demos of Hyperbole features start in 'section 06 - Hyperbole Buttons' in this first
   table.  Press {M-RET} either in the first column <[button name]> or in the second
   column video link to watch each section.
-  
+
   |--------------------------------------+-----------------------------------------|
-  | Hyperbole Video Overview Sections    | Video Snippets                          |
+  | Hyperbole Overview Video Sections    | Video Snippets                          |
   |--------------------------------------+-----------------------------------------|
   |--------------------------------------+-----------------------------------------|
   | 01. <[Introduction]>                 | <yt-play "WKwZHSbHmPg" "0:01" "1:38">   |
@@ -48,8 +53,10 @@
   | 22. <[The Big Picture]>              | <yt-play "WKwZHSbHmPg" "54:25" "56:44"> |
   |--------------------------------------+-----------------------------------------|
 
+** Hyperbole Videos
+
   |-----------------------------------------------------+------------------------------|
-  | GNU Hyperbole Videos                                | Web Link                     |
+  | GNU Hyperbole Videos                                | Web Links                    |
   |-----------------------------------------------------+------------------------------|
   |-----------------------------------------------------+------------------------------|
   | <[Overview and Demo]>                               | https://youtu.be/WKwZHSbHmPg |
@@ -186,7 +193,7 @@
        directories. By default, Org files, Python files and Elisp files are
        handled.
 
-    "(hyperbole)action-key-modeline-function" 
+    "(hyperbole)action-key-modeline-function"
 
        Double quoted Info manual references are also implicit buttons.  You
        can link to both nodes/sections in GNU Info manuals as well as to
@@ -271,7 +278,7 @@
        within key series surrounded by parentheses maintain spaces between
        words without the need to use 'SPC'.
 
-    {M-x shell RET M-> (export HYPERBOLE_DIR=${hyperb:dir} && 
+    {M-x shell RET M-> (export HYPERBOLE_DIR=${hyperb:dir} &&
      cd $HYPERBOLE_DIR && grep -n gbut:label-list *.el) RET}
 
        Use both a Hyperbole resolved variable, ${hyperb:dir}, and a
@@ -449,22 +456,22 @@ To learn how to create new kinds of implicit button and action types, see
   a HyWikiWord is a capitalized word that contains upper and lowercase
   letters only and has a corresponding HyWikiWord.org wiki page file
   below `hywiki-directory'.  HyWikiWords require no delimiters.
-  
+
   Use {M-RET} on the first line of the expression below to set a demo
   HyWiki directory and turn on hywiki-mode so HyWikiWords are
   highlighted outside of the HyWiki directory.
-  
+
     <progn (setq hywiki-directory (hpath:expand "${hyperb:dir}/hywiki/"))
            (hywiki-mode 1)>
-  
+
   Now all these wiki-words should be highlighted and can appear in any
   text buffer and will be treated as hyperlinks.  Simply press {M-RET}
   on each to display the associated wiki page:
-  
+
     HyWiki
     HyWikiMenus
     Publishing
-  
+
   Let's create a new page.  Press {M-RET} on the HyWikiWord below:
 
   TestWord

--- a/MANIFEST
+++ b/MANIFEST
@@ -43,6 +43,7 @@ hui-jmenu.el         - Popup menus for jumping to and managing buffers, frames, 
 hui-menu.el          - Menubar menu of GNU Hyperbole commands
 hui-mini.el          - Single line command menus for GNU Hyperbole
 hui-mouse.el         - Use key or mouse key for many functions, e.g. GNU Hyperbole menus
+hui-register.el      - Hyperbole links to Emacs registers
 hui-select.el        - Select delimited or larger and larger syntax-driven regions in a buffer
 hui-treemacs.el      - GNU Hyperbole Smart Key support for the Treemacs file manager package
 hui-window.el        - Smart Mouse Key window and modeline depress/release actions

--- a/hactypes.el
+++ b/hactypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    23-Sep-91 at 20:34:36
-;; Last-Mod:     28-Mar-26 at 13:03:44 by Bob Weiner
+;; Last-Mod:      5-Jun-26 at 08:42:07 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -560,7 +560,8 @@ on the implicit button to which to link."
 
   (unless name-key
     (hypb:error "(link-to-ibut): Point must be on an implicit button to create a link-to-ibut"))
-  (let (but
+  (let (actype
+        but
 	normalized-file)
     (if but-src
 	(unless (and (get-buffer but-src)
@@ -576,8 +577,13 @@ on the implicit button to which to link."
       (goto-char (min point (point-max))))
     (setq but (ibut:to-text name-key))
     (cond (but
-	   (setq but (ibut:at-p))
-	   (hbut:act but))
+           (setq actype (actype:def-symbol (hattr:get but 'actype)))
+           (if (eq actype 'link-to-ibut)
+	       (hypb:error "(link-to-ibut): Failed to find implicit button named `%s' in `%s'"
+		           (ibut:key-to-label name-key)
+		           (or but-src (buffer-name)))
+             (apply #'actype:act (hattr:get but 'actype)
+                    (hattr:get but 'args))))
 	  (name-key
 	   (hypb:error "(link-to-ibut): No implicit button named `%s' found in `%s'"
 		       (ibut:key-to-label name-key)

--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:     15-Mar-26 at 22:16:44 by Bob Weiner
+;; Last-Mod:      7-Jun-26 at 11:26:22 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1250,8 +1250,8 @@ button file) or within the current buffer if both are null.  Use
 of point when desired.
 
 Caller must have used (ibut:at-p) to create hbut:current prior to
-calling this function.  When KEY-SRC is given, this set's
-hbut:current's \\='loc attribute to KEY-SRC."
+calling this function.  The `hbut:current' \\='loc attribute is set
+to KEY-SRC when it is provided."
   (if buffer
       (if (bufferp buffer)
 	  (set-buffer buffer)
@@ -2683,7 +2683,7 @@ Summary of operations based on inputs (name arg from \\='hbut:current attrs):
 	   (insert ibut:label-separator))))
   (let* ((orig-actype (or (hattr:get ibut 'actype)
 			  (hattr:get ibut 'categ)))
-	 (actype (or (actype:elisp-symbol orig-actype)
+	 (actype (or (actype:def-symbol (actype:elisp-symbol orig-actype))
 		     (and (symbolp orig-actype) (fboundp orig-actype)
 			  orig-actype)))
 	 (args   (hattr:get ibut 'args))
@@ -2691,25 +2691,26 @@ Summary of operations based on inputs (name arg from \\='hbut:current attrs):
 	 (arg2   (nth 1 args))
 	 (arg3   (nth 2 args)))
     (pcase actype
-      ('actypes::kbd-key
+      ('kbd-key
        (cond ((and (stringp arg1) (string-match "\\s-*{.+}\\s-*" arg1))
 	      (insert arg1))
 	     ((stringp arg1)
 	      (insert "{" arg1 "}"))
 	     (t (insert "{}"))))
-      ((or 'actypes::link-to-directory 'actypes::link-to-Info-node 'actypes::link-to-Info-index-item)
+      ((or 'link-to-directory 'link-to-Info-node 'link-to-Info-index-item)
        (insert "\"" arg1 "\""))
-      ('actypes::annot-bib (insert "[" arg1 "]"))
-      ('actypes::exec-shell-cmd (insert "\"!" arg1 "\""))
-      ('actypes::exec-window-cmd (insert "\"&" arg1 "\""))
-      ('actypes::link-to-gbut (insert "<glink:" arg1 ">"))
-      ('actypes::link-to-ebut (progn (insert "<elink:" arg1)
-				     (when arg2 (insert ": " arg2))
-				     (insert ">")))
-      ('actypes::link-to-ibut (progn (insert "<ilink:" arg1)
-				     (when arg2 (insert ": " arg2))
-				     (insert ">")))
-      ('actypes::link-to-kcell
+      ('annot-bib (insert "[" arg1 "]"))
+      ('exec-shell-cmd (insert "\"!" arg1 "\""))
+      ('exec-window-cmd (insert "\"&" arg1 "\""))
+      ('link-to-gbut (insert "<glink:" arg1 ">"))
+      ('link-to-ebut (progn (insert "<elink:" arg1)
+			    (when arg2 (insert ": " arg2))
+			    (insert ">")))
+      ('link-to-ibut (progn (insert "<ilink:"
+                                    (hbut:key-to-label arg1))
+			    (when arg2 (insert ": " arg2))
+			    (insert ">")))
+      ('link-to-kcell
        (if arg2
 	   (progn (insert "<")
 		  (when arg1 (insert arg1))
@@ -2717,33 +2718,33 @@ Summary of operations based on inputs (name arg from \\='hbut:current attrs):
 	 (insert "<@ ")
 	 (when arg1 (insert arg1))
 	 (insert ">")))
-      ((or 'actypes::link-to-kotl 'klink:act)
+      ((or 'link-to-kotl 'klink:act)
        (when (stringp arg1)
 	 (if (string-prefix-p "<" arg1)
 	     (insert arg1)
 	   (insert "<" arg1 ">"))))
       ;; Insert an Org-style link here so can include the Org title linked
       ;; to for clarity.
-      ('actypes::link-to-org-id
+      ('link-to-org-id
        (insert (if arg2
                    (format "[[id:%s][%s]]" arg1 arg2)
                  (format "[[id:%s]]" arg1))))
-      ('actypes::link-to-rfc (insert (format "rfc%d" arg1)))
-      ('actypes::link-to-wikiword (insert (if (and (stringp arg1)
-                                                   (string-match-p "\\s-" arg1))
-                                              ;; Double-quote when has a space
-                                              (format "\"%s\"" arg1)
-                                            arg1)))
+      ('link-to-rfc (insert (format "rfc%d" arg1)))
+      ('link-to-wikiword (insert (if (and (stringp arg1)
+                                          (string-match-p "\\s-" arg1))
+                                     ;; Double-quote when has a space
+                                     (format "\"%s\"" arg1)
+                                   arg1)))
       ('man (insert arg1))
-      ('actypes::man-show (insert arg1))
-      ('actypes::link-to-file-line (insert (format "\"%s:L%d\""
-						   (hpath:shorten arg1) arg2)))
-      ('actypes::link-to-file-line-and-column
+      ('man-show (insert arg1))
+      ('link-to-file-line (insert (format "\"%s:L%d\""
+					  (hpath:shorten arg1) arg2)))
+      ('link-to-file-line-and-column
        (insert
 	(if (eq arg3 0)
 	    (format "\"%s:L%d\"" (hpath:shorten arg1) arg2)
 	  (format "\"%s:L%d:C%d\"" (hpath:shorten arg1) arg2 arg3))))
-      ('actypes::link-to-file
+      ('link-to-file
        ;; arg2 when given is a buffer position
        (insert "\""
 	       (if arg2
@@ -2752,14 +2753,14 @@ Summary of operations based on inputs (name arg from \\='hbut:current attrs):
 		 ;; filename only
 		 (hpath:shorten arg1))
 	       "\""))
-      ('actypes::link-to-string-match
+      ('link-to-string-match
        (insert (format "\"%s#%s%s\"" (hpath:shorten arg3) arg1
 		       (if (<= arg2 1) "" (concat ":I" (number-to-string arg2))))))
-      ('actypes::link-to-texinfo-node
+      ('link-to-texinfo-node
        (insert (format "\"%s#%s\"" (hpath:shorten arg1) arg2)))
       ('nil (error "(ibut:insert-text): actype must be a Hyperbole actype or Lisp function symbol, not '%s'" orig-actype))
       ;; Generic action button type
-      (_ (insert (format "<%s%s%s>" (or (actype:def-symbol actype) actype)
+      (_ (insert (format "<%s%s%s>" actype
 			 (if args " " "")
 			 (if args (hypb:format-args args) "")))))
     (unless (looking-at "\\s-\\|\\'")
@@ -2862,7 +2863,10 @@ When NAME-KEY is nil, return the ibutton at point or nil if none."
 			;; Handle a name given rather than a name key
 			(when (string-match-p "\\s-" name-key)
 			  (setq name-key (ibut:label-to-key name-key)))
-			(let ((regexp (ibut:name-regexp name-key t))
+			(let ((regexp
+                               (concat (regexp-quote ibut:label-start)
+                                       "\\(" (ibut:name-regexp name-key t) "\\)"
+                                       (regexp-quote ibut:label-end)))
 			      (start (point))
 			      at-name-key
 			      pos
@@ -2874,7 +2878,7 @@ When NAME-KEY is nil, return the ibutton at point or nil if none."
 			    (forward-line 0)
 			    ;; re-search forward
 			    (while (and (not found) (re-search-forward regexp nil t))
-			      (setq pos (match-beginning 0)
+			      (setq pos (match-beginning 1)
 				    ;; Point might be on closing delimiter of ibut in which
 				    ;; case ibut:label-p returns nil; move back one
 				    ;; character to prevent this.
@@ -2886,7 +2890,7 @@ When NAME-KEY is nil, return the ibutton at point or nil if none."
 			      (goto-char start))
 			    ;; re-search backward
 			    (while (and (not found) (re-search-backward regexp nil t))
-			      (setq pos (match-beginning 0)
+			      (setq pos (match-beginning 1)
 				    at-name-key (ibut:at-p t)
 				    found (equal at-name-key name-key))))
 			  (when found
@@ -2959,35 +2963,28 @@ Find the nearest implicit button with LBL-KEY (a name or name key)
 within the visible portion of the current buffer and move to within
 its button text.  This will find an implicit button if point is
 within its name or text or if LBL-KEY is a name/name-key of an
-existing implicit button.  It will not find other unnamed implicit
-buttons.
+existing implicit button within the current buffer.  It will not
+find other unnamed implicit buttons.
 
 The caller must have populated the attributes of \='hbut:current.
 
 Return the symbol for the button if found, else nil."
-  (unless (stringp lbl-key)
-    (error "(ibut:to-text): %s 'lbl-key' arg must be a string, not: %S"
+  (unless (and (stringp lbl-key) (not (string-empty-p lbl-key)))
+    (error "(ibut:to-text): %s 'lbl-key' arg must be a non-empty string, not: %S"
 	   (hattr:get 'hbut:current 'categ)
 	   lbl-key))
   (hbut:funcall
    (lambda (lbl-key _buffer _key-src)
-     (let* ((name-end (hattr:get 'hbut:current 'name-end))
-	    (at-name (hattr:get 'hbut:current 'name))
-	    (at-text-key (hattr:get 'hbut:current 'lbl-key))
-	    (opoint (point))
+     (let* ((opoint (point))
 	    move-flag
 	    start
 	    ibut)
        ;; Do not move point if it is already in the text of an
        ;; implicit button matching LBL-KEY.  If on the name of
        ;; the same button, move into the text of the button.
-       (cond ((and lbl-key (equal at-text-key lbl-key))
-	      (setq ibut 'hbut:current))
-	     ((and at-name (equal (ibut:label-to-key at-name) lbl-key))
-	      (setq ibut 'hbut:current
-		    move-flag t))
-	     ((and lbl-key (setq ibut (ibut:to lbl-key)))
-	      (setq move-flag t)))
+       (when (and lbl-key (setq ibut (ibut:to lbl-key)))
+	 (setq move-flag t))
+
        (when (and move-flag ibut)
 	 ;; Skip past any optional name and separators
 	 (if (setq start (hattr:get ibut 'lbl-start))

--- a/hmouse-tag.el
+++ b/hmouse-tag.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    24-Aug-91
-;; Last-Mod:     27-May-26 at 09:54:20 by Bob Weiner
+;; Last-Mod:      7-Jun-26 at 10:53:31 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -417,7 +417,7 @@ When optional NO-FLASH, do not flash."
   (ignore-errors (require 'cc-mode) (c-initialize-cc-mode))
   nil)
 
-(defun smart-emacs-lisp-mode-p (&optional skip-identifier-flag)
+(defun smart-emacs-lisp-mode-p (&optional skip-existing-identifier-flag)
   "Return non-nil if in a mode using Emacs Lisp symbols."
   ;; Beyond Lisp files, Emacs Lisp symbols appear frequently in Byte-Compiled
   ;; buffers, debugger buffers, program ChangeLog buffers, Help buffers,
@@ -430,9 +430,10 @@ When optional NO-FLASH, do not flash."
       ;; Consider the following buffer types only if on an Emacs Lisp
       ;; symbol that can be looked up, e.g. in a TAGS file or via a
       ;; previous symbol load.
-      (and (or (apply #'derived-mode-p '(help-mode change-log-mode))
+      (and (or (apply #'derived-mode-p '(change-log-mode comint-mode
+                                         compilation-mode help-mode))
 	       (string-match-p "\\`\\*Help\\|Help\\*\\'" (buffer-name)))
-	   (or skip-identifier-flag (smart-lisp-at-known-identifier-p)))))
+	   (or skip-existing-identifier-flag (smart-lisp-at-known-identifier-p)))))
 
 (defun smart-fortran (&optional identifier next)
   "Jump to the definition of optional Fortran IDENTIFIER or the one at point.

--- a/hui-register.el
+++ b/hui-register.el
@@ -1,9 +1,9 @@
-;;; hui-register.el --- register support for Hyperbole    -*- lexical-binding: t; -*-
+;;; hui-register.el --- Hyperbole links to Emacs registers    -*- lexical-binding: t; -*-
 ;;
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:     6-Oct-91 at 03:42:38
-;; Last-Mod:      4-Nov-24 at 00:36:58 by Mats Lidell
+;; Last-Mod:      5-Jun-26 at 07:32:34 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;

--- a/hui.el
+++ b/hui.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 21:42:03
-;; Last-Mod:      4-Jun-26 at 09:55:07 by Bob Weiner
+;; Last-Mod:      5-Jun-26 at 07:58:00 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -2141,7 +2141,13 @@ Buffer without File      link-to-buffer-tmp"
 				  ;; On an implicit button other than a non-existing
 				  ;; potential HyWikiWord, so link to it
 				  ;; (message "%S" (hattr:list hbut-sym))
-				  (list 'link-to-ibut lbl-key (or (hypb:buffer-file-name) (buffer-name))))
+                                  (let ((file (hypb:buffer-file-name)))
+                                    (if (equal file buffer-file-name)
+				        (list 'link-to-ibut
+                                              (hbut:key-to-label lbl-key))
+				      (list 'link-to-ibut
+                                            (hbut:key-to-label lbl-key)
+                                            (or file (buffer-name))))))
 				 ((and (require 'bookmark)
 				       (derived-mode-p 'bookmark-bmenu-mode)
 				       (list 'link-to-bookmark (bookmark-bmenu-bookmark))))

--- a/hypb.el
+++ b/hypb.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     6-Oct-91 at 03:42:38
-;; Last-Mod:     28-May-26 at 12:18:39 by Bob Weiner
+;; Last-Mod:      5-Jun-26 at 07:51:13 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -282,7 +282,7 @@ name differs at the start and end of BODY."
 
 ;;;###autoload
 (defun hypb:buffer-file-name (&optional buffer)
-  "Return name of file BUFFER or current buffer is visiting; nil if none.
+  "Return name of file that BUFFER or current buffer is visiting; nil if none.
 No argument or nil as argument means use the current buffer.
 Produces the correct file name for indirect buffers as well."
    (buffer-file-name (or (buffer-base-buffer buffer) buffer)))

--- a/test/hui-register-tests.el
+++ b/test/hui-register-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    10-Sep-22 at 20:43:17
-;; Last-Mod:     16-Aug-25 at 15:36:47 by Bob Weiner
+;; Last-Mod:      6-Jun-26 at 01:57:16 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -62,13 +62,16 @@
     (unwind-protect
         (progn
           (find-file file1)
-          (insert "<[label]> ${HOME}")
+          (erase-buffer)
+          (insert "<[ibut-name]> ${HOME}")
           (goto-char 5)
           (let ((content (hui-register-struct-at-point)))
             (find-file file2)
-	    ;; Inserts ebut into file2 that contains an ilink in file1
-	    ;; that jumps to ${HOME}
+            (erase-buffer)
+	    ;; Inserts ebut into file2 that contains an ilink to an ibut
+            ;; named 'ibut-name' in file1 that jumps to ${HOME}
             (register-val-insert content)
+            (save-buffer)
             (should (equal (hypb:buffer-file-name) file2))
             (goto-char 5)
             (should (ebut:at-p))

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     12-Apr-26 at 15:11:31 by Bob Weiner
+;; Last-Mod:      6-Jun-26 at 01:57:18 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -648,8 +648,9 @@ of the defun."
     (unwind-protect
         (progn
           (find-file file)
+          (erase-buffer)
 	  (hy-test-helpers:ert-simulate-keys "ibut\rlink-to-rfc\r123\r"
-	    (hact (lambda () (call-interactively 'hui:ibut-create))))
+	    (call-interactively 'hui:ibut-create))
           (should (string= "<[ibut]> - rfc123" (buffer-string))))
       (hy-delete-file-and-buffer file))))
 
@@ -659,11 +660,12 @@ of the defun."
     (unwind-protect
         (progn
           (find-file file)
+          (erase-buffer)
           (insert "ibut")
           (set-mark (point-min))
           (goto-char (point-max))
 	  (hy-test-helpers:ert-simulate-keys "\rlink-to-rfc\r123\r"
-	    (hact (lambda () (call-interactively 'hui:ibut-create))))
+	    (call-interactively 'hui:ibut-create))
           (should (string= "<[ibut]> - rfc123" (buffer-string))))
       (hy-delete-file-and-buffer file))))
 
@@ -674,9 +676,10 @@ of the defun."
     (unwind-protect
         (progn
           (find-file file)
+          (erase-buffer)
           (insert "(sexp)")
 	  (hy-test-helpers:ert-simulate-keys "ibut\rlink-to-rfc\r123\r"
-	    (hact (lambda () (call-interactively 'hui:ibut-create))))
+	    (call-interactively 'hui:ibut-create))
           (should (string= "(sexp); <[ibut]> - rfc123" (buffer-string))))
       (hy-delete-file-and-buffer file))))
 


### PR DESCRIPTION
- link-to-ibut - Fix infinite loop, in-buffer links and but attr refs

- ibut:to-text - Fix in-buffer links and remove ref to ilink attributes
when intend to be refering to the attributes of the linked to ibut
itself.

- ibut:to - Fix to not find ibut names within <ilink:ibut-name> action
buttons.

- hui:link-possible-types - Fix to use ibut label rather than its key and
  omit location parameter if link is to a button in the source buffer.

- smart-emacs-lisp-mode-p - Add support for comint-mode and complilation-mode.