### PR TITLE
Use a cache for emacs.d/elpa

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,5 +38,11 @@ jobs:
           grep "Warning:" MAKE_BIN_OUTPUT >> $GITHUB_STEP_SUMMARY || true
           echo '```' >> $GITHUB_STEP_SUMMARY
 
+      - name: Cache emacs.d/elpa
+        uses: actions/cache@v5
+        with:
+            path: ~/.emacs.d/elpa
+            key: elpa-${{ matrix.version }}-${{ hashFiles('Makefile') }}
+
       - name: Test
         run: make test

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2026-08-11  Mats Lidell  <matsl@gnu.org>
+
+* .github/workflows/main.yml (jobs): Use a cache for emacs.d/elpa in
+    the CI build.
+
 2026-08-10  Mats Lidell  <matsl@gnu.org>
 
 * test/MANIFEST: New test file.


### PR DESCRIPTION
# What

Download packages and compile them once per emacs version to speed up
the CI build and reduce connections to external sites during CI
build. To start with Hash on the Makefile so that updates on that
invalidates the cache.

* .github/workflows/main.yml (jobs): Use a cache for emacs.d/elpa in
the CI build.

# Why

Downloading external dependencies on each build takes time and
resources. This is the first step in changing the CI to be more lean
on the resources and provide quicker feedback.
