### PR TITLE
Remove warnings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2026-08-29  Mats Lidell  <matsl@gnu.org>
+
+* hui-mini.el (hui:menu-last-help-string): Defvar.
+    (hkey-help-hide): Declare function.
+    (hui:menu-quit): Use function definition.
+
 2026-08-29  Bob Weiner  <rsw@gnu.org>
 
 * hyrolo.el (hyrolo-get-entry): Add call to 'hyrolo-hdr-at-p' to only skip

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,7 +2,6 @@
 
 * hui-mini.el (hui:menu-last-help-string): Defvar.
     (hkey-help-hide): Declare function.
-    (hui:menu-quit): Use function definition.
 
 2026-08-29  Bob Weiner  <rsw@gnu.org>
 

--- a/hui-mini.el
+++ b/hui-mini.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Oct-91 at 20:13:17
-;; Last-Mod:     29-Aug-26 at 18:07:05 by Mats Lidell
+;; Last-Mod:     30-Aug-26 at 10:55:42 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -384,6 +384,8 @@ instead returns the one line help string for the key sequence."
 
 (defalias 'hui:menu-quit   #'hui:menu-enter)
 (defalias 'hui:menu-abort  #'hui:menu-enter)
+;; FIXME: Change alias, hui:menu-help is an existing function
+;;(defalias 'hui:menu-help   #'hui:menu-enter)
 (defalias 'hui:menu-top    #'hui:menu-enter)
 (defalias 'hui:menu-select #'hui:menu-enter)
 

--- a/hui-mini.el
+++ b/hui-mini.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Oct-91 at 20:13:17
-;; Last-Mod:     22-Aug-26 at 09:58:54 by Bob Weiner
+;; Last-Mod:     29-Aug-26 at 18:07:05 by Mats Lidell
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -33,6 +33,7 @@
 (defvar hsys-org-enable-smart-keys)     ; "hsys-org.el"
 (defvar hui:menu-highlight-flag)        ; "hui-mini.el"
 (defvar hui:menu-hywiki nil)            ; "hui-mini.el"
+(defvar hui:menu-last-help-string)      ; "hui-mini.el"
 (defvar hui:menu-mode-map)              ; "hui-mini.el"
 (defvar hui:menu-rolo nil)              ; "hui-mini.el"
 (defvar hyperbole-mode-map)             ; "hyperbole.el"
@@ -43,6 +44,7 @@
 (defvar org-mode-map)                   ; "org.el"
 
 (declare-function hargs:at-p "hargs")
+(declare-function hkey-help-hide "hmouse-drv")
 (declare-function hkey-help-show "hmouse-drv")
 (declare-function hmouse-update-smart-keys "hmouse-key")
 (declare-function hpath:find "hpath")
@@ -382,7 +384,6 @@ instead returns the one line help string for the key sequence."
 
 (defalias 'hui:menu-quit   #'hui:menu-enter)
 (defalias 'hui:menu-abort  #'hui:menu-enter)
-(defalias 'hui:menu-help   #'hui:menu-enter)
 (defalias 'hui:menu-top    #'hui:menu-enter)
 (defalias 'hui:menu-select #'hui:menu-enter)
 


### PR DESCRIPTION
# What

Remove warnings

* hui-mini.el (hui:menu-last-help-string): Defvar.
(hkey-help-hide): Declare function.

# Why

Warnings should be kept to a miminum. Sometimes they contain important
info like in this case with a function, hui:menu-help, also being
defined as an alias.
