### PR TITLE
Add HyWiki include and exclude major-mode tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2026-07-22  Mats Lidell  <matsl@gnu.org>
+
+* test/hywiki-tests.el (hywiki-tests--potential-buffer-p): New test.
+    (hywiki-tests--active-in-current-buffer-p): Refactor test, no buffers.
+
 2026-07-21  Bob Weiner  <rsw@gnu.org>
 
 * hywiki.el (hywiki-get-entry): Fix return of display-buffer string

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    18-May-24 at 23:59:48
-;; Last-Mod:     14-Jul-26 at 01:52:39 by Bob Weiner
+;; Last-Mod:     21-Jul-26 at 22:30:31 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -595,18 +595,16 @@ HyWikiWord reference."
 
 (ert-deftest hywiki-tests--active-in-current-buffer-p ()
   "Verify `hywiki-active-in-current-buffer-p'."
-  (hywiki-tests--preserve-hywiki-mode
-    (with-current-buffer (find-file-noselect wiki-page)
-      (should (hywiki-active-in-current-buffer-p))
-      (hywiki-mode nil)
-      (should-not (hywiki-active-in-current-buffer-p))
-      (let ((hywiki-exclude-major-modes (list 'org-mode)))
-        (should-not (hywiki-active-in-current-buffer-p)))
-      (hywiki-mode nil)
-      (mocklet ((hywiki-in-page-p => nil))
-        (should-not (hywiki-active-in-current-buffer-p)))
-      (dired-mode)
-      (should-not (hywiki-active-in-current-buffer-p)))))
+  (let ((hywiki-mode nil))
+    (should-not (hywiki-active-in-current-buffer-p)))
+  (let ((hywiki-mode :pages))
+    (with-mock
+      (mock (hywiki-in-page-p) => 'in-page-p)
+      (should (eq 'in-page-p (hywiki-active-in-current-buffer-p)))))
+  (let ((hywiki-mode :all))
+    (with-mock
+      (mock (hywiki-potential-buffer-p) => 'potential-buffer-p)
+      (should (eq 'potential-buffer-p (hywiki-active-in-current-buffer-p))))))
 
 (ert-deftest hywiki-tests--directory-get-mod-time ()
   "Verify `hywiki-directory-get-mod-time'."
@@ -2351,6 +2349,27 @@ See helper `hywiki-display-hywiki-test' above for verifying display call."
       (save-excursion
         (beginning-of-line)
         (should (looking-at-p (regexp-quote "[[*Header")))))))
+
+(ert-deftest hywiki-tests--potential-buffer-p ()
+  "Verify include and exclude mode treatment in `hywiki-potential-buffer-p'.
+Verifies the behavior controlled by the variables
+`hywiki-include-special-modes' and `hywiki-exclude-major-modes'."
+  (cl-letf (((symbol-function 'minibufferp)
+             (lambda (&optional _buffer _live) t)))
+    (should-not (hywiki-potential-buffer-p)))
+  (with-temp-buffer
+    ;; Regular major-mode
+    (python-mode)
+    (should (hywiki-potential-buffer-p))
+    (let ((hywiki-exclude-major-modes (list 'python-mode)))
+      (should-not (hywiki-potential-buffer-p))
+      (let ((hywiki-include-special-modes (list 'python-mode)))
+        (should (hywiki-potential-buffer-p))))
+    ;; Special major-mode
+    (dired-mode)
+    (should-not (hywiki-potential-buffer-p))
+    (let ((hywiki-include-special-modes (list 'dired-mode)))
+      (should (hywiki-potential-buffer-p)))))
 
 (provide 'hywiki-tests)
 


### PR DESCRIPTION
# What

Add HyWiki include and exclude major-mode tests.

* test/hywiki-tests.el (hywiki-tests--potential-buffer-p): New test.
    (hywiki-tests--active-in-current-buffer-p): Refactor test, no buffers.

# Why

More tests.
