### PR TITLE
smart-org - Fix `hkey-help' to show org-link attribs and assist doc 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,28 @@
+2026-09-10  Bob Weiner  <rsw@gnu.org>
+
+* hmouse-drv.el (hkey-help-hbut): Add.
+                (hkey-help): Replace call 'hbut:report' with (or but-def-symbol
+    (htype:def-symbol actype)) for better compatibility with 'hkey-alist' items.
+    Also, remove (unless assist-function-flag...) call that was blocking display
+    of overal Assist Key behavior.  These changes also fix that {C-u C-h A} on
+    an Org link was displaying a blank help buffer.
+
+  hui-mouse.el (smart-org): Call 'hkey-help-hbut' when on an Org link
+    instead of calling 'hkey-help'.  This now displays Org link
+    attributes like a regular Hyperbole button's attributes.
+  hact.el (htype:def-symbol): If given an fboundp function symbol, return
+    that rather than nil.
+
+2026-09-09  Bob Weiner  <rsw@gnu.org>
+
+* hbut.el (hbut:funcall): Expand 'key-src' when is a path to resolve
+    any variable name.  This fixes a bug where a buffer name with
+    the variable, like `${hyperb:dir)/hbut.el' is created.
+          (ibut:set-name-and-label-key-p): Clarify doc that returns
+    t when on implicit button text only if such text is delimited.
+    Also, fix so recognizes an ibut if point is on a separator between
+    the ibut name and its text; see doc for 'ibut:label-separator-regexp'.
+
 2026-08-30  Bob Weiner  <rsw@gnu.org>
 
 * test/hywiki-tests.el (hywiki-tests--preserve-hywiki-mode): Call

--- a/hact.el
+++ b/hact.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:     14-Jul-26 at 09:16:07 by Bob Weiner
+;; Last-Mod:     10-Sep-26 at 12:43:08 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -255,8 +255,9 @@ given as a string or a symbol."
   (let ((name (if (stringp type)
 		  type
 		(symbol-name type))))
-    (when (string-match "\\`\\(ib\\|ac\\)types::" name)
-      (intern (substring name (match-end 0))))))
+    (cond ((string-match "\\`\\(ib\\|ac\\)types::" name)
+           (intern (substring name (match-end 0))))
+          ((intern-soft name)))))
 
 (defun    htype:delete (type type-category)
   "Delete a Hyperbole TYPE derived from TYPE-CATEGORY (both symbols).

--- a/hbut.el
+++ b/hbut.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    18-Sep-91 at 02:57:09
-;; Last-Mod:     16-Jul-26 at 16:25:00 by Bob Weiner
+;; Last-Mod:     10-Sep-26 at 08:50:44 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1271,7 +1271,12 @@ to KEY-SRC when it is provided."
 	  (set-buffer buffer)
 	(error "(ibut:get): Invalid buffer argument: %s" buffer))
     (if key-src
-	(hattr:set 'hbut:current 'loc key-src)
+        ;; `key-src' may have a variable name in it,
+        ;; e.g. "${hyperb:dir}/hbut.el", so expand it before trying to
+        ;; derive a buffer name from it which would include the variable.
+	(progn (unless (get-buffer key-src)
+                 (setq key-src (hpath:expand key-src)))
+               (hattr:set 'hbut:current 'loc key-src))
       (let ((loc (hattr:get 'hbut:current 'loc)))
 	(when loc
 	  (hbut:key-src-set-buffer loc)))
@@ -1881,8 +1886,8 @@ Use `ibut:at-type-p' to test the type of the implicit button at point."
 
 (defun    ibut:set-name-and-label-key-p (&optional start-delim end-delim)
   "Set ibut name, lbl-key, lbl-start/end attributes in \\='hbut:current.
-Point may be on the implicit button text or its optional preceding
-name.  Return t if on a named or delimited text implicit button;
+Point may be within any delimited implicit button text or its optional
+preceding name.  Return t if on a named or delimited text implicit button;
 return nil otherwise.
 
 Optional START-DELIM and END-DELIM may be given to find the
@@ -1896,87 +1901,94 @@ this will return nil on a non-delimited pathname implicit button.
 
 Any implicit button name must contain at least two characters,
 excluding delimiters, not just one."
-  (let* ((opoint (point-marker))
-	 ;; Next line finds the name only if point is on it, not on the
-	 ;; text of the button.
-	 (name-start-end (ibut:label-p t nil nil t t))
-	 (name       (nth 0 name-start-end))
-	 (name-start (nth 1 name-start-end))
-	 (name-end   (nth 2 name-start-end))
-	 lbl-start-end
-	 lbl-start
-	 lbl-end
-	 lbl-key)
+  (let* ((opoint (point-marker)))
     (unwind-protect
 	(progn
-	  ;; Skip past any optional name and separators
-	  (when name-end
-	    (goto-char name-end)
-	    (setq lbl-start (if (looking-at ibut:label-separator-regexp)
-				(progn
-				  ;; Move past up to 2 possible characters of ibut
-				  ;; delimiters; this prevents recognizing named,
-				  ;; delimited ibuts of a single character since
-				  ;; no one should need that.
-				  (goto-char (min (+ 2 (match-end 0)) (point-max)))
-				  (match-end 0))
-			      (prog1 (point)
-				(goto-char opoint))))
-	    (hattr:set 'hbut:current 'lbl-start lbl-start))
+          ;; Point may be between ibut name and its text; if so, move back into
+          ;; name first
+          (when (looking-at ibut:label-separator-regexp)
+            (re-search-backward (concat (regexp-quote ibut:label-end)
+                                        ibut:label-separator-regexp)
+                                (line-beginning-position) t))
 
-	  (setq lbl-start-end (if (and start-delim end-delim)
-				  (ibut:label-p nil start-delim end-delim t t)
-				(or
-				 ;; <action> buttons can be longer
-				 ;; than two lines, so don't limit
-				 ;; the length.
-				 (ibut:label-p nil "<" ">" t)
-				 (ibut:label-p nil "\"" "\"" t t)
-				 (ibut:label-p nil "{" "}" t t)
-				 (ibut:label-p nil "[" "]" t t))))
-	  (when lbl-start-end
-	    (setq lbl-key (nth 0 lbl-start-end)
-		  lbl-start (nth 1 lbl-start-end)
-		  lbl-end (nth 2 lbl-start-end))
-	    (when (and (stringp lbl-key)
-		       (string-prefix-p (concat hywiki-org-link-type ":") lbl-key t))
-	      ;; Remove any HyWiki org-link-type prefix
-	      (setq lbl-key (substring lbl-key 3)
-		    lbl-start (+ lbl-start (length hywiki-org-link-type) 1))))
-	  (when lbl-start
-	    (hattr:set 'hbut:current   'loc (save-excursion
-					      (hbut:to-key-src 'full)))
-	    (hattr:set 'hbut:current 'categ 'implicit)
-	    (hattr:set 'hbut:current 'lbl-key lbl-key)
-	    (hattr:set 'hbut:current 'lbl-start lbl-start)
-	    (hattr:set 'hbut:current 'lbl-end lbl-end))
+          ;; Next line finds the name only if point is on it, not on the
+          ;; text of the button.
+          (let* ((name-start-end (ibut:label-p t nil nil t t))
+	         (name       (nth 0 name-start-end))
+	         (name-start (nth 1 name-start-end))
+	         (name-end   (nth 2 name-start-end))
+	         lbl-start-end
+	         lbl-start
+	         lbl-end
+	         lbl-key)
+	    ;; Skip past any optional name and separators
+	    (when name-end
+	      (goto-char name-end)
+	      (setq lbl-start (if (looking-at ibut:label-separator-regexp)
+				  (progn
+				    ;; Move past up to 2 possible characters of ibut
+				    ;; delimiters; this prevents recognizing named,
+				    ;; delimited ibuts of a single character since
+				    ;; no one should need that.
+				    (goto-char (min (+ 2 (match-end 0)) (point-max)))
+				    (match-end 0))
+			        (prog1 (point)
+				  (goto-char opoint))))
+	      (hattr:set 'hbut:current 'lbl-start lbl-start))
 
-	  (when (and lbl-start (not name-end))
-	    ;; Point is within ibut text, not its name, so search
-	    ;; backward for any name on the same line.
-	    (goto-char lbl-start)
-	    ;; Skip back past any likely opening delim preceding
-	    ;; button text.
-	    (skip-chars-backward "\"<{[| \t")
-	    ;; Allow for looking back at any name separator space.
-	    (skip-chars-forward " \t")
-	    ;; Look back past any name separator.
-	    (when (looking-back ibut:label-separator-regexp
-				(line-beginning-position) t)
-	      ;; Move to within delimiters of name
-	      (goto-char (max (- (match-beginning 0) 3) (point-min)))
-	      (setq name-start-end (ibut:label-p t nil nil t t)
-		    name           (nth 0 name-start-end)
-		    name-start     (nth 1 name-start-end)
-		    name-end       (nth 2 name-start-end))))
+	    (setq lbl-start-end (if (and start-delim end-delim)
+				    (ibut:label-p nil start-delim end-delim t t)
+				  (or
+				   ;; <action> buttons can be longer
+				   ;; than two lines, so don't limit
+				   ;; the length.
+				   (ibut:label-p nil "<" ">" t)
+				   (ibut:label-p nil "\"" "\"" t t)
+				   (ibut:label-p nil "{" "}" t t)
+				   (ibut:label-p nil "[" "]" t t))))
+	    (when lbl-start-end
+	      (setq lbl-key (nth 0 lbl-start-end)
+		    lbl-start (nth 1 lbl-start-end)
+		    lbl-end (nth 2 lbl-start-end))
+	      (when (and (stringp lbl-key)
+		         (string-prefix-p (concat hywiki-org-link-type ":") lbl-key t))
+	        ;; Remove any HyWiki org-link-type prefix
+	        (setq lbl-key (substring lbl-key 3)
+		      lbl-start (+ lbl-start (length hywiki-org-link-type) 1))))
+	    (when lbl-start
+	      (hattr:set 'hbut:current   'loc (save-excursion
+					        (hbut:to-key-src 'full)))
+	      (hattr:set 'hbut:current 'categ 'implicit)
+	      (hattr:set 'hbut:current 'lbl-key lbl-key)
+	      (hattr:set 'hbut:current 'lbl-start lbl-start)
+	      (hattr:set 'hbut:current 'lbl-end lbl-end))
 
-	  (when (and lbl-start name)
-	    (hattr:set 'hbut:current 'name name))
-	  (when (and lbl-start name-start name-end)
-	    (hattr:set 'hbut:current 'name-start name-start)
-	    (hattr:set 'hbut:current 'name-end name-end))
-	  (when lbl-start
-	    t))
+	    (when (and lbl-start (not name-end))
+	      ;; Point is within ibut text, not its name, so search
+	      ;; backward for any name on the same line.
+	      (goto-char lbl-start)
+	      ;; Skip back past any likely opening delim preceding
+	      ;; button text.
+	      (skip-chars-backward "\"<{[| \t")
+	      ;; Allow for looking back at any name separator space.
+	      (skip-chars-forward " \t")
+	      ;; Look back past any name separator.
+	      (when (looking-back ibut:label-separator-regexp
+				  (line-beginning-position) t)
+	        ;; Move to within delimiters of name
+	        (goto-char (max (- (match-beginning 0) 3) (point-min)))
+	        (setq name-start-end (ibut:label-p t nil nil t t)
+		      name           (nth 0 name-start-end)
+		      name-start     (nth 1 name-start-end)
+		      name-end       (nth 2 name-start-end))))
+
+	    (when (and lbl-start name)
+	      (hattr:set 'hbut:current 'name name))
+	    (when (and lbl-start name-start name-end)
+	      (hattr:set 'hbut:current 'name-start name-start)
+	      (hattr:set 'hbut:current 'name-end name-end))
+	    (when lbl-start
+	      t)))
       (goto-char opoint)
       (set-marker opoint nil))))
 

--- a/hmouse-drv.el
+++ b/hmouse-drv.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-90
-;; Last-Mod:     30-Aug-26 at 11:12:09 by Bob Weiner
+;; Last-Mod:     10-Sep-26 at 15:23:19 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1187,7 +1187,7 @@ documentation is found."
 			       (if mouse-flag "Mouse " "")))
 
 		    ;; Print Hyperbole button attributes
-		    (when (memq cmd-sym '(hui:hbut-act hui:hbut-help))
+		    (when (memq cmd-sym '(hui:hbut-act hui:hbut-help smart-org))
 		      (let* ((lbl-key (hattr:get 'hbut:current 'lbl-key))
 			     (categ (hattr:get 'hbut:current 'categ))
 			     (attributes (nthcdr 2 (hattr:list 'hbut:current)))
@@ -1225,7 +1225,7 @@ documentation is found."
                         (when lbl-key
                           (unwind-protect
                               ;; Need to save and restore 'hbut:current here
-                              ;; since hywiki-get-definition overwrites it
+                              ;; since `hywiki-get-definition' overwrites it
                               (progn (hattr:copy 'hbut:current 'saved-but)
                                      (setq def (hywiki-get-definition
 			                        (ibut:key-to-label lbl-key)))
@@ -1245,20 +1245,6 @@ documentation is found."
 			  (princ (format "%s\n"
 					 (replace-regexp-in-string "^" "  " (documentation categ)
 								   nil t))))
-			(when assisting
-			  (let* ((ibtype-name (htype:names 'ibtypes categ))
-				 (custom-help-func (when (stringp ibtype-name)
-						     (intern-soft
-						      (concat ibtype-name ":help"))))
-				 (type-help-func (or (and custom-help-func
-							  (fboundp custom-help-func)
-							  custom-help-func)
-						     'hbut:report)))
-			    (princ (format "\n%s ASSIST KEY SPECIFICS:\n%s\n"
-					   type-help-func
-					   (replace-regexp-in-string
-					    "^" "  " (documentation type-help-func)
-					    nil t)))))
 
 			;; Display possibly custom actype :help documentation for
 			;; an Action button
@@ -1280,6 +1266,22 @@ documentation is found."
 					    "^" "  " (documentation type-help-func)
 					    nil t)))))
 
+			(when assisting
+			  (let* ((ibtype-name (htype:names 'ibtypes categ))
+				 (custom-help-func (when (stringp ibtype-name)
+						     (intern-soft
+						      (concat ibtype-name ":help"))))
+				 (type-help-func (or (and custom-help-func
+							  (fboundp custom-help-func)
+							  custom-help-func)
+                                                     (or but-def-symbol
+					                 (htype:def-symbol actype)))))
+			    (princ (format "\n%s ASSIST KEY SPECIFICS:\n%s\n"
+					   type-help-func
+					   (replace-regexp-in-string
+					    "^" "  " (documentation type-help-func)
+					    nil t)))))
+
 			(terpri)))
 
 		    ;; Print Emacs push-button attributes
@@ -1294,11 +1296,12 @@ documentation is found."
 			  (unless (markerp button)
 			    (princ (format "\n%s ACTION SPECIFICS:\n%s\n"
 					   (plist-get attributes 'action)
-					   (replace-regexp-in-string "^" "  " (actype:doc button t)
-								     nil t))))
+					   (replace-regexp-in-string
+                                            "^" "  " (actype:doc button t)
+					    nil t))))
 			  (terpri))))
 
-                    (unless assist-function-flag
+                    (progn
 		      (princ (format "A %s of the %s %sKey"
 				     (if mouse-flag
 				         (if mouse-drag-flag "DRAG" "CLICK")
@@ -1331,6 +1334,132 @@ documentation is found."
 	    (message "No %s Key command for current context."
 		     (if assisting "Assist" "Action"))))
     doc))
+
+(defun hkey-help-hbut (&optional assisting)
+  "Display hbut help for Action or Assist Keys (if ASSISTING prefix arg is non-nil)."
+  (interactive)
+  (let* ((actype (or (actype:elisp-symbol
+                      (hattr:get 'hbut:current 'actype))
+		     (hattr:get 'hbut:current 'actype)))
+	 (mouse-flag (when (mouse-event-p last-command-event)
+		       (or action-key-depress-position assist-key-depress-position)))
+	 (mouse-drag-flag (hmouse-drag-p))
+	 (temp-buffer-show-hook
+	  (lambda (buf)
+	    (set-buffer buf)
+	    (help-mode)
+	    (let ((owind (selected-window)))
+	      (if (br-in-browser)
+		  (save-excursion
+		    (br-to-view-window)
+		    (select-window (previous-window))
+		    (display-buffer buf 'other-win))
+		(display-buffer buf 'other-win))
+	      (select-window
+	       (if (bound-and-true-p help-window-select)
+		   (get-buffer-window buf)
+		 owind)))))
+	 (temp-buffer-show-function temp-buffer-show-hook))
+    (with-output-to-temp-buffer
+	(hypb:help-buf-name
+	 (format "%s %sKey"
+		 (if assisting "Assist" "Action")
+		 (if mouse-flag "Mouse " "")))
+
+      ;; Print Hyperbole button attributes
+      (let* ((lbl-key (hattr:get 'hbut:current 'lbl-key))
+	     (categ (hattr:get 'hbut:current 'categ))
+	     (attributes (nthcdr 2 (hattr:list 'hbut:current)))
+	     (but-def-symbol (htype:def-symbol
+			      (if (eq categ 'explicit) actype categ)))
+             (wikiword-referent
+              (when (eq (htype:def-symbol actype) 'link-to-wikiword)
+                (hywiki-get-referent
+                 (hattr:get 'hbut:current 'lbl-key)))))
+
+        (when wikiword-referent
+          (hattr:set 'hbut:current 'referent-type
+                     (car wikiword-referent))
+          (hattr:set 'hbut:current 'referent-value
+                     (cdr wikiword-referent)))
+
+	(princ (format "%s %s SPECIFICS:\n"
+		       (or but-def-symbol
+			   (htype:def-symbol actype))
+		       (cond ((eq categ 'explicit)
+			      "EXPLICIT BUTTON")
+			     (categ
+			      "IMPLICIT BUTTON")
+			     (t "ACTION TYPE"))))
+
+	;; (when (and assisting
+	;;            (not (eq categ (ibtype:elisp-symbol 'action)))
+	;; 	   (or (plist-member attributes 'actype)
+	;; 	       (plist-member attributes 'action)))
+	;;   (setq attributes (copy-sequence attributes))
+	;;   (hypb:remove-from-plist attributes 'actype)
+	;;   (hypb:remove-from-plist attributes 'action))
+	(hattr:report attributes)
+
+        (when lbl-key
+          (unwind-protect
+              ;; Need to save and restore 'hbut:current here
+              ;; since `hywiki-get-definition' overwrites it
+              (progn (hattr:copy 'hbut:current 'saved-but)
+                     (setq def (hywiki-get-definition
+			        (ibut:key-to-label lbl-key)))
+                     (when (stringp def)
+                       (terpri)
+                       (princ def)))
+            (hattr:copy 'saved-but 'hbut:current)))
+
+	(unless (or assisting
+		    (eq categ 'explicit)
+		    (null categ)
+		    (not (fboundp categ))
+		    (null (documentation categ)))
+	  ;; Include implicit button's ibtype doc
+	  (princ (format "\n%s ACTION KEY SPECIFICS:\n"
+			 (htype:names 'ibtypes categ)))
+	  (princ (format "%s\n"
+			 (replace-regexp-in-string "^" "  " (documentation categ)
+						   nil t))))
+
+	;; Display possibly custom actype :help documentation for
+	;; an Action button
+	(when (or (not assisting)
+		  (eq (htype:def-symbol categ) 'action))
+	  (let* ((actype-name (or (htype:names 'actypes actype)
+				  (symbol-name actype)))
+		 (custom-help-func (when (stringp actype-name)
+				     (intern-soft
+				      (concat actype-name ":help"))))
+		 (type-help-func (or (and custom-help-func
+					  (fboundp custom-help-func)
+					  custom-help-func)
+				     actype)))
+	    (princ (format "\n%s ACTYPE SPECIFICS:\n%s\n"
+			   (or (htype:names 'actypes type-help-func)
+			       (symbol-name type-help-func))
+			   (replace-regexp-in-string
+			    "^" "  " (documentation type-help-func)
+			    nil t)))))
+
+	(when assisting
+	  (let* ((ibtype-name (htype:names 'ibtypes categ))
+		 (custom-help-func (when (stringp ibtype-name)
+				     (intern-soft
+				      (concat ibtype-name ":help"))))
+		 (type-help-func (or (and custom-help-func
+					  (fboundp custom-help-func)
+					  custom-help-func)
+				     (or but-def-symbol
+					 (htype:def-symbol actype)))))
+	    (princ (format "\n%s ASSIST KEY SPECIFICS:\n%s\n"
+			   type-help-func
+			   (replace-regexp-in-string
+			    "^" "  " (documentation type-help-func)
+			    nil t)))))))))
 
 (defun hkey-assist-help ()
   "Display doc associated with Assist Key command in current context.

--- a/hui-mouse.el
+++ b/hui-mouse.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    04-Feb-89
-;; Last-Mod:     16-Jul-26 at 11:09:40 by Bob Weiner
+;; Last-Mod:     10-Sep-26 at 13:59:46 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -1976,16 +1976,17 @@ handled by the separate implicit button type, `org-link-outside-org-mode'."
 		    (hact 'org-internal-target-link)
 		    t)
 		   ((setq start-end (hsys-org-link-at-p))
+		    (hsys-org-set-ibut-label start-end)
                     (cond ((setq link-start-end (hsys-denote-link-at-p
                                                  (car start-end)
                                                  (cdr start-end)))
                            (hact 'link-to-denote (car link-start-end)))
-		          ((not assist-flag)
-			   (hsys-org-set-ibut-label start-end)
+                          (assist-flag
+                           (hact 'hkey-help-hbut t))
+		          (t
 		           (hact 'org-link-open-from-string
 		                 (buffer-substring-no-properties
-		                  (car start-end) (cdr start-end))))
-		          (t (hact 'hkey-help)))
+		                  (car start-end) (cdr start-end)))))
 		    t)
 		   ((hbut:at-p)
 		    ;; Fall through until Hyperbole button context and
@@ -2022,16 +2023,17 @@ handled by the separate implicit button type, `org-link-outside-org-mode'."
 		    (hact 'org-radio-target-link)
 		    t)
 		   ((setq start-end (hsys-org-link-at-p))
+		    (hsys-org-set-ibut-label start-end)
                     (cond ((setq link-start-end (hsys-denote-link-at-p
                                                  (car start-end)
                                                  (cdr start-end)))
                            (hact 'link-to-denote (car link-start-end)))
-		          ((not assist-flag)
-			   (hsys-org-set-ibut-label start-end)
+                          (assist-flag
+                           (hact 'hkey-help-hbut t))
+		          (t
 		           (hact 'org-link-open-from-string
 		                 (buffer-substring-no-properties
-		                  (car start-end) (cdr start-end))))
-		          (t (hact 'hkey-help)))
+		                  (car start-end) (cdr start-end)))))
 		    t)
  		   ((hbut:at-p)
 		    ;; Fall through until Hyperbole button context and


### PR DESCRIPTION
- smart-org - Fix 'hkey-help' to show org-link attribs and assist doc

- smart-org - Call 'hkey-help-hbut' when on an Org link instead of calling 'hkey-help'.  Now displays Org link attributes like a regular Hyperbole button's attributes.

- htype:def-symbol - If given an 'fboundp' function symbol, return that rather than nil.

- hbut:funcall - Expand 'key-src' when is a path to resolve any variable name.  This fixes a bug where a buffer name with the variable, like '${hyperb:dir)/hbut.el' is created.

- ibut:set-name-and-label-key-p - Clarify doc that returns t when on implicit button text only if such text is delimited.  Also, fix so recognizes an ibut if point is on a separator between the ibut name and its text; see doc for 'ibut:label-separator-regexp'.