### PR TITLE
Add copyright to installation instruction files

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2026-07-25  Mats Lidell  <matsl@gnu.org>
+
+* man/hy-package.el:
+* man/hy-straight.el: Add copyright
+
 2026-07-23  Bob Weiner  <rsw@gnu.org>
 
 * hywiki.el (hywiki-get-entry): Strip file header when returning

--- a/man/hy-package.el
+++ b/man/hy-package.el
@@ -1,3 +1,17 @@
+;;; hy-package.el --- Hyperbole package.el installation and configuration instructions  -*- lexical-binding: t; -*-
+;;
+;; Author:       Bob Weiner
+;;
+;; Orig-Date:    15-Jul-26 at 12:28:58
+;; Last-Mod:     25-Jul-26 at 22:25:11 by Mats Lidell
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
+;; Copyright (C) 2026  Free Software Foundation, Inc.
+;; See the "../HY-COPY" file for license information.
+;;
+;; This file is part of GNU Hyperbole.
+
 ;;; ************************************************************************
 ;;; Requirements
 ;;; ************************************************************************

--- a/man/hy-straight.el
+++ b/man/hy-straight.el
@@ -1,3 +1,17 @@
+;;; hy-straight.el --- Hyperbole Straight installation and configuration instructions  -*- lexical-binding: t; -*-
+;;
+;; Author:       Bob Weiner
+;;
+;; Orig-Date:    15-Jul-26 at 12:28:58
+;; Last-Mod:     25-Jul-26 at 22:25:45 by Mats Lidell
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
+;; Copyright (C) 2026  Free Software Foundation, Inc.
+;; See the "../HY-COPY" file for license information.
+;;
+;; This file is part of GNU Hyperbole.
+
 ;;; ************************************************************************
 ;;; Section 1: Straight setup
 ;;; ************************************************************************


### PR DESCRIPTION
# What

Add copyright to installation instruction files.

* man/hy-package.el:
* man/hy-straight.el: Add copyright

# Why

Needed by Elpa copyright check.
