### PR TITLE
hywiki-word-highlight-post-self-insert - Dehighlight non-WikiWords

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2026-09-11  Bob Weiner  <rsw@gnu.org>
+
+* hywiki.el (hywiki-word-highlight-post-self-insert): Replace call to
+   'hywiki--maybe-dehighlight-at-point' with
+   'hywiki-maybe-dehighlight-between-references' to fix insertion of
+   letters in front of a WikiWord not dehighlighting it.
+
 2026-09-10  Bob Weiner  <rsw@gnu.org>
 
 * hmouse-drv.el (hkey-help-hbut): Add.

--- a/hywiki.el
+++ b/hywiki.el
@@ -3,7 +3,7 @@
 ;; Author:       Bob Weiner
 ;;
 ;; Orig-Date:    21-Apr-24 at 22:41:13
-;; Last-Mod:     30-Aug-26 at 23:17:45 by Bob Weiner
+;; Last-Mod:     11-Sep-26 at 10:58:58 by Bob Weiner
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
@@ -700,7 +700,7 @@ more characters while the command is still executing.  The
     ;; Dehighlight any previously highlighted WikiWord at point
     ;; before we move to the start of any current WikiWord and
     ;; rehighlight that.
-    (hywiki--maybe-dehighlight-at-point))
+    (hywiki-maybe-dehighlight-between-references))
 
   (save-excursion
     (cond ((marker-position hywiki--buttonize-start)


### PR DESCRIPTION
Replace call to 'hywiki--maybe-dehighlight-at-point' with 'hywiki-maybe-dehighlight-between-references' to fix insertion of letters in front of a WikiWord not dehighlighting it.