### PR TITLE
Add target for checking copyright notice on .el-files

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 2026-08-11  Mats Lidell  <matsl@gnu.org>
 
+* (check-copyright): Check copyright and SPDX headers.
+
 * .github/workflows/main.yml (jobs): Use a cache for emacs.d/elpa in
     the CI build.
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Author:       Bob Weiner
 #
 # Orig-Date:    15-Jun-94 at 03:42:38
-# Last-Mod:      4-Aug-26 at 22:23:24 by Mats Lidell
+# Last-Mod:     11-Aug-26 at 23:39:12 by Mats Lidell
 #
 # Copyright (C) 1994-2026  Free Software Foundation, Inc.
 # See the file HY-COPY for license information.
@@ -728,3 +728,20 @@ coverage:
 	--eval "(load-file \"test/hy-test-dependencies.el\")" \
 	--eval "(load-file \"test/hy-test-coverage.el\")" \
 	--eval "(hy-test-coverage-file \"${file}\" \"${COVERAGE_TESTSPEC}\")"
+
+# List files missing copyright headers.  ELPA fails builds where
+# .el-files does not contain the proper copyright.  The SPDX header
+# might not be checked for but we check for that here as well anyway.
+.PHONY: check-copyright
+check-copyright:
+	@missing="$$( \
+	  { \
+	    git grep -L 'Copyright.*Free Software Foundation' -- '*.el' ':(exclude)**.dir-locals.el'; \
+	    git grep -L 'SPDX-License-Identifier: GPL-3.0-or-later' -- '*.el' ':(exclude)**.dir-locals.el' ; \
+	  } | sort -u \
+	)"; \
+	if test -n "$$missing" ; then \
+	  echo "Files missing copyright statement:"; \
+	  echo "$$missing"; \
+	  exit 1; \
+	fi


### PR DESCRIPTION
# What

(check-copyright): Check copyright and SPDX headers

# Why

ELPA fails builds where .el-files does not contain the proper
copyright.  This adds a target so we can easily check for this
situation.  The SPDX header might not be checked for but we check for
that here as well anyway.
