### PR TITLE
pr fix remote path regexp

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2026-08-28  Mats Lidell  <matsl@gnu.org>
+
+* hpath.el (hpath:tramp-file-name-regexp): Use variable
+    tramp-file-name-regexp available from Emacs 28.  Remove unused
+    tramp-localname-regexp.
+    Error on unrecognized regexp to catch early changes in
+    tramp-file-name-regexp.
+
 2026-08-28  Bob Weiner  <rsw@gnu.org>
 
 * hyrolo.el (hyrolo-set-major-mode): Add.

--- a/hpath.el
+++ b/hpath.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     1-Nov-91 at 00:44:23
-;; Last-Mod:     26-Aug-26 at 15:33:49 by Bob Weiner
+;; Last-Mod:     28-Aug-26 at 09:41:18 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -808,15 +808,16 @@ used."
   "Return a regexp for matching to the beginning of a remote file name.
 Modifies `tramp-file-name-regexp' by removing bol anchor and
 match to empty string if present."
-  (let* ((tramp-localname-regexp "[^[:cntrl:]]*\\'")
-	 (tramp-regexp (car (if (fboundp 'tramp-file-name-structure)
-				(tramp-file-name-structure)
-			      tramp-file-name-structure))))
-    (replace-regexp-in-string "\\`^\\|\\\\`" "" tramp-regexp)))
-     ;; (cond ((string-match-p "\\\\(\\?:^/\\\\)" tramp-regexp)
-     ;;        (replace-regexp-in-string  "\\\\(\\?:\\^/\\\\)" "\\(?:/\\)" tramp-regexp nil t))
-     ;;       (t (substring tramp-regexp 1)))
-
+  (let ((tramp-regexp (car tramp-file-name-structure)))
+    (cond
+     ((string-prefix-p "^/" tramp-regexp)
+      (substring tramp-regexp 1))
+     ((string-prefix-p "\\(?:^/\\)" tramp-regexp)
+      (concat "/" (substring tramp-regexp (length "\\(?:^/\\)"))))
+     ((string-prefix-p "\\(?:\\`/\\)" tramp-regexp)
+      (concat "/" (substring tramp-regexp (length "\\(?:\\`/\\)"))))
+     (t
+      (error "Unexpected TRAMP file name regexp: %S" tramp-regexp)))))
 
 (defun hpath:remote-at-p ()
   "Return a remote pathname that point is within or nil.

--- a/test/hpath-tests.el
+++ b/test/hpath-tests.el
@@ -389,7 +389,6 @@
 
 (ert-deftest hpath:remote-at-p ()
   "Verify hpath:remote-at-p match a tramp remote file name."
-  (ert-skip "!! TODO Disable until fix with Emacs 29 and 30")
   (mocklet ((hpath:remote-available-p => nil))
     (should-not (hpath:remote-at-p)))
   (let ((tramp-file "/ssh:user@host.org:/home/username/file"))


### PR DESCRIPTION
# What

- **Adjust for tramp regexp for Emacs 29 and 30**

* hpath.el (hpath:tramp-file-name-regexp): Use variable
tramp-file-name-regexp available from Emacs 28.  Remove unused
tramp-localname-regexp.
Error on unrecognized regexp to catch early changes in
tramp-file-name-regexp.

# Why

Tramp regexp was changed in Emacs 31 and a temporary solution was
implemented.  That supported Emacs 28 and 31 but not Emacs 29 and 30.
This adds back in Emacs 29 and 30 and enables the unit test again.
