### PR TITLE
Change path substitution var insertion

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2026-07-11  Mats Lidell  <matsl@gnu.org>
+
+* hpath.el (hpath:substitute-var): Try the substitution on the
+    absolute path.
+    (hpath:substitute-var-name): Anchor regexp substitution on first pos.
+
+* test/hpath-tests.el (hpath:substitute-var-test):
+    (hpath:substitute-var-name-test): Unit tests.
+
 2026-07-10  Bob Weiner  <rsw@gnu.org>
 
 * hywiki.el (hywiki-word-at-point, hywiki-word-at): Add to doc that point may
@@ -30,6 +39,7 @@
     string or nil, not the 't return value from 'hypb:in-string-p'.  Also,
     limit region narrowing to just where it is needed near the function
     beginning.
+
 2026-07-07  Bob Weiner  <rsw@gnu.org>
 
 * hsys-youtube.el (hsys-youtube-end-format): YouTube no longer allows end

--- a/hpath.el
+++ b/hpath.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Nov-91 at 00:44:23
-;; Last-Mod:     10-Jul-26 at 14:36:54 by Bob Weiner
+;; Last-Mod:     11-Jul-26 at 18:53:47 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -2283,13 +2283,13 @@ variable reference like ${variable}."
 	  (setq val (symbol-value var))
 	  (cond ((stringp val)
 		 (if (setq result
-			   (hpath:substitute-var-name var val path))
+			   (hpath:substitute-var-name var val (expand-file-name path)))
 		     (setq new-path result)))
 		((null val))
 		((listp val)
 		 (while (and val (null new-path))
 		   (when (setq result
-			       (hpath:substitute-var-name var (car val) path))
+			       (hpath:substitute-var-name var (car val) (expand-file-name path)))
 		     (setq new-path result))
 		   (setq val (cdr val))))
 		(t (error "(hpath:substitute-var): `%s' has invalid value for hpath:variables" var)))))
@@ -2890,8 +2890,7 @@ resolved without attaching the variable name.
 If PATH is modified, return PATH, otherwise return nil."
   (when (and (stringp var-dir-val) (file-name-absolute-p var-dir-val))
     (let ((new-path (replace-regexp-in-string
-		     (regexp-quote (file-name-as-directory
-				    (or var-dir-val default-directory)))
+		     (concat "^" (regexp-quote (file-name-as-directory var-dir-val)))
 		     ;; Remove matching path rather than adding the
 		     ;; variable to the path when the variable is one
 		     ;; for Elisp file paths and path is to an Elisp

--- a/test/hpath-tests.el
+++ b/test/hpath-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    28-Feb-21 at 23:26:00
-;; Last-Mod:     20-May-26 at 16:01:46 by Bob Weiner
+;; Last-Mod:      5-Jul-26 at 00:10:53 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -269,6 +269,46 @@
 
   (should (string= (hpath:substitute-value "$UNDEFINED_IS_NOT_SUBSTITUTED") "$UNDEFINED_IS_NOT_SUBSTITUTED"))
   (should (string= (hpath:substitute-value "${UNDEFINED_IS_NOT_SUBSTITUTED}") "${UNDEFINED_IS_NOT_SUBSTITUTED}")))
+
+(ert-deftest hpath:substitute-var-test ()
+  "Verify `hpath:substitute-var' inserts vars."
+  (let* ((hyperb:dir (make-temp-file "hypb_dir" t))
+         (file (expand-file-name "file" hyperb:dir))
+         (el-file (expand-file-name "file.el" hyperb:dir))
+         (non-existing-file (expand-file-name "foo.el" hyperb:dir))
+         (other-dir (make-temp-file "other_dir" t))
+         (other-el-file (expand-file-name "other.el" other-dir)))
+    (unwind-protect
+        (progn
+          (make-empty-file file)
+          (make-empty-file el-file)
+          (make-empty-file other-el-file)
+          (should (string= "${hyperb:dir}/file"
+                           (hpath:substitute-var file)))
+          (let ((default-directory other-dir))
+            (should (string= "${hyperb:dir}/file"
+                             (hpath:substitute-var (file-relative-name file default-directory)))))
+          (let ((default-directory hyperb:dir))
+            (should (string= (concat "../" (file-name-base other-dir) "/other.el")
+                             (hpath:substitute-var (file-relative-name other-el-file default-directory)))))
+          (should (string= "file.el"
+                           (hpath:substitute-var el-file)))
+          (should (string= non-existing-file
+                           (hpath:substitute-var non-existing-file))))
+      (hy-delete-files-and-buffers (list file el-file other-el-file))
+      (hy-delete-dir-and-buffer hyperb:dir)
+      (hy-delete-dir-and-buffer other-dir))))
+
+(ert-deftest hpath:substitute-var-name-test ()
+  "Verify variable name is substituted for the variable value in path."
+  (should (string= "${hyperb:dir}/file"
+                   (hpath:substitute-var-name 'hyperb:dir "/home/user/folder" "/home/user/folder/file")))
+  (should-not (hpath:substitute-var-name 'hyperb:dir "/home/user/folder" "../home/user/folder/file"))
+  (should (string= "${hyperb:dir}/file"
+                   (hpath:substitute-var-name 'hyperb:dir "/home/user/folder/" "/home/user/folder/file")))
+  (should (string= "file.el"
+                   (hpath:substitute-var-name 'hyperb:dir "/home/user/folder/" "/home/user/folder/file.el")))
+  (should-not (hpath:substitute-var-name 'hyperb:dir "/home/user/folder2/" "/home/user/folder/file.el")))
 
 (defun hypb-run-shell-test-command (command buffer)
   "Run a shell COMMAND with output to BUFFER and select it."


### PR DESCRIPTION
# What

Change path substitution var insertion.

Only insert variable if it matches the first pos in the path.

* hpath.el (hpath:substitute-var): Try the substitution on the
absolute path.
(hpath:substitute-var-name): Anchor regexp substitution on first pos.

* test/hpath-tests.el (hpath:substitute-var-test):
(hpath:substitute-var-name-test): Unit tests.

# Why

When linking to a line in a file in the hyperb:dir where a relative
link would be created the var was substituted in the path but kept as
a relative path. Like this:
     ```"..${hyperb:dir}/README.md:L14"```
Since it is a path with a variable it should be absolute.
