### PR TITLE
Update Maintainer header, remove Maintainers

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 2026-07-25  Mats Lidell  <matsl@gnu.org>
 
+* hyperbole.el: Use only Maintainer header.
+
 * man/hy-package.el:
 * man/hy-straight.el: Add copyright
 

--- a/hyperbole.el
+++ b/hyperbole.el
@@ -2,14 +2,13 @@
 
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
-;; Copyright (C) 1992-2025  Free Software Foundation, Inc.
+;; Copyright (C) 1992-2026  Free Software Foundation, Inc.
 
 ;; Author:       Robert Weiner <rsw@gnu.org>
-;; Authors:      Robert Weiner <rsw@gnu.org>, Mats Lidell <matsl@gnu.org>
 ;; Maintainer:   Robert Weiner <rsw@gnu.org>
-;; Maintainers:  Robert Weiner <rsw@gnu.org>, Mats Lidell <matsl@gnu.org>
+;;               Mats Lidell <matsl@gnu.org>
 ;; Created:      06-Oct-92 at 11:52:51
-;; Last-Mod:     22-Jul-26 at 11:15:05 by Bob Weiner
+;; Last-Mod:     25-Jul-26 at 22:44:16 by Mats Lidell
 ;; Released:     10-Mar-24
 ;; Version:      9.0.2pre
 ;; Keywords:     comm, convenience, files, frames, hypermedia, languages, mail, matching, mouse, multimedia, outlines, tools, wp


### PR DESCRIPTION
# What

Update Maintainer header, remove Maintainers.

* hyperbole.el: Use only Maintainer header.

# Why

The Maintainer header can be used for multiple maintainers
nowadays. Maintainers is not needed and possibly not even used.
