### PR TITLE
Apply advice for package-install for Emacs 31.1, needed in github

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,9 @@
 2026-08-28  Mats Lidell  <matsl@gnu.org>
 
+* test/hy-test-dependencies.el (version<): Apply advice for
+    package-install from Emacs version 31.1 now when we have that in the
+    workflow.
+
 * .github/workflows/main.yml:
 * Makefile (DOCKER_VERSIONS): Add Emacs 31.1.
 

--- a/test/hy-test-dependencies.el
+++ b/test/hy-test-dependencies.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    20-Feb-21 at 23:16:00
-;; Last-Mod:     20-Jul-26 at 10:17:10 by Bob Weiner
+;; Last-Mod:     28-Aug-26 at 20:10:04 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -45,8 +45,8 @@
            (sleep-for delay)))))
     result))
 
-;; Apply advice only for Emacs master branch version used in CI
-(unless (version< emacs-version "32.0.50")
+;; Apply advice for Emacs 31.1 or later.  Needed in github workflow.
+(unless (version< emacs-version "31.1")
   (advice-add 'package-install :around #'hypb:package-install-advice-for-retry))
 
 (declare-function markdown-ts-mode "ext:markdown-ts-mode")


### PR DESCRIPTION
# What

Apply advice for package-install for Emacs 31.1, needed in github.

* test/hy-test-dependencies.el (version<): Apply advice for
package-install from Emacs version 31.1 now when we have that in the
workflow.

# Why

We had the check set to 32.0.50 that worked for the master branch but
with 31.1 in the workflow we need to apply it for 31.1 too. This was
expected since master branch was close to 31.1 but missed.

See error in master build [here](https://github.com/rswgnu/hyperbole/actions/runs/33193238451/job/98923789741#step:7:708)
