### PR TITLE
link-to-url - Add actype to support grabbing links from EWW buffers

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 2026-07-16  Bob Weiner  <rsw@gnu.org>
 
+* hsys-www.el (link-to-url): Explicitly duplicate `www-url' defact, for now.
+
 * hui.el (hui:ibut-message): Prefer 'name' to 'lbl-key' in message describing
     an implicit button.
          (hui:link-possible-types): For 'link-to-url', include and use anchor

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,36 @@
+2026-07-16  Bob Weiner  <rsw@gnu.org>
+
+* hui.el (hui:ibut-message): Prefer 'name' to 'lbl-key' in message describing
+    an implicit button.
+         (hui:link-possible-types): For 'link-to-url', include and use anchor
+    text as button name only if a prefix argument is given because that is
+    how 'hui:ibut-link-directly' on {C-u C-h h i l} works.
+  hbut.el (ibut:insert-text): For 'link-to-url' never insert anchor text as
+    title, that is done elsewhere.
+
+* test/hpath-tests.el (hpath:substitute-var-name-test, hpath:substitute-var-test):
+  hpath.el (hpath:substitute-var-name): Don't drop ${hyperb:dir} substitution
+    because path may be to another dir with that value in the root of its path.
+    Once we drop the whole prefix, the file could resolve to the wrong directory
+    and file.  So instead put the variable into the path.
+
+* hsys-www.el (www-url): Replace call of Hyperbole-defined 'eww-link-at-point'
+    with eww-defined 'eww-links-at-point'.
+  hui.el (hui:link-possible-types): Replace 'eww--url-at-point' call with
+    '(car (eww-links-at-point)' call
+
+* hywiki.el (hywiki-non-hook-context-p): Add Emacs pushbutton read-only
+    contexts (disallow HyWiki words there).
+  hibtypes.el (hywiki-existing-word, hywiki-word): Add initial check of
+    whether in a valid context, rather than doing this after local vars
+    are bound.
+
 2026-07-15  Bob Weiner  <rsw@gnu.org>
+
+* hbut.el (ibut:insert-text):
+  hui.el (hui:link-possible-types): Add linking support to urls within
+    'eww-mode' buffers.
+  hsys-www.el (link-to-url): Add and alias to actype www-url.
 
 * Makefile (env): Add and document this target (alias of echo target).
 

--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:     13-Jul-26 at 19:23:07 by Bob Weiner
+;; Last-Mod:     16-Jul-26 at 16:25:00 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -2686,7 +2686,7 @@ Summary of operations based on inputs (name arg from \\='hbut:current attrs):
 
     (let ((lbl-key (hattr:get 'hbut:current 'lbl-key)))
       (unless (and (stringp lbl-key) (not (string-empty-p lbl-key)))
-	(hypb:error "(ibut:operate): hbut:current lbl-key must be non-nil")))
+        (hypb:error "(ibut:operate): hbut:current lbl-key must be non-nil")))
 
     (run-hooks (if edit-flag 'ibut-edit-hook 'ibut-create-hook))
 
@@ -2732,6 +2732,7 @@ Summary of operations based on inputs (name arg from \\='hbut:current attrs):
 	     (t (insert "{}"))))
       ((or 'link-to-directory 'link-to-Info-node 'link-to-Info-index-item)
        (insert "\"" arg1 "\""))
+      ('link-to-url (insert arg1))
       ('annot-bib (insert "[" arg1 "]"))
       ('exec-shell-cmd (insert "\"!" arg1 "\""))
       ('exec-window-cmd (insert "\"&" arg1 "\""))

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:     29-Jun-26 at 22:27:41 by Mats Lidell
+;; Last-Mod:     16-Jul-26 at 10:47:49 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -129,7 +129,8 @@ use.
 
 Existing HyWikiWords are handled by the implicit button type
 `hywiki-existing-word'."
-  (when (hywiki-active-in-current-buffer-p)
+  (when (and (hywiki-active-in-current-buffer-p)
+             (not (hywiki-non-hook-context-p)))
     (let* ((wikiword-start-end (hywiki-highlight-word-get-range))
 	   (wikiword (nth 0 wikiword-start-end))
 	   (start    (nth 1 wikiword-start-end))
@@ -1839,7 +1840,8 @@ for this to activate.
 
 See the implicit button type `hywiki-word' for creation of referents to
 not yet existing HyWikiWords."
-  (when (hywiki-active-in-current-buffer-p)
+  (when (and (hywiki-active-in-current-buffer-p)
+             (not (hywiki-non-hook-context-p)))
     (cl-destructuring-bind (wikiword start end)
 	(hywiki-referent-exists-p :range)
       (when wikiword

--- a/hpath.el
+++ b/hpath.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Nov-91 at 00:44:23
-;; Last-Mod:     15-Jul-26 at 17:33:26 by Bob Weiner
+;; Last-Mod:     16-Jul-26 at 16:57:49 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -2892,8 +2892,8 @@ that returns a replacement string."
   "Replace with VAR-SYMBOL any occurrences of VAR-DIR-VAL in PATH.
 Replacement is done iff VAR-DIR-VAL is an absolute path.
 
-If VAR-SYMBOL is \\='hyperb:dir or \\='load-path, remove the matching PATH
-part rather than replacing it with the variable since it can be
+If VAR-SYMBOL is \\='load-path, remove the matching PATH part
+rather than replacing it with the variable since it can be
 resolved without attaching the variable name.
 
 If PATH is modified, return PATH, otherwise return nil."
@@ -2905,7 +2905,7 @@ If PATH is modified, return PATH, otherwise return nil."
 		     ;; for Elisp file paths and path is to an Elisp
 		     ;; file.  These can be resolved without the
 		     ;; variable being included in the path.
-		     (if (and (memq var-symbol '(hyperb:dir load-path))
+		     (if (and (memq var-symbol '(load-path))
 			      (delq nil (mapcar (lambda (suffix) (string-suffix-p suffix path))
 						(get-load-suffixes))))
 			 ""

--- a/hsys-www.el
+++ b/hsys-www.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Apr-94 at 17:17:39 by Bob Weiner
-;; Last-Mod:      7-Nov-25 at 19:23:34 by Mats Lidell
+;; Last-Mod:     16-Jul-26 at 17:00:46 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -91,9 +91,15 @@ Valid values of this variable include `browse-url-default-browser' and
 	 ;; Don't match if at the end of the buffer; end of line is
 	 ;; handled elsewhere.
 	 nil)
-	((and (eq major-mode 'eww-mode) (eww-link-at-point))
-	 (ibut:label-set (eww-link-at-point))
-	 (hact 'eww-follow-link))
+	((and (eq major-mode 'eww-mode) (eww-links-at-point))
+         (let ((push-button (button-at (point))))
+           ;; Set the ibut name to be the text description of the url
+           (hattr:set 'hbut:current 'name (button-label push-button))
+           ;; Set the ibut lbl-key to be the url
+	   (ibut:label-set (car (eww-links-at-point))
+                           (button-start push-button)
+                           (button-end push-button))
+	   (hact 'eww-follow-link)))
 	((eq major-mode 'eww-bookmark-mode)
 	 (ibut:label-set (concat (eww-bookmark-property :title)
 				 (if (eww-bookmark-property :url)
@@ -110,11 +116,14 @@ Valid values of this variable include `browse-url-default-browser' and
 		 (progn (ibut:label-set link-and-pos)
 			(hact 'www-url (car link-and-pos))))))))
 
-(defact www-url (url)
-  "Follow a link given by URL.
+(defact www-url (url &optional _label)
+  "Follow a link given by URL and optional text _LABEL.
 The variable, `browse-url-browser-function', customizes the url browser that
 is used.  Valid values of this variable include `browse-url-default-browser' and
-`browse-url-generic'."
+`browse-url-generic'.
+
+_LABEL is used in `hui:link-possible-types' with the `link-to-url' call and
+in `ibut:insert-text' as the name of the implicit button inserted."
   (interactive "sURL to follow: ")
   (unless (stringp url)
     (error "(www-url): URL = `%s' but must be a string" url))
@@ -143,6 +152,9 @@ is used.  Valid values of this variable include `browse-url-default-browser' and
 	(browse-url url)
 	(message "Sending %s to %s...done" url browser))
     (error "(www-url): `browse-url-browser-function' must be set to a web browser invoking function")))
+
+;; Make `link-to-url' an alias actype for `www-url'.
+(eval `(defact link-to-url ,@(nthcdr 2 (actype:action-body 'www-url))))
 
 (defun www-url-compose-mail (to &optional subject body &rest _ignore)
   "Compose a mailto url and open it in the default `browse-url' web browser.

--- a/hsys-www.el
+++ b/hsys-www.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Apr-94 at 17:17:39 by Bob Weiner
-;; Last-Mod:     16-Jul-26 at 17:00:46 by Bob Weiner
+;; Last-Mod:     16-Jul-26 at 17:36:43 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -116,6 +116,45 @@ Valid values of this variable include `browse-url-default-browser' and
 		 (progn (ibut:label-set link-and-pos)
 			(hact 'www-url (car link-and-pos))))))))
 
+
+(defact link-to-url (url &optional _label)
+  "Follow a link given by URL and optional text _LABEL.
+The variable, `browse-url-browser-function', customizes the url browser that
+is used.  Valid values of this variable include `browse-url-default-browser' and
+`browse-url-generic'.
+
+_LABEL is used in `hui:link-possible-types' with the `link-to-url' call and
+in `ibut:insert-text' as the name of the implicit button inserted."
+  (interactive "sURL to follow: ")
+  (unless (stringp url)
+    (error "(link-to-url): URL = `%s' but must be a string" url))
+  (unless (seq-position url ?:)
+    (setq url (concat "https://" url)))
+  (if (or (functionp browse-url-browser-function)
+	  ;; May be a predicate alist of functions from which to select
+	  (consp browse-url-browser-function))
+      (let ((browse-url-browser-function
+	     (if (eq browse-url-browser-function #'eww-browse-url)
+		 ;; Hyperbole-specific version
+		 #'www-eww-browse-url
+	       browse-url-browser-function))
+	    browse-function-name
+	    browser)
+	(if (symbolp browse-url-browser-function)
+	    (setq browse-function-name (symbol-name browse-url-browser-function)
+		  browser (and (string-match
+				"-\\([^-]+\\)\\'"
+				browse-function-name)
+			       (capitalize (substring browse-function-name
+						      (match-beginning 1)
+						      (match-end 1)))))
+	  (setq browser "default browser"))
+	(message "Sending %s to %s..." url browser)
+	(browse-url url)
+	(message "Sending %s to %s...done" url browser))
+    (error "(link-to-url): `browse-url-browser-function' must be set to a web browser invoking function")))
+
+;; !! TODO: Duplicate of `link-to-url' defact to consider getting rid of
 (defact www-url (url &optional _label)
   "Follow a link given by URL and optional text _LABEL.
 The variable, `browse-url-browser-function', customizes the url browser that
@@ -152,9 +191,6 @@ in `ibut:insert-text' as the name of the implicit button inserted."
 	(browse-url url)
 	(message "Sending %s to %s...done" url browser))
     (error "(www-url): `browse-url-browser-function' must be set to a web browser invoking function")))
-
-;; Make `link-to-url' an alias actype for `www-url'.
-(eval `(defact link-to-url ,@(nthcdr 2 (actype:action-body 'www-url))))
 
 (defun www-url-compose-mail (to &optional subject body &rest _ignore)
   "Compose a mailto url and open it in the default `browse-url' web browser.

--- a/hui-mouse.el
+++ b/hui-mouse.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-89
-;; Last-Mod:     13-Jul-26 at 16:26:41 by Bob Weiner
+;; Last-Mod:     16-Jul-26 at 11:09:40 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -261,8 +261,10 @@ The button's attributes are stored in the symbol, `hbut:current'.")
     ((eq major-mode 'dired-sidebar-mode)
      . ((smart-dired-sidebar) . (smart-dired-sidebar)))
     ;;
-    ;; Handle Emacs push buttons in buffers
-    ((button-at (point))
+    ;; Handle non-eww url Emacs push buttons in buffers
+    ((and (setq hkey-value (button-at (point)))
+          ;; If an eww url button, handle later as an ibut
+          (not (and (eq major-mode 'eww-mode) (eww-links-at-point))))
      . ((smart-push-button nil (mouse-event-p last-command-event))
 	. (smart-push-button-help nil (mouse-event-p last-command-event))))
     ;;

--- a/hui.el
+++ b/hui.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 21:42:03
-;; Last-Mod:     14-Jul-26 at 09:28:33 by Bob Weiner
+;; Last-Mod:     16-Jul-26 at 16:29:30 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -42,6 +42,8 @@
 (declare-function Info-menu-item-at-p "hmouse-info")
 (declare-function actypes::link-to-wikiword "hywiki")
 (declare-function bookmark-bmenu-bookmark "bookmark")
+(declare-function eww-current-url "eww")
+(declare-function eww-links-at-point "eww")
 (declare-function hsys-denote-file-at-p "hsys-denote")
 (declare-function hsys-denote-link-at-p "hsys-denote")
 (declare-function hui-register-struct-at-point "hui-register")
@@ -1380,7 +1382,8 @@ runs this command."
 	  (setq edit-flag t
 		but-loc (hattr:get 'hbut:current 'loc)
 		but-dir (hattr:get 'hbut:current 'dir)
-		name-key (ibut:label-to-key (hattr:get 'hbut:current 'name)))
+		name-key (or (ibut:label-to-key (hattr:get 'hbut:current 'name))
+                             (hattr:get 'hbut:current 'lbl-key)))
 	(setq but-loc (hui:key-src (current-buffer))
 	      but-dir (hui:key-dir (current-buffer))))
 
@@ -1395,8 +1398,11 @@ runs this command."
 			       hkey-region)
 			      ((use-region-p)
 			       (hui:hbut-label-default
-				(region-beginning) (region-end))))
-			"ibut-link-directly"
+				(region-beginning) (region-end)))
+                              ((eq (caar link-types) 'link-to-url)
+                               ;; Use the link anchor text as the label default
+                               (nth 2 (car link-types))))
+                        "ibut-link-directly"
 			"Name for implicit button: ")
 	      name-key (hbut:label-to-key but-name)))
 
@@ -1957,7 +1963,8 @@ With BUT-EDIT-FLAG non-nil message about ibut being edited."
                        actype)))
     (message "%s%s%s %s %S"
 	     ibut:label-start
-	     (hbut:key-to-label (hattr:get 'hbut:current 'lbl-key))
+             (or (hattr:get 'hbut:current 'name)
+	         (hbut:key-to-label (hattr:get 'hbut:current 'lbl-key)))
 	     ibut:label-end
 	     (if but-edit-flag "now executes" "executes")
 	     (cons actype args))))
@@ -2071,6 +2078,7 @@ possible types.
 Referent Context         Possible Link Type Returned
 ----------------------------------------------------
 Denote Link              link-to-denote
+EWW Web Page Buffer      link-to-url
 Org Roam or Org Id       link-to-org-id
 HyWikiWord Reference     link-to-wikiword
 Global Button            link-to-gbut
@@ -2109,6 +2117,13 @@ Buffer without File      link-to-buffer-tmp"
                         ;; Denote file and possible section heading
                         ((setq lbl-key (hsys-denote-file-at-p))
                          (list 'link-to-denote lbl-key))
+
+		        ((derived-mode-p 'eww-mode)
+                         (let ((url-at-point (car (eww-links-at-point))))
+		           (list 'link-to-url
+                                 (or url-at-point (eww-current-url))
+                                 (when (and url-at-point current-prefix-arg)
+                                   (button-label (button-at (point)))))))
 
                         ;; Org id or Org Roam id
                         ((and (featurep 'org-id)

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Apr-24 at 22:41:13
-;; Last-Mod:     14-Jul-26 at 09:25:49 by Bob Weiner
+;; Last-Mod:     16-Jul-26 at 10:42:48 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -878,6 +878,8 @@ When used within a `post-command-hook', point must be moved back to
 its location prior to the associated command run before this is called
 since the command may have moved it off a HyWikiWord."
   (or (minibuffer-window-active-p (selected-window))
+      ;; Can't be on an Emacs read-only pushbutton
+      (button-at (point))
       ;; (and (bound-and-true-p edebug-active)
       ;;   (active-minibuffer-window))
       (and (derived-mode-p 'prog-mode)

--- a/test/hpath-tests.el
+++ b/test/hpath-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    28-Feb-21 at 23:26:00
-;; Last-Mod:     15-Jul-26 at 17:37:35 by Bob Weiner
+;; Last-Mod:     16-Jul-26 at 13:43:29 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -291,7 +291,7 @@
           (let ((default-directory hyperb:dir))
             (should (string= (concat "../" (file-name-base other-dir) "/other.el")
                              (hpath:substitute-var (file-relative-name other-el-file default-directory)))))
-          (should (string= "file.el"
+          (should (string= "${hyperb:dir}/file.el"
                            (hpath:substitute-var el-file)))
           (should (string= non-existing-file
                            (hpath:substitute-var non-existing-file))))
@@ -306,7 +306,7 @@
   (should-not (hpath:substitute-var-name 'hyperb:dir "/home/user/folder" "../home/user/folder/file"))
   (should (string= "${hyperb:dir}/file"
                    (hpath:substitute-var-name 'hyperb:dir "/home/user/folder/" "/home/user/folder/file")))
-  (should (string= "file.el"
+  (should (string= "${hyperb:dir}/file.el"
                    (hpath:substitute-var-name 'hyperb:dir "/home/user/folder/" "/home/user/folder/file.el")))
   (should-not (hpath:substitute-var-name 'hyperb:dir "/home/user/folder2/" "/home/user/folder/file.el")))
 


### PR DESCRIPTION
- hpath:substitute-var-name - Don't drop ${hyperb:dir} substitution because path may be to another dir with that value in the root of its path.

- hywiki-non-hook-context-p - Add Emacs pushbutton read-only contexts (disallow HyWiki words there).

- hywiki-existing-word, hywiki-word - Add initial check of whether in a valid context, rather than doing this after local vars are bound.