### PR TITLE
hui--hbut-act--links - Add test to distinguish i/e/g/link referents

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,15 @@
 2026-06-28  Bob Weiner  <rsw@gnu.org>
 
+* test/hui-tests.el (hui--hbut-act--links): Add for testing that ilinks,
+    elinks and glinks do not confuse each others referents.
+
+* hpath.el (hpath:delimited-possible-path): Fix 'delq nil' call to allow
+    for ~, ., *, ?, / and \\ valid single character/wildcard path characters.
+    Otherwise, paths like "~" and "./" are not recognized.
+
+* hypb.el (hypb:in-string-p): Fix doc to reflect that a list with positions
+    of the string is returned iff 'range-flag' is non-nil.
+
 * hmouse-drv.el (hkey-help): Improve to:
     1. show the doc for custom actype:help functions for the Assist Key
        (in addition to ibtype:help functions, e.g. see hsys-youtube.el.

--- a/hargs.el
+++ b/hargs.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    31-Oct-91 at 23:17:35
-;; Last-Mod:     27-Aug-25 at 23:10:25 by Bob Weiner
+;; Last-Mod:     28-Jun-26 at 13:57:12 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -162,8 +162,8 @@ normalized as a Hyperbole button key (no spaces)."
 	 string-start-end)
 
     (if (and (null start-regexp-flag) (null end-regexp-flag)
-	     (string-match "\\`['`\"]+\\'" start-delim)
-	     (string-match "\\`['`\"]+\\'" end-delim))
+	     (string-match-p "\\`['`\"]+\\'" start-delim)
+	     (string-match-p "\\`['`\"]+\\'" end-delim))
 	;; This is a string match
 	(setq string-start-end (hypb:in-string-p 2 :range)
 	      start (nth 1 string-start-end)

--- a/hpath.el
+++ b/hpath.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Nov-91 at 00:44:23
-;; Last-Mod:     21-May-26 at 10:01:23 by Bob Weiner
+;; Last-Mod:     28-Jun-26 at 14:18:59 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1187,7 +1187,10 @@ end-pos) or nil."
 	;; quote or surrounded by braces; if so, don't consider it a path.
 	;; Also ignore whitespace delimited root dirs, e.g. " / ".
 	(when (and (stringp p) (not (string-match-p "\\`{.*}\\'\\|\"\\|\\`[/\\]+\\'" p))
-		   (delq nil (mapcar (lambda (c) (/= (char-syntax ?.) (char-syntax c))) p)))
+		   (delq nil (mapcar (lambda (c)
+                                       (or (memq c '(?~ ?. ?/ ?* ?? ?\\))
+                                           (/= (char-syntax ?.) (char-syntax c))))
+                                     p)))
 	  ;; Prepend proper directory from cd, ls *, recursive ls or dir file
 	  ;; listings when needed.
 	  (setq p (string-trim p)

--- a/hypb.el
+++ b/hypb.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     6-Oct-91 at 03:42:38
-;; Last-Mod:      5-Jun-26 at 07:51:13 by Bob Weiner
+;; Last-Mod:     28-Jun-26 at 13:28:33 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -744,8 +744,8 @@ This will this install the Emacs helm package when needed."
 	     help-file))))
 
 (defun hypb:in-string-p (&optional max-lines range-flag)
-  "Return (is-in-string start end) for point, cached by buffer & modified time.
-Return non-nil iff point is within a string and not on the closing quote.
+  "Return non-nil iff point is within a string and not on the closing quote.
+This is cached by buffer & modified time for speed.
 
 With optional MAX-LINES, an integer, match only within that many
 lines from point.  With optional RANGE-FLAG when there is a

--- a/test/hui-tests.el
+++ b/test/hui-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    30-Jan-21 at 12:00:00
-;; Last-Mod:     25-Jun-26 at 09:59:14 by Bob Weiner
+;; Last-Mod:     28-Jun-26 at 14:11:17 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -32,6 +32,44 @@
 (load "klink")
 
 (declare-function hy-test-helpers:consume-input-events "hy-test-helpers")
+
+(ert-deftest hui--hbut-act--links ()
+  "Verify `hui:hbut-act' finds the ilink but not elink and glink."
+  ;; What should happen for elink and glink is not clear to me so I'm
+  ;; keeping the current behavior below that succeeds even for those
+  ;; cases.
+  (with-temp-buffer
+    (set-window-buffer (selected-window) (current-buffer))
+    (insert "\
+<ilink: Command >
+<[Command]> <identity 123)>
+")
+    (goto-char 4)
+    (ert-with-message-capture cap
+      (action-key)
+      (should (string-match-p "123\n" cap)))
+
+    ;; This should lead to possibly "No action defined for this
+    ;; context; try another location" or something similar.
+    (erase-buffer)
+    (insert "\
+<elink: Command >
+<[Command]> <identity 456)>
+")
+    (goto-char 4)
+    (ert-with-message-capture cap
+      (should-error (action-key)))
+
+    ;; This should lead to possibly "No action defined for this
+    ;; context; try another location" or something similar.
+    (erase-buffer)
+    (insert "\
+<glink: Command >
+<[Command]> <identity 789)>
+")
+    (goto-char 4)
+    (ert-with-message-capture cap
+      (should-error (action-key)))))
 
 (ert-deftest hui-gbut-edit-link-to-file-button ()
   "A global button with action type link-to-file shall be possible to edit."


### PR DESCRIPTION
- test/hui-tests.el (hui--hbut-act--links): Add for testing that ilinks, elinks and glinks do not confuse each others referents.

- hpath.el (hpath:delimited-possible-path): Fix 'delq nil' call to allow for ~, ., *, ?, / and \\ valid single character/wildcard path characters.  Otherwise, paths like "~" and "./" are not recognized.

- hypb.el (hypb:in-string-p): Fix doc to reflect that a list with positions of the string is returned iff 'range-flag' is non-nil.