### PR TITLE
hyrolo-get-entry - Fix `hyrolo-yank' with call to 'hyrolo-hdr-at-p' 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,14 @@
+2026-08-29  Bob Weiner  <rsw@gnu.org>
+
+* hyrolo.el (hyrolo-get-entry): Add call to 'hyrolo-hdr-at-p' to only skip
+    to next record if there is a header included in the results.  Some
+    HyRolo files lack a header.
+
+* test/hpath-tests.el (hpath--at-p-checks-files-with-hash-in-name-exists,
+                       hpath--at-p-checks-file-that-with-hash-that-does-not-exist-returns-nil):
+    Fix to make file references be in the 'temporary-file-directory' and show all relevant
+    values if any test failure via 'ert-info'.
+
 2026-08-28  Bob Weiner  <rsw@gnu.org>
 
 * hyrolo.el (hyrolo-set-major-mode): Add.
@@ -189,7 +200,8 @@
 * hpath.el (hpath:cache-mswindows-mount-points): Fix 'shell-command-to-string'
     call that had been wrapped in 'ignore-errors' but this grabbed the error
     string as the plist result (found because errors when 'tcsh' shell is used).
-    Instead wrap with a 'condition-case' so returns nil on any error.
+    Instead wrap with a 'condition-case' so returns nil on any error.  Fixes
+    bug#81549.
 
 2026-07-30  Bob Weiner  <rsw@gnu.org>
 

--- a/hyrolo.el
+++ b/hyrolo.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:     7-Jun-89 at 22:08:29
-;; Last-Mod:     28-Aug-26 at 00:45:30 by Bob Weiner
+;; Last-Mod:     29-Aug-26 at 23:35:44 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -881,7 +881,8 @@ below the matched one."
 		  (hyrolo-grep (if regexp-flag name (regexp-quote name)) -1 nil nil t nil nil exclude-sub-entries))))
         (when found
           ;; Ignore any file header included before record
-          (hyrolo-outline-next-visible-heading 1)
+          (when (hyrolo-hdr-at-p)
+            (hyrolo-outline-next-visible-heading 1))
           (buffer-substring (point) (point-max)))))))
 
 ;;;###autoload

--- a/test/hpath-tests.el
+++ b/test/hpath-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell <matsl@gnu.org>
 ;;
 ;; Orig-Date:    28-Feb-21 at 23:26:00
-;; Last-Mod:     26-Aug-26 at 16:11:43 by Bob Weiner
+;; Last-Mod:     29-Aug-26 at 12:09:01 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -432,29 +432,34 @@
 
 (ert-deftest hpath--at-p-checks-files-with-hash-in-name-exists ()
   "Verify that file existence is checked for filenames containing a hash character."
-  (let ((dir (make-temp-file "hypb" t)))
+  (let ((dir (make-temp-file "hypb" t))
+        filename)
     (unwind-protect
         (dolist (fn '("#file#" "#.file#" "#file path#" "path#section" "#path#section"))
-          (let ((filename (expand-file-name fn dir)))
+          (setq filename (expand-file-name fn dir))
+          (ert-info ((format "Filename \"%s\":" filename))
             (unwind-protect
                 (progn
                   (find-file filename)
                   (insert "\"" fn "\"")
                   (hypb:save-buffer-silently)
-                  (goto-char 3)
-                  (should (string= (hpath:at-p) fn))
-                  (should (string= (hpath:is-p fn) fn)))
+	          (ert-info ((format "File referenced: \"%s\"" filename))
+                    (goto-char 3)
+                    (should (string= (hpath:at-p) fn))
+                    (should (string= (hpath:is-p fn) fn))))
               (hy-delete-file-and-buffer filename))))
       (delete-directory dir))))
 
 (ert-deftest hpath--at-p-checks-file-that-with-hash-that-does-not-exist-returns-nil ()
   "Verify that file existence is checked for filenames containing a hash character."
-  (dolist (fn '("#file#" "#.file#" "#file path#" "path#section" "#path#section"))
-    (with-temp-buffer
-      (insert "\"" fn "\"")
-      (goto-char 3)
-      (should-not (hpath:at-p))
-      (should-not (hpath:is-p fn)))))
+  (let ((default-directory temporary-file-directory))
+    (dolist (fn '("abc" "#file#" "#.file#" "#file path#" "path#section" "#path#section"))
+      (with-temp-buffer
+        (insert "\"" fn "\"")
+        (goto-char 3)
+        (ert-info ((format "File referenced: \"%s\"; Buffer point is in: \"%s\":" (expand-file-name fn) (buffer-name)))
+          (should-not (hpath:at-p))
+          (should-not (hpath:is-p fn)))))))
 
 (ert-deftest hpath--expand-no-wildcards-existing-path ()
   "Verify expand with no wildcards gives path back."


### PR DESCRIPTION
- hyrolo-get-entry - Fix `hyrolo-yank' with call to 'hyrolo-hdr-at-p'

- hpath--at-p-checks-files-with-hash-in-name-exists,
hpath--at-p-checks-file-that-with-hash-that-does-not-exist-returns-nil -
  Fix to make file references be in the 'temporary-file-directory' and
  show all relevant values if any test failure via 'ert-info'.