### PR TITLE
Add ibtypes::ilink tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,8 @@
 2026-06-20  Mats Lidell  <matsl@gnu.org>
 
 * test/hibtypes-tests.el (ibtypes::ilink-ibut-in-other-file)
-    (ibtypes::ilink-error-case-missing-button): Add tests.
+    (ibtypes::ilink-error-case-missing-button)
+    (ibtypes::elink-ebut-in-other-file): Add tests.
 
 2026-06-18  Bob Weiner  <rsw@gnu.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2026-06-20  Mats Lidell  <matsl@gnu.org>
+
+* test/hibtypes-tests.el (ibtypes::ilink-ibut-in-other-file)
+    (ibtypes::ilink-error-case-missing-button): Add tests.
+
 2026-06-18  Bob Weiner  <rsw@gnu.org>
 
 * hui-select.el (hui-select-get-syntax-table): Add and leave syntax-table

--- a/test/hibtypes-tests.el
+++ b/test/hibtypes-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    20-Feb-21 at 23:45:00
-;; Last-Mod:     20-Jun-26 at 11:14:35 by Mats Lidell
+;; Last-Mod:     20-Jun-26 at 23:08:13 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -460,9 +460,9 @@
 (ert-deftest ibtypes::ilink-error-case-missing-button ()
   "Check `ibtypes::ilink' errors when named button does not exist in `other-buffer'."
   :expected-result :failed
-  ;; FIXME: This is cept as a separate test case for showing the
-  ;; problem. When it is fixed the test can me merged in the working
-  ;; inlink tests.
+  ;; FIXME: This is kept as a separate test case for showing the
+  ;; problem. When it is fixed the test can me merged with the working
+  ;; inlink test.
   (let ((file (make-temp-file "ilink-test")))
     (unwind-protect
         (progn

--- a/test/hibtypes-tests.el
+++ b/test/hibtypes-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    20-Feb-21 at 23:45:00
-;; Last-Mod:     18-Jun-26 at 12:04:02 by Bob Weiner
+;; Last-Mod:     20-Jun-26 at 11:06:02 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -399,6 +399,61 @@
             (should
              (string-match-p (rx "No button " (any punct) "Button3" (any punct) " in")
                              (cadr err)))))
+      (hy-delete-file-and-buffer file))))
+
+(ert-deftest ibtypes::ilink-ibut-in-other-file ()
+  "Verify link to ibut in other file."
+  (let ((file (make-temp-file "ilink.txt")))
+    (unwind-protect
+        (progn
+          (find-file file)
+          (insert "<[Button]> <identity 1>")
+
+          (save-excursion
+            (with-temp-buffer
+              (insert (format "<ilink: Button:\"%s\">\n" file))
+              (goto-char 4)
+              (should (= 1 (ibtypes::ilink)))))
+
+          (insert "<[ABC]> <identity 2>")
+
+          (save-excursion
+            (with-temp-buffer
+              (insert (format "<ilink: ABC:\"%s\">\n" file))
+              (goto-char 4)
+              (should (= 2 (ibtypes::ilink)))))
+
+          (save-excursion
+            (with-temp-buffer
+              (insert (format "<ilink: XYZ:\"%s\">\n" file))
+              (goto-char 4)
+              (let ((err (should-error (ibtypes::ilink))))
+              (should
+               (string-match-p (rx "No button " (any punct) "XYZ" (any punct) " in")
+                               (cadr err)))))))
+
+      (hy-delete-file-and-buffer file))))
+
+(ert-deftest ibtypes::ilink-error-case-missing-button ()
+  "Check `ibtypes::ilink' errors when named button does not exist in `other-buffer'."
+  :expected-result :failed
+  ;; FIXME: This is cept as a separate test case for showing the
+  ;; problem. When it is fixed the test can me merged in the working
+  ;; inlink tests.
+  (let ((file (make-temp-file "ilink-test")))
+    (unwind-protect
+        (progn
+          (find-file file)
+          (insert "<[Button]> <identity 1234>\n")
+          (with-temp-buffer
+            (insert (format "<ilink: XYZ : \"%s\">\n" file))
+            (goto-char 4)
+            ;; FIXME: This is what happens
+            ;; (should (= 1234 (ibtypes::ilink))))))
+            (let ((err (should-error (ibtypes::ilink))))
+              (should
+               (string-match-p (rx "No button " (any punct) "XYZ" (any punct) " in")
+                               (cadr err))))))
       (hy-delete-file-and-buffer file))))
 
 ;; ipython-stack-frame

--- a/test/hibtypes-tests.el
+++ b/test/hibtypes-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    20-Feb-21 at 23:45:00
-;; Last-Mod:     20-Jun-26 at 11:06:02 by Mats Lidell
+;; Last-Mod:     20-Jun-26 at 11:14:35 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -344,6 +344,29 @@
              ;; Nil looks wrong for the file name.
              (string-match-p (rx "No button " (any punct) "Other" (any punct))
                              (cadr err)))))
+      (hy-delete-files-and-buffers (list file)))))
+
+(ert-deftest ibtypes::elink-ebut-in-other-file ()
+  "Verify link to ebut in other file."
+  (let ((file (make-temp-file "elink")))
+    (unwind-protect
+        (progn
+          (find-file file)
+          (ebut:program "Button" 'eval-elisp '(message "EBUT"))
+
+          (save-excursion
+            (with-temp-buffer
+              (insert (format "<elink: Button:\"%s\">\n" file))
+              (goto-char 4)
+              (should (string= "EBUT" (ibtypes::elink)))
+
+              (goto-char (point-min))
+              (insert (format "<elink: Other:\"%s\">\n" file))
+              (goto-char 4)
+              (let ((err (should-error (ibtypes::elink))))
+                (should
+                 (string-match-p (rx "No button " (any punct) "Other" (any punct))
+                                 (cadr err)))))))
       (hy-delete-files-and-buffers (list file)))))
 
 ;; glink


### PR DESCRIPTION
# What

Add ibtypes::ilink tests.

* test/hibtypes-tests.el (ibtypes::ilink-ibut-in-other-file)
(ibtypes::ilink-error-case-missing-button)
(ibtypes::elink-ebut-in-other-file): Add tests.

# Why

Adding test for ibtypes::ilink and ibtypes::elink for but in other file which was missing before.

# Note

This PR includes a expected-result failed test which when fixed should
be possible to include with the other ibtyes::ilink tests. Maybe after
some rework when the cause of the problem has been solved.
