### PR TITLE
hash-merge - Fix `hash-map' call so stores symbol keys, not strings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2026-06-16  Bob Weiner  <rsw@gnu.org>
+
+* hasht.el (hash-merge): Fix call to hash-map which was not treating its
+    input as string-keys.  This led to HyWiki hash tables having string keys
+    rather than symbol keys whenever a non-page referent HyWiki word was read
+    in from the file where it was saved.
+
 2026-06-14  Bob Weiner  <rsw@gnu.org>
 
 * hactypes.el (link-to-ibut): Fix infinite loop in <ilink:label> by preventing

--- a/hasht.el
+++ b/hasht.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    16-Mar-90 at 03:38:48
-;; Last-Mod:     17-Feb-26 at 22:42:00 by Bob Weiner
+;; Last-Mod:     16-Jun-26 at 09:40:09 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -257,9 +257,9 @@ whose keys are the same."
 		       key value)
 		   (mapc
 		     (lambda (ht)
-		       (hash-map (lambda (val-key-cons)
-				   (setq value (car val-key-cons)
-					 key (cdr val-key-cons))
+		       (hash-map (lambda (val-string-key-cons)
+				   (setq value (car val-string-key-cons)
+					 key (intern (cdr val-string-key-cons)))
 				   (if (gethash key htable)
 				       ;; Merge values
 				       (puthash

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Apr-24 at 22:41:13
-;; Last-Mod:      9-Jun-26 at 11:01:49 by Bob Weiner
+;; Last-Mod:     15-Jun-26 at 18:10:04 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -3355,15 +3355,16 @@ If such an instance is not found, trigger an error."
 					    (setq key (file-name-sans-extension file))
 					    (unless (hash-get key non-page-hasht)
 					      (cons (cons 'page file) key)))
-					  page-files))))
+					  page-files)))
+             (page-hasht (hash-make page-elts)))
 	(setq hywiki--referent-hasht
 	      (if non-page-elts
- 		  (hash-merge non-page-hasht
-			      (hash-make page-elts))
-		(hash-make page-elts)))))))
+ 		  (hash-merge non-page-hasht page-hasht)
+		page-hasht))))))
 
 (defun hywiki-non-page-elt (val-key)
-  (unless (eq (caar val-key) 'page) val-key))
+  (unless (eq (caar val-key) 'page)
+    val-key))
 
 (defun hywiki--sitemap-file ()
   "Return file name for the sitemap file."


### PR DESCRIPTION
This fixes a HyWiki error where hash table keys were coming back as strings and then a 'symbol-name' call was applied which triggered an error.