### PR TITLE
Do not trigger workflow on doc updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,8 +3,14 @@ name: CI
 on:
   push:
     branches: [ "master" ]
+    paths-ignore:
+      - '**.md'
+      - 'man/**'
   pull_request:
     branches: [ "master" ]
+    paths-ignore:
+      - '**.md'
+      - 'man/**'
 
   workflow_dispatch:
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,9 @@
 2026-06-29  Mats Lidell  <matsl@gnu.org>
 
+* .github/workflows/main.yml (on): Reduce number of builds by
+    eliminating the main workflow to trigger on updates to markdown and
+    man/** files. Those are handled by the docs workflow.
+
 * hibtypes.el (hywiki-add-spec, hywiki-message-spec):
     (hywiki-word-create-and-display): Declare functions.
 


### PR DESCRIPTION
# What

Do not trigger workflow on doc updates.

* .github/workflows/main.yml (on): Reduce number of builds by
eliminating the main workflow to trigger on updates to markdown and
man/** files. Those are handled by the docs workflow.

# Why

Try to only do builds that are relevant for the current changes.
