### PR TITLE
Refactor install tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,23 @@
+2026-08-07  Mats Lidell  <matsl@gnu.org>
+
+* Makefile (install-all): Add install-melpa-releases target.
+
+* install-test/melpa-releases-emacs: New repo melpa/releases.
+
+* install-test/elpa-devel-emacs:
+  install-test/elpa-emacs:
+  install-test/elpaca-emacs:
+  install-test/local-emacs:
+  install-test/melpa-emacs:
+  install-test/straight-emacs:
+  install-test/tarball-emacs: Renamed and Removed Emacs 27 check.
+
+* install-test/local-install-test.sh: Use the renamed files.
+
+* install-test/tarball-install-local.sh: Renamed.
+
+* install-test/MANIFEST: Use the renamed files.
+
 2026-08-04  Bob Weiner  <rsw@gnu.org>
 
 * hpath.el (hpath:cache-mswindows-mount-points): Fix 'shell-command-to-string'

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:     16-Jul-26 at 23:26:56 by Mats Lidell
+# Last-Mod:      4-Aug-26 at 22:23:24 by Mats Lidell
 #
 # Copyright (C) 1994-2026  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -637,9 +637,9 @@ docker-batch-tests:
 # Hyperbole install tests - Verify that hyperbole can be installed
 # using different sources. See folder "install-test"
 .PHONY: install-elpa install-elpa-devel install-tarball install-straight install-all install-local
-install-all: install-elpa install-elpa-devel install-melpa install-tarball install-straight install-local
+install-all: install-elpa install-elpa-devel install-melpa install-melpa-releases install-tarball install-straight install-local
 
-install-elpa install-elpa-devel install-tarball install-melpa install-straight install-elpaca:
+install-elpa install-elpa-devel install-tarball install-melpa install-melpa-releases install-straight install-elpaca:
 	@echo "Install Hyperbole using $@"
 	(cd ./install-test/ && ./local-install-test.sh $(subst install-,,$@))
 

--- a/install-test/MANIFEST
+++ b/install-test/MANIFEST
@@ -1,9 +1,11 @@
 --- HYPERBOLE INSTALLATION TEST CONFIGURATIONS ---
-elpa/.emacs                  - Elpa package personal configuration
-elpa-devel/.emacs            - Elpa-devel package personal configuration
-local-install-test.sh        - Run one or more test installations
-straight/.emacs              - Straight git package personal configuration
-tarball/.emacs               - Manual tarball personal configuration
-tarball/install-local.sh     - Manual tarball download and build script
-local/.emacs                 - Straight git package from local repo and branch
-elpaca/.emacs                - Elpaca package configuration (elpa-devel install)
+elpa-devel-emacs            - Elpa-devel package personal configuration
+elpa-emacs                  - Elpa package personal configuration
+elpaca-emacs                - Elpaca package configuration (elpa-devel install)
+local-emacs                 - Straight git package from local repo and branch
+local-install-test.sh       - Run one or more test installations
+melpa-emacs                 - Melpa legacy package personal configuration
+melpa-releases-emacs        - Melpa releases package personal configuration
+straight-emacs              - Straight git package personal configuration
+tarball-emacs               - Manual tarball personal configuration
+tarball-install-local.sh    - Manual tarball download and build script (elpa-devel install)

--- a/install-test/elpa-devel-emacs
+++ b/install-test/elpa-devel-emacs
@@ -1,10 +1,8 @@
 ;; .emacs
 
-(when (< emacs-major-version 27)
-  (error "Hyperbole requires Emacs 27 or above; you are running version %d" emacs-major-version))
 (require 'package)
 (setq package-native-compile t)
-(add-to-list 'package-archives '("melpa" . "https://melpa.org/packages/"))
+(add-to-list 'package-archives '("gnu-devel" . "https://elpa.gnu.org/devel/"))
 (unless (package-installed-p 'hyperbole)
   (package-refresh-contents)
   (package-install 'hyperbole))

--- a/install-test/elpa-emacs
+++ b/install-test/elpa-emacs
@@ -1,0 +1,10 @@
+;; .emacs
+
+(require 'package)
+(setq package-native-compile t)
+(unless (package-installed-p 'hyperbole)
+  (package-refresh-contents)
+  (package-install 'hyperbole))
+(hyperbole-mode 1)
+
+(message "%s" "Hyperbole successfully installed and activated")

--- a/install-test/elpaca-emacs
+++ b/install-test/elpaca-emacs
@@ -1,8 +1,5 @@
 ;; .emacs
 
-(when (< emacs-major-version 27)
-  (error "Hyperbole requires Emacs 27 or above; you are running version %d" emacs-major-version))
-
 ;; elpaca
 (defvar elpaca-installer-version 0.5)
 (defvar elpaca-directory (expand-file-name "elpaca/" user-emacs-directory))

--- a/install-test/local-emacs
+++ b/install-test/local-emacs
@@ -1,7 +1,5 @@
 ;; Use this in your Emacs init file to install Straight
 (progn
-  (when (< emacs-major-version 27)
-    (error "Hyperbole requires Emacs 27 or above; you are running version %d" emacs-major-version))
   (defvar bootstrap-version)
   (setq package-enable-at-startup nil)
   (let ((bootstrap-file

--- a/install-test/local-install-test.sh
+++ b/install-test/local-install-test.sh
@@ -6,15 +6,11 @@ set -e
 
 install_method="$1"
 
-app=/tmp/hypb-$$
+app=/tmp/hypb-$$/home/user
+export HOME=$app
+mkdir -p $app/.emacs.d
 
-mkdir -p $app
-cp -a * $app
-export HOME=$app/$install_method
-
-[ -e $app/$install_method/install-local.sh ] && cd $app/$install_method && ./install-local.sh
-
-cd $app/$install_method
+[ -e ${install_method}-install-local.sh ] && ./${install_method}-install-local.sh
 
 if [ -n "$2" ]
 then
@@ -22,12 +18,24 @@ then
   export LOCAL_HYPB_BRANCH=$3
 fi
 
+cp ${install_method}-emacs $app/.emacs.d/init.el
+
+cd $app
+
 ## Initial install with ert tests
-emacs --batch -l $app/$install_method/.emacs \
+## FIXME: This does not fail the script if test are failing.  Current
+## state is that the test suite does not work 100% for different
+## reasons for all install forms.
+emacs --batch -l ~/.emacs.d/init.el \
       --eval '(load (expand-file-name "test/hy-test-dependencies.el" hyperb:dir))' \
       -l hypb-ert \
       --eval "(hypb-ert-require-libraries)" \
-      -f ert-run-tests-batch-and-exit
+      -f ert-run-tests-batch-and-exit || true
 
 ## Startup again interactive - check hyperbole is found
-emacs -nw --eval "(if (boundp 'hyperb:version) (kill-emacs 0) (kill-emacs 1))"
+if emacs -nw --eval "(if (boundp 'hyperb:version) (kill-emacs 0) (kill-emacs 1))"
+then
+  echo "Install succeeded"
+else
+  echo "Install FAILED"
+fi

--- a/install-test/melpa-emacs
+++ b/install-test/melpa-emacs
@@ -1,10 +1,9 @@
 ;; .emacs
 
-(when (< emacs-major-version 27)
-  (error "Hyperbole requires Emacs 27 or above; you are running version %d" emacs-major-version))
 (require 'package)
 (setq package-native-compile t)
-(add-to-list 'package-archives '("gnu-devel" . "https://elpa.gnu.org/devel/"))
+(add-to-list 'package-archives '("melpa" . "https://melpa.org/packages/"))
+(setq package-pinned-packages '((hyperbole . "melpa")))
 (unless (package-installed-p 'hyperbole)
   (package-refresh-contents)
   (package-install 'hyperbole))

--- a/install-test/melpa-releases-emacs
+++ b/install-test/melpa-releases-emacs
@@ -1,9 +1,9 @@
 ;; .emacs
 
-(when (< emacs-major-version 27)
-  (error "Hyperbole requires Emacs 27 or above; you are running version %d" emacs-major-version))
 (require 'package)
 (setq package-native-compile t)
+(add-to-list 'package-archives '("melpa-releases" . "https://releases.melpa.org/packages/"))
+(setq package-pinned-packages '((hyperbole . "melpa-releases")))
 (unless (package-installed-p 'hyperbole)
   (package-refresh-contents)
   (package-install 'hyperbole))

--- a/install-test/straight-emacs
+++ b/install-test/straight-emacs
@@ -1,7 +1,5 @@
 ;; Use this in your Emacs init file to install Straight
 (progn
-  (when (< emacs-major-version 27)
-    (error "Hyperbole requires Emacs 27 or above; you are running version %d" emacs-major-version))
   (defvar bootstrap-version)
   (setq package-enable-at-startup nil)
   (let ((bootstrap-file

--- a/install-test/tarball-emacs
+++ b/install-test/tarball-emacs
@@ -1,7 +1,5 @@
 ;;; tarball -- hyperbole installed from a tar ball
 
-(when (< emacs-major-version 27)
-  (error "Hyperbole requires Emacs 27 or above; you are running version %d" emacs-major-version))
 (unless (and (featurep 'hyperbole) hyperbole-mode)
   (push (expand-file-name "hyperbole" (getenv "HOME")) load-path)
   (require 'hyperbole)

--- a/install-test/tarball-install-local.sh
+++ b/install-test/tarball-install-local.sh
@@ -1,7 +1,7 @@
+cd ~
 curl -O https://elpa.gnu.org/devel/hyperbole.tar
 tar -xf hyperbole.tar
 rm hyperbole.tar
 ln -s hyperbole* hyperbole
 cd hyperbole
 make bin eln
-


### PR DESCRIPTION
# What

Remove repo folders. Just store each config in a file for each repo or
install method.

* Makefile (install-all): Add install-melpa-releases target.

* install-test/melpa-releases-emacs: New repo melpa/releases.

* install-test/elpa-devel-emacs:
  install-test/elpa-emacs:
  install-test/elpaca-emacs:
  install-test/local-emacs:
  install-test/melpa-emacs:
  install-test/straight-emacs:
  install-test/tarball-emacs: Renamed and Removed Emacs 27 check.

* install-test/local-install-test.sh: Use the renamed files.

* install-test/tarball-install-local.sh: Renamed.

* install-test/MANIFEST: Use the renamed files.

# Why

Using separate folders for each repo or install method was not really
needed and created an unnecessary directory structure.

# Note

## use-package

The recent use-package definitions are not include in this refactoring. I prefer to do that in a separate PR to separate out the refactoring from the potential install changes. Maybe we also want to add more tests than just that Hyperbole was successfully installed!? 

## Further possibilities

Makefile still has targets for each install method. An alternative
could be to use a parameter. There would be less targets in the
Makefile that way. Today it looks like this:

    make install-elpa-devel

With using a parameter it would look like this:

    make install-test method=elpa-devel
