### PR TITLE
Resolve warnings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 2026-07-25  Mats Lidell  <matsl@gnu.org>
 
+* hibtypes.el (hywiki-non-hook-context-p):
+  hmouse-drv.el (hattr:copy, hywiki-get-definition, ibut:key-to-label):
+  hsys-www.el (eww-links-at-point): Declare functions.
+
+* hyrolo.el (hyrolo-get-entry): Remove unused lexical variables.
+
 * hyperbole.el: Use only Maintainer header.
 
 * man/hy-package.el:

--- a/hibtypes.el
+++ b/hibtypes.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    19-Sep-91 at 20:45:31
-;; Last-Mod:     16-Jul-26 at 10:47:49 by Bob Weiner
+;; Last-Mod:     25-Jul-26 at 22:57:10 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -76,6 +76,7 @@
 (declare-function hywiki-referent-exists-p "hywiki")
 (declare-function hywiki-word-create-and-display "hywiki")
 (declare-function hywiki-word-from-reference "hywiki")
+(declare-function hywiki-non-hook-context-p "hywiki")
 (declare-function markdown-footnote-goto-text "ext:markdown")
 (declare-function markdown-footnote-marker-positions "ext:markdown")
 (declare-function markdown-footnote-return "ext:markdown")

--- a/hmouse-drv.el
+++ b/hmouse-drv.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-90
-;; Last-Mod:     23-Jul-26 at 00:17:46 by Bob Weiner
+;; Last-Mod:     25-Jul-26 at 23:02:11 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -62,6 +62,7 @@
 
 (declare-function br-in-browser "hpath")
 (declare-function hattr:clear "hbut")
+(declare-function hattr:copy "hbut")
 (declare-function hattr:get "hbut")
 (declare-function hattr:list "hbut")
 (declare-function hattr:report "hbut")
@@ -72,7 +73,9 @@
 (declare-function hpath:display-buffer "hpath")
 (declare-function hui:ebut-link-directly "hui")
 (declare-function hui:ibut-link-directly "hui")
+(declare-function hywiki-get-definition "hywiki")
 (declare-function hywiki-get-referent "hywiki")
+(declare-function ibut:key-to-label "hbut")
 (declare-function mouse-drag-frame "mouse") ;; Obsolete from Emacs 28
 (declare-function org-todo "org")
 

--- a/hsys-www.el
+++ b/hsys-www.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Apr-94 at 17:17:39 by Bob Weiner
-;; Last-Mod:     16-Jul-26 at 17:36:43 by Bob Weiner
+;; Last-Mod:     25-Jul-26 at 23:06:19 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -44,6 +44,7 @@
 (defvar hpath:display-where-alist)      ; "hpath.el"
 
 (declare-function eww--dwim-expand-url "eww" (url))
+(declare-function eww-links-at-point "eww")
 
 (declare-function hpath:display-buffer "hpath")
 (declare-function hpath:remote-at-p "hpath")

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Jun-89 at 22:08:29
-;; Last-Mod:     21-Jul-26 at 01:19:45 by Bob Weiner
+;; Last-Mod:     25-Jul-26 at 23:08:13 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -860,26 +860,23 @@ instead of a string."
   (when (or (null name) (not (stringp name)))
     (error "(hyrolo-get-entry): Invalid name: `%s'" name))
 
-  (let ((buf (current-buffer))
-        (buf-file buffer-file-name))
-    (save-window-excursion
-      (with-temp-buffer
-	(let ((hyrolo-display-buffer (current-buffer))
-	      (start (point))
-	      found)
-	  (save-excursion
-	    (setq found
-		  (if (and (hsys-consult-active-p)
-                           ;; Extract search string from the results of an
-                           ;; `hsys-consult' call stored in `name'
-			   (string-match "\\([^ \t\n\r\"'`]*[^ \t\n\r:\"'`0-9]\\): ?\\([1-9][0-9]*\\)[ :]"
-					 name))
-		      (hyrolo-grep-file (match-string-no-properties 1 name)
-					(regexp-quote (substring name (match-end 0)))
-					-1 nil t)
-		    (hyrolo-grep (if regexp-flag name (regexp-quote name)) -1 nil nil t))))
-          (when found
-            (buffer-string)))))))
+  (save-window-excursion
+    (with-temp-buffer
+      (let ((hyrolo-display-buffer (current-buffer))
+	    found)
+	(save-excursion
+	  (setq found
+		(if (and (hsys-consult-active-p)
+                         ;; Extract search string from the results of an
+                         ;; `hsys-consult' call stored in `name'
+			 (string-match "\\([^ \t\n\r\"'`]*[^ \t\n\r:\"'`0-9]\\): ?\\([1-9][0-9]*\\)[ :]"
+				       name))
+		    (hyrolo-grep-file (match-string-no-properties 1 name)
+				      (regexp-quote (substring name (match-end 0)))
+				      -1 nil t)
+		  (hyrolo-grep (if regexp-flag name (regexp-quote name)) -1 nil nil t))))
+        (when found
+          (buffer-string))))))
 
 ;;;###autoload
 (defun hyrolo-grep (regexp &optional max-matches hyrolo-files-or-bufs count-only headline-only no-display interactive-flag)


### PR DESCRIPTION
# What

Resolve warnings.

* hibtypes.el (hywiki-non-hook-context-p):
  hmouse-drv.el (hattr:copy, hywiki-get-definition, ibut:key-to-label):
  hsys-www.el (eww-links-at-point): Declare functions.

* hyrolo.el (hyrolo-get-entry): Remove unused lexical variables.

# Why

Minimal warnings are good.
