### PR TITLE
Add a delay before retrying

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2026-07-19  Mats Lidell  <matsl@gnu.org>
+
+* test/hy-test-dependencies.el (hypb:package-install-advice-for-retry):
+    Add delay before retrying.
+
 2026-07-18  Mats Lidell  <matsl@gnu.org>
 
 * test/hy-test-dependencies.el (hypb:package-install-advice-for-retry):

--- a/test/hy-test-dependencies.el
+++ b/test/hy-test-dependencies.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    20-Feb-21 at 23:16:00
-;; Last-Mod:     19-Jul-26 at 09:45:26 by Mats Lidell
+;; Last-Mod:     19-Jul-26 at 18:00:48 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -40,8 +40,8 @@
            (signal (car err) (cdr err)))
          (if (>= attempt retries)
              (signal (car err) (cdr err))
-           (message "package-install failed (attempt %d/%d): %s"
-                    attempt retries (error-message-string err))
+           (message "(hypb:package-install-advice-for-retry) package-install of '%s' failed (attempt %d/%d): %s"
+                    (car args) attempt retries (error-message-string err))
            (sleep-for delay)))))
     result))
 

--- a/test/hy-test-dependencies.el
+++ b/test/hy-test-dependencies.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    20-Feb-21 at 23:16:00
-;; Last-Mod:     18-Jul-26 at 15:13:20 by Mats Lidell
+;; Last-Mod:     19-Jul-26 at 09:45:26 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -25,6 +25,7 @@
   "Add a retry layer on top of package-install."
   (let ((retries 3)
         (attempt 0)
+        (delay 1)
         done
         result)
     (while (not done)
@@ -37,10 +38,11 @@
          ;; Reraise if error is not stringp nil
          (unless (equal (cdr err) '(stringp nil))
            (signal (car err) (cdr err)))
-         (if (<= attempt retries)
-             (message "package-install failed (attempt %d/%d): %s"
-                      attempt retries (error-message-string err))
-           (signal (car err) (cdr err))))))
+         (if (>= attempt retries)
+             (signal (car err) (cdr err))
+           (message "package-install failed (attempt %d/%d): %s"
+                    attempt retries (error-message-string err))
+           (sleep-for delay)))))
     result))
 
 ;; Apply advice only for Emacs master branch version used in CI


### PR DESCRIPTION
# What

Add a delay before retrying.

* test/hy-test-dependencies.el (hypb:package-install-advice-for-retry):
    Add delay before retrying.

# Why

The master build failed even after three retries. Adding a delay
between the retries to see if that works better in the master build.

# Note

This PR run actually shows the issue and did one retry before the installation worked:
```
...
   passed  418/706  hyrolo-tests--fgrep-and-goto-next-visible-kotl-heading-level-2 (0.010737 sec)
Setting `package-selected-packages' temporarily since "emacs -q" would overwrite customizations
package-install failed (attempt 1/3): Wrong type argument: stringp, nil
Contacting host: elpa.nongnu.org:443
Contacting host: elpa.nongnu.org:443
Parsing tar file...
Parsing tar file...done
Extracting... \
Extracting...done
  INFO     Scraping 2 files for loaddefs...
  INFO     Scraping 2 files for loaddefs...done
  GEN      markdown-mode-autoloads.el
Checking /github/home/.emacs.d/elpa/markdown-mode-2.8...
Compiling /github/home/.emacs.d/elpa/markdown-mode-2.8/markdown-mode-autoloads.el...
Compiling /github/home/.emacs.d/elpa/markdown-mode-2.8/markdown-mode-pkg.el...
Compiling /github/home/.emacs.d/elpa/markdown-mode-2.8/markdown-mode.el...
Done (Total of 1 file compiled, 2 skipped)
Contacting host: elpa.nongnu.org:443
Package `markdown-mode' installed
   passed  419/706  hyrolo-tests--fgrep-and-goto-next-visible-md-heading (2.377287 sec)
...
```
