### PR TITLE
Fix warnings

### DIFF
--- a/hsys-denote.el
+++ b/hsys-denote.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Jul-16 at 14:54:14
-;; Last-Mod:     14-Jul-26 at 09:53:27 by Bob Weiner
+;; Last-Mod:     14-Jul-26 at 17:00:54 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -37,11 +37,15 @@
 ;;;###autoload
 (declare-function denote-extract-id-from-string "ext:denote")
 ;;;###autoload
+(declare-function denote-file-has-denoted-filename-p "ext:denote")
+;;;###autoload
 (declare-function denote-file-prompt "ext:denote")
 ;;;###autoload
 (declare-function denote-get-link-description "ext:denote")
 ;;;###autoload
 (declare-function denote-get-path-by-id "ext:denote")
+;;;###autoload
+(declare-function denote-retrieve-filename-identifier "ext:denote")
 
 (defvar denote-date-identifier-regexp)
 
@@ -235,7 +239,7 @@ column number."
                                       (error (point-min))))
                                   ;; Without 1+, line count is often off by one
                                   (min (1+ (point)) (point-max)))
-                               (current-line)))
+                               (line-number-at-pos)))
                    (col-num (current-column)))
                (concat (unless (<= line-num 1)
                          (format ":L%d" line-num))

--- a/hsys-org.el
+++ b/hsys-org.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     2-Jul-16 at 14:54:14
-;; Last-Mod:     14-Jul-26 at 02:41:34 by Bob Weiner
+;; Last-Mod:     14-Jul-26 at 17:05:28 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -58,6 +58,7 @@
 
 (defvar hyperbole-mode-map)             ; "hyperbole.el"
 (defvar org--inhibit-version-check)     ; "org-macs.el"
+(defvar hywiki-org-link-type)           ; "hywiki.el"
 (defvar hywiki-org-link-type-required)  ; "hywiki.el"
 (defvar org-agenda-buffer-tmp-name)     ; "org-agenda.el"
 (defvar org-uuid-regexp)                ; "org-macs.el"


### PR DESCRIPTION
# What

Fix warnings.

* hsys-denote.el (denote-file-has-denoted-filename-p):
(denote-retrieve-filename-identifier): Declare functions.
(hsys-denote-file-at-p): Use line-number-at-pos.
* hsys-org.el (hywiki-org-link-type): Defvar.

# Why

Warnings should be fixed.

Note: current-line does not exist. Use line-number-at-pos. Rest are
definitions.
