### PR TITLE
hywiki-completion-at-point - Fix to always return nil when no result

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,16 @@
+2026-08-30  Bob Weiner  <rsw@gnu.org>
+
+* hmouse-drv.el (hkey-help-show): Fix that ? help buffer in Hyperbole minibuffer
+    menus was not put into 'help-mode' in some Emacs versions because
+    'quit-window' is now bound in the default major mode that the ? buffer
+    starts in.  This is typically 'fundamental-mode'.
+
+* hui-mini.el (hui:menu-help): Set menu help buffer to read only.
+
+* hywiki.el (hywiki-completion-at-point): Fix to return nil anytime an error
+    occurs when getting the candidate list, not just for one specific error.
+    This fixes gh#1048.
+
 2026-08-29  Bob Weiner  <rsw@gnu.org>
 
 * hyrolo.el (hyrolo-get-entry): Add call to 'hyrolo-hdr-at-p' to only skip

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,15 @@
 2026-08-30  Bob Weiner  <rsw@gnu.org>
 
+* test/hywiki-tests.el (hywiki-tests--preserve-hywiki-mode): Call
+   'hywiki-add-page' with 'debug-flag' enabled, so if ever get null a
+   null referent returned, get a stack trace showing the source of the
+   problem.
+
+* hywiki.el (hywiki-completion-at-point): Fix to not return nil if no #section
+    completions found; continue and allow for referent-only completions.
+            (hywiki-get-referent-list): Add and call in above function rather
+    than limiting to WikiWords attached to pages.
+
 * hmouse-drv.el (hkey-help-show): Fix that ? help buffer in Hyperbole minibuffer
     menus was not put into 'help-mode' in some Emacs versions because
     'quit-window' is now bound in the default major mode that the ? buffer
@@ -7,9 +17,13 @@
 
 * hui-mini.el (hui:menu-help): Set menu help buffer to read only.
 
-* hywiki.el (hywiki-completion-at-point): Fix to return nil anytime an error
-    occurs when getting the candidate list, not just for one specific error.
-    This fixes gh#1048.
+* hywiki.el (hywiki-completion-at-point): Fix to set 'output' to nil anytime
+    an error occurs with the grep call generating #section candidates.
+    Previously, the code matched to only one specific error.  This fixes bug
+    report gh#1048.  Also, change completion table to use strings rather than
+    lists of strings, for simplicity.
+  test/hywiki-tests.el (hywiki-tests--completion-at-point): Adapt to above
+    change to completion table.
 
 2026-08-29  Mats Lidell  <matsl@gnu.org>
 

--- a/hmouse-drv.el
+++ b/hmouse-drv.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-90
-;; Last-Mod:     15-Aug-26 at 22:29:02 by Bob Weiner
+;; Last-Mod:     30-Aug-26 at 11:12:09 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1407,12 +1407,18 @@ the current window.  By default, it is displayed according to the setting of
 	  ;; Ignore org-mode's temp help buffers which it handles on its own.
 	  (when (and wind (not hkey-org-help))
 	    (setq minibuffer-scroll-window wind)
-	    ;; Don't use `help-mode' in buffers already set up with a
-	    ;; quit-key to bury the buffer, e.g. minibuffer completions,
-	    ;; as this will sometimes disable default left mouse key item
-	    ;; selection.
-	    (unless (or (where-is-internal 'quit-window (current-local-map))
-			(where-is-internal 'hkey-help-hide (current-local-map)))
+            (when (or
+                   ;; In more recent Emacs versions, `quit-window' is bound in
+                   ;; the default 'major-mode' (typically `fundamental-mode'),
+                   ;; so we have to specifically check for it and switch to
+                   ;; `help-mode'.
+                   (eq major-mode (default-value 'major-mode))
+	           ;; Don't use `help-mode' in buffers already set up with a
+	           ;; quit-key to bury the buffer, e.g. minibuffer completions,
+	           ;; as this will sometimes disable default left mouse key item
+	           ;; selection.
+                   (not (or (where-is-internal 'quit-window (current-local-map))
+			    (where-is-internal 'hkey-help-hide (current-local-map)))))
 	      (when (string-match "^\\*Help\\|Help\\*$" (buffer-name))
 		(help-mode))
 	      (when (derived-mode-p 'help-mode)

--- a/hui-mini.el
+++ b/hui-mini.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Oct-91 at 20:13:17
-;; Last-Mod:     22-Aug-26 at 09:58:54 by Bob Weiner
+;; Last-Mod:     30-Aug-26 at 10:46:08 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -441,7 +441,8 @@ help window."
                 (toggle-truncate-lines 1)
 	        (insert help-str)
 	        (set-buffer-modified-p nil)
-                (setq hui:menu-last-help-string help-str)
+	        (setq buffer-read-only t
+                      hui:menu-last-help-string help-str)
                 (fit-window-to-buffer)
                 (goto-char (point-min))))
           (when (eq owind (minibuffer-window))

--- a/hui-mini.el
+++ b/hui-mini.el
@@ -3,11 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    15-Oct-91 at 20:13:17
-<<<<<<< HEAD
-;; Last-Mod:     30-Aug-26 at 10:46:08 by Bob Weiner
-=======
-;; Last-Mod:     30-Aug-26 at 10:55:42 by Mats Lidell
->>>>>>> master
+;; Last-Mod:     30-Aug-26 at 11:19:18 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Apr-24 at 22:41:13
-;; Last-Mod:     21-Aug-26 at 11:55:52 by Bob Weiner
+;; Last-Mod:     30-Aug-26 at 10:21:23 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1845,42 +1845,49 @@ Each candidate is an alist with keys: file, line, text, and display."
          (existing-wikiword-prefix (when ref (hywiki-word-strip-suffix ref))))
     (when prefix
       (let* ((default-directory hywiki-directory)
-             (cmd (format "grep -nEH '^([ \t]*\\*+|#\\+TITLE:) +' ./%s*%s"
+             ;; set +f ensures globbing is on, so file wildcards are
+             ;; expanded but only within the subshell created by the outer
+             ;; parens
+             (cmd (format "(set +f && grep -nEH '^([ \t]*\\*+|#\\+TITLE:) +' ./%s*%s)"
                           existing-wikiword-prefix
                           hywiki-file-extension))
-             (output (shell-command-to-string cmd))
-             (lines (split-string output "[\n\r]" t))
-             (candidates
-              ;; If no matching HyWiki pages were found, return nil
-              (unless (and (= 1 (length lines))
-                           (string-match "No such file or directory" (car lines)))
-                (delq nil
-                      (nconc
-                       ;; Return only candidates that start with 'existing-wikiword-prefix'
-                       (seq-filter (lambda (str)
-                                     (string-prefix-p existing-wikiword-prefix str))
-                                   (hywiki-get-page-list))
-                       (mapcar #'hywiki-format-grep-to-reference lines)))))
-             (candidates-alist (when candidates (mapcar #'list candidates))))
-        (when candidates-alist
-          (setq hywiki--char-before (char-before start)
-                hywiki--start-pos start
-                hywiki--end-pos end)
-          (list start end candidates-alist
-                :exclusive 'no
-                ;; For company, allow any non-delim chars in prefix
-                ;; :company-prefix-length t
-                ;; :company-prefix-dirty t
-                ;; Returning the prefix as (string . t) tells Company:
-                ;; 'This is the prefix, and yes, it is currently valid (dirty).'
-                ;; :company-prefix-snapshot (cons ref t)
+             (output (with-temp-buffer
+                       ;; Check exist status and if any error (non-zero),
+                       ;; that means there were no HyWiki page completions,
+                       ;; so return nil
+                       (when (zerop (call-process-shell-command
+                                     cmd nil (current-buffer)))
+                         (buffer-string)))))
+        (when output
+          (let* ((lines (split-string output "[\n\r]" t))
+                 (candidates
+                  (delq nil
+                        (nconc
+                         ;; Return only candidates that start with 'existing-wikiword-prefix'
+                         (seq-filter (lambda (str)
+                                       (string-prefix-p existing-wikiword-prefix str))
+                                     (hywiki-get-page-list))
+                         (mapcar #'hywiki-format-grep-to-reference lines))))
+                 (candidates-alist (when candidates (mapcar #'list candidates))))
+            (when candidates-alist
+              (setq hywiki--char-before (char-before start)
+                    hywiki--start-pos start
+                    hywiki--end-pos end)
+              (list start end candidates-alist
+                    :exclusive 'no
+                    ;; For company, allow any non-delim chars in prefix
+                    ;; :company-prefix-length t
+                    ;; :company-prefix-dirty t
+                    ;; Returning the prefix as (string . t) tells Company:
+                    ;; 'This is the prefix, and yes, it is currently valid (dirty).'
+                    ;; :company-prefix-snapshot (cons ref t)
 
-                ;; This prevents the minibuffer/Corfu/Company from
-                ;; re-parsing the # as a 'function quote' trigger.
-                :company-kind (lambda (_) 'keyword)
-                :annotation-function (lambda (_) " [HyWiki]")
-                ;; Corfu uses this
-                :exit-function #'hywiki-completion-exit-function))))))
+                    ;; This prevents the minibuffer/Corfu/Company from
+                    ;; re-parsing the # as a 'function quote' trigger.
+                    :company-kind (lambda (_) 'keyword)
+                    :annotation-function (lambda (_) " [HyWiki]")
+                    ;; Corfu uses this
+                    :exit-function #'hywiki-completion-exit-function))))))))
 
 (defun hywiki-completion-exit-function (&rest _)
   "Function called when HyWiki reference completion ends."

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Apr-24 at 22:41:13
-;; Last-Mod:     30-Aug-26 at 10:21:23 by Bob Weiner
+;; Last-Mod:     30-Aug-26 at 23:17:45 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1853,41 +1853,40 @@ Each candidate is an alist with keys: file, line, text, and display."
                           hywiki-file-extension))
              (output (with-temp-buffer
                        ;; Check exist status and if any error (non-zero),
-                       ;; that means there were no HyWiki page completions,
-                       ;; so return nil
+                       ;; that means there were no HyWiki #section completions,
+                       ;; so `output' will be nil.  Still need to allow for
+                       ;; HyWiki page completions further down.
                        (when (zerop (call-process-shell-command
                                      cmd nil (current-buffer)))
-                         (buffer-string)))))
-        (when output
-          (let* ((lines (split-string output "[\n\r]" t))
-                 (candidates
-                  (delq nil
-                        (nconc
-                         ;; Return only candidates that start with 'existing-wikiword-prefix'
-                         (seq-filter (lambda (str)
-                                       (string-prefix-p existing-wikiword-prefix str))
-                                     (hywiki-get-page-list))
-                         (mapcar #'hywiki-format-grep-to-reference lines))))
-                 (candidates-alist (when candidates (mapcar #'list candidates))))
-            (when candidates-alist
-              (setq hywiki--char-before (char-before start)
-                    hywiki--start-pos start
-                    hywiki--end-pos end)
-              (list start end candidates-alist
-                    :exclusive 'no
-                    ;; For company, allow any non-delim chars in prefix
-                    ;; :company-prefix-length t
-                    ;; :company-prefix-dirty t
-                    ;; Returning the prefix as (string . t) tells Company:
-                    ;; 'This is the prefix, and yes, it is currently valid (dirty).'
-                    ;; :company-prefix-snapshot (cons ref t)
+                         (buffer-string))))
+             (lines (when output (split-string output "[\n\r]" t)))
+             (candidates
+              (delq nil
+                    (nconc
+                     ;; Return only candidates that start with 'existing-wikiword-prefix'
+                     (seq-filter (lambda (str)
+                                   (string-prefix-p existing-wikiword-prefix str))
+                                 (hywiki-get-referent-list))
+                     (mapcar #'hywiki-format-grep-to-reference lines)))))
+        (when candidates
+          (setq hywiki--char-before (char-before start)
+                hywiki--start-pos start
+                hywiki--end-pos end)
+          (list start end candidates
+                :exclusive 'no
+                ;; For company, allow any non-delim chars in prefix
+                ;; :company-prefix-length t
+                ;; :company-prefix-dirty t
+                ;; Returning the prefix as (string . t) tells Company:
+                ;; 'This is the prefix, and yes, it is currently valid (dirty).'
+                ;; :company-prefix-snapshot (cons ref t)
 
-                    ;; This prevents the minibuffer/Corfu/Company from
-                    ;; re-parsing the # as a 'function quote' trigger.
-                    :company-kind (lambda (_) 'keyword)
-                    :annotation-function (lambda (_) " [HyWiki]")
-                    ;; Corfu uses this
-                    :exit-function #'hywiki-completion-exit-function))))))))
+                ;; This prevents the minibuffer/Corfu/Company from
+                ;; re-parsing the # as a 'function quote' trigger.
+                :company-kind (lambda (_) 'keyword)
+                :annotation-function (lambda (_) " [HyWiki]")
+                ;; Corfu uses this
+                :exit-function #'hywiki-completion-exit-function))))))
 
 (defun hywiki-completion-exit-function (&rest _)
   "Function called when HyWiki reference completion ends."
@@ -2759,7 +2758,7 @@ not contain a directory path or returns nil."
 
 (defun hywiki-get-page-file (reference)
   "Return possibly non-existent `hywiki-directory' path from REFERENCE.
-REFERENCE may be an existing absolute file path; then, return it.
+REFERENCE may be an existing file path; then, return it.
 Otherwise, REFERENCE should not contain a directory and may have or may omit
 `hywiki-file-extension' and an optional trailing #section, both of which are
 left attached to the result returned.  So given the input, WikiWord#section,
@@ -2815,6 +2814,10 @@ Strip any leading '*' and space characters from the headings."
 			(when (eq (caar referent-type) 'page)
 			  (cdr referent-type)))
 		      (hywiki-get-referent-hasht))))
+
+(defun hywiki-get-referent-list ()
+  "Return the full list of HyWikiWords."
+  (delq nil (hash-map #'cdr (hywiki-get-referent-hasht))))
 
 (defun hywiki-get-referent (wikiword &optional absolute-path-flag)
   "Return the referent of HyWiki WIKIWORD or nil if it does not exist.

--- a/test/hywiki-tests.el
+++ b/test/hywiki-tests.el
@@ -3,7 +3,7 @@
 ;; Author:       Mats Lidell
 ;;
 ;; Orig-Date:    18-May-24 at 23:59:48
-;; Last-Mod:     21-Aug-26 at 11:58:32 by Bob Weiner
+;; Last-Mod:     30-Aug-26 at 23:15:25 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -303,8 +303,7 @@ around the call.  This is for simulating the command loop."
 
                  ;; `hywiki-mode' must be enabled within the current buffer or
                  ;; the setting of `wiki-page' below will fail
-                 (unless (eq hywiki-mode :all)
-                   (hywiki-mode :all))
+                 (hywiki-mode :all)
 
                  ;; Since we newly created the `hywiki-directory', it is
                  ;; empty and we don't need to do a (redisplay t) or
@@ -312,7 +311,7 @@ around the call.  This is for simulating the command loop."
 
                  ;; `wiki-page' wil be set to the page's absolute filename
                  ;; after `hywiki-mode' is enabled.
-                 (setq wiki-page (cdr (hywiki-add-page "WikiWord")))
+                 (setq wiki-page (cdr (hywiki-add-page "WikiWord" nil t)))
                  ,@body)
              (hy-delete-files-and-buffers (list wiki-page (hywiki-cache-default-file)))
              (hywiki-tests--delete-hywiki-dir-and-buffer hywiki-directory)
@@ -2284,7 +2283,7 @@ See helper `hywiki-display-hywiki-test' above for verifying display call."
     (ert-info ("Word 'Wi' can be completed")
       (erase-buffer)
       (insert "Wi")
-      (should (equal (list 1 3 '(("WikiWord")))
+      (should (equal (list 1 3 '("WikiWord"))
                      (hywiki-tests--remove-keyword-args (hywiki-completion-at-point)))))
     (ert-info ("Word is extended to 'Wixx' so it can't be completed")
       (insert "xx")
@@ -2302,7 +2301,8 @@ See helper `hywiki-display-hywiki-test' above for verifying display call."
     (ert-info ("Word 'Wiki' can be completed so headers are returned")
       (erase-buffer)
       (insert "Wiki")
-      (should (equal (list 1 5 '(("WikiWord") ("WikiWord#Header") ("WikiWord#SubHeader") ("WikiWord#SubSubHeader")))
+      (should (equal (list 1 5 '("WikiWord" "WikiWord#Header"
+                                 "WikiWord#SubHeader" "WikiWord#SubSubHeader"))
                      (hywiki-tests--remove-keyword-args (hywiki-completion-at-point)))))))
 
 (ert-deftest hywiki-tests--verify-hook-functions ()


### PR DESCRIPTION
- hywiki-completion-at-point - Fix to set `output' to nil on any error.  Any time an error occurs with the grep call generating #section candidates.  Previously, the code matched to only one specific error.  This fixes bug report gh#1048.  Also, change completion table to use strings rather than lists of strings, for simplicity.

- hywiki-get-referent-list - Add and call in above function rather than limiting to WikiWords attached to pages.

- hywiki-tests--completion-at-point - Adapt to above  change to completion table.

- hywiki-tests--preserve-hywiki-mode - Call `hywiki-add-page' with `debug-flag' enabled, so if ever get null a null referent returned, get a stack trace showing the source of the problem.

- hkey-help-show - Fix that ? help buffer in Hyperbole minibuffer menus was not put into 'help-mode' in some Emacs versions because 'quit-window' is now bound in the default major mode that the ? buffer starts in.  This is typically 'fundamental-mode'.

- hui:menu-help - Set menu help buffer to read only.