### PR TITLE
Fix remove command for docker volumes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2026-07-16  Mats Lidell  <matsl@gnu.org>
+
+* Makefile (docker-clean): Fix remove command for docker volumes.
+
 2026-07-16  Bob Weiner  <rsw@gnu.org>
 
 * hsys-www.el (link-to-url): Explicitly duplicate `www-url' defact, for now.

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:     15-Jul-26 at 21:34:14 by Bob Weiner
+# Last-Mod:     16-Jul-26 at 23:26:56 by Mats Lidell
 #
 # Copyright (C) 1994-2026  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -707,7 +707,7 @@ run-bash:
 
 .PHONY: docker-clean
 docker-clean:
-	docker rm elpa-local
+	docker volume rm elpa-local || true
 
 # Run with coverage. Run tests given by testspec and monitor the
 # coverage for the specified file.


### PR DESCRIPTION
# What

* Makefile (docker-clean): Fix remove command for docker volumes.

# Why

The command was wrong. Maybe docker changed it over time but this
works on my machine.

# Note

I noticed this problem when trying to develop #1007. For being close to GitHub local elpa cache have to be removed between each "make docker" run.  We had a target for that but the command did not work any more and this fixes that.

With this you can do:

```make docker-clean docker ...```

to get something close to what CI is doing in Github.

Unfortunately running without a local elpa cache does not help to trouble shoot the problem I have now. The local docker build works even without a cache even in #1007.
