### PR TITLE
Fix warnings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,12 @@
 2026-06-29  Mats Lidell  <matsl@gnu.org>
 
+* hibtypes.el (hywiki-add-spec, hywiki-message-spec):
+    (hywiki-word-create-and-display): Declare functions.
+
+* hmouse-drv.el (hattr:set, hywiki-get-referent): Declare functions.
+
+* hywiki.el (hywiki-add-spec): Fix quotes in docstring.
+
 * test/hui-tests.el (hui--hbut-act--links): Check error messages
     matches elink and glink. Remove old comments.
 

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:     28-Jun-26 at 09:27:49 by Bob Weiner
+;; Last-Mod:     29-Jun-26 at 22:27:41 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -68,10 +68,13 @@
 (declare-function hyperb:stack-frame "hversion")
 (declare-function hyrolo-get-file-list "hyrolo")
 (declare-function hywiki-active-in-current-buffer-p "hywiki")
+(declare-function hywiki-add-spec wikiword "hywiki")
 (declare-function hywiki-get-existing-page-file "hywiki")
 (declare-function hywiki-get-singular-wikiword "hywiki")
 (declare-function hywiki-highlight-word-get-range "hywiki")
+(declare-function hywiki-message-spec wikiword "hywiki")
 (declare-function hywiki-referent-exists-p "hywiki")
+(declare-function hywiki-word-create-and-display "hywiki")
 (declare-function hywiki-word-from-reference "hywiki")
 (declare-function markdown-footnote-goto-text "ext:markdown")
 (declare-function markdown-footnote-marker-positions "ext:markdown")

--- a/hmouse-drv.el
+++ b/hmouse-drv.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-90
-;; Last-Mod:     28-Jun-26 at 12:32:38 by Bob Weiner
+;; Last-Mod:     29-Jun-26 at 22:30:19 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -65,12 +65,14 @@
 (declare-function hattr:get "hbut")
 (declare-function hattr:list "hbut")
 (declare-function hattr:report "hbut")
+(declare-function hattr:set "hbut")
 (declare-function hbut:label "hbut")
 (declare-function hkey-quit-window "hmouse-drv") ; Alias defined in this file.
 (declare-function hkey-set-key "hyperbole")
 (declare-function hpath:display-buffer "hpath")
 (declare-function hui:ebut-link-directly "hui")
 (declare-function hui:ibut-link-directly "hui")
+(declare-function hywiki-get-referent "hywiki")
 (declare-function mouse-drag-frame "mouse") ;; Obsolete from Emacs 28
 (declare-function org-todo "org")
 

--- a/hywiki.el
+++ b/hywiki.el
@@ -1580,7 +1580,7 @@ with the page."
 (defun hywiki-add-spec (wikiword)
   "Create a WIKIWORD spec whose action selects and displays its referent type.
 The specified WIKIWORD is highlighted.  This replaces any existing referent
-the WIKIWORD may have.  Use ‘hywiki-get-referent’ to determine any referent
+the WIKIWORD may have.  Use `hywiki-get-referent' to determine any referent
 type associated with WIKIWORD prior to invoking this.
 
 This differs from `hywiki-word-create-and-display' in that selection and
@@ -1588,7 +1588,7 @@ display of the WIKIWORD referent is deferred until the first Action Key
 activation of the WIKIWORD.
 
 When the WIKIWORD spec is activated, prompt for and choose a typed referent.
-See ‘hywiki-referent-menu’ for valid referent types.  Select Page for a
+See `hywiki-referent-menu' for valid referent types.  Select Page for a
 standard HyWiki page.
 
 If WIKIWORD is invalid, trigger an error if called interactively


### PR DESCRIPTION
# What

Fix warnings

* hibtypes.el (hywiki-add-spec):
(hywiki-message-spec):
(hywiki-word-create-and-display): Declare functions.

* hmouse-drv.el (hattr:set):
(hywiki-get-referent): Declare functions.

* hywiki.el (hywiki-add-spec): Fix quotes in docstring.

# Why

Avoid warnings.
